### PR TITLE
Added temporary setup login step

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,17 @@ The Actions CLI allows you to setup Actions on your local dev machine or on a Ku
 * Download the [release](https://github.com/actionscore/cli/releases) for your OS
 * Unpack it
 * Move it to your desired location (for Mac/Linux - ```mv actions /usr/local/bin```. For Windows, add the executable to your System PATH.)
+* **Temporary**: Run the following command to login to Docker with read-only credentials:
+
+```bash
+Docker login actionscore.azurecr.io --username 390401a7-d7a6-46da-b10f-3ceff7a1cdd5 --password 485b3522-59bb-4152-8938-ca8b90108af6
+```
+
+__*Note: For Windows users, run the cmd terminal in administrator mode*__
+
+__*Note: For Linux users, if you run docker cmds with sudo, yuu need to use "sudo actions init*__
+
+
 
 ### Usage
 


### PR DESCRIPTION
Added step to login to docker account. Not doing this will result in a failure to pull the actions image down. 

**Note**: This is temporary. Once Actions is public, there won't be any need for auth.