### PR TITLE
Add release tag if branch is release-*

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -76,6 +76,6 @@ jobs:
   - build_windows_amd64_actions
   - build_linux_arm_actions
   - build_linux_arm64_actions
-  condition: contains(variables['Build.SourceBranch'], 'tag')
+  condition: contains(variables['Build.SourceBranch'], 'release-')
   steps:
     - bash: 'echo "##vso[build.addbuildtag]release"'


### PR DESCRIPTION
DownloadArtifact task filter does not support `release-*` so it cannot download the artifact from the last release branch, but it allows us to filter build tag. This PR will set release tag for new release-* branch and DownloadArtifact task can download the latest artifact from the latest release branch.