### PR TITLE
change namespace message

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ To setup Actions on Kubernetes:
 $ actions init --kubernetes
 ⌛  Making the jump to hyperspace...
 ▇   Deploying the Actions Operator to your cluster...
-✅  Success! Actions is up and running. To verify, run 'kubectl get pods -n actions-system' in your terminal
+✅  Success! Actions is up and running. To verify, run 'kubectl get pods' in your terminal
 ```
 
 *Note: The init command will install the latest stable version of Actions on your cluster. For more advanced use cases, please use our [Helm Chart](https://github.com/actionscore/actions/tree/master/charts/actions-operator).*

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -24,7 +24,7 @@ var InitCmd = &cobra.Command{
 				print.FailureStatusEvent(os.Stdout, err.Error())
 				return
 			}
-			print.SuccessStatusEvent(os.Stdout, "Success! Actions is up and running. To verify, run 'kubectl get pods -n actions-system' in your terminal")
+			print.SuccessStatusEvent(os.Stdout, "Success! Actions is up and running. To verify, run 'kubectl get pods' in your terminal")
 		} else {
 			err := standalone.Init(runtimeVersion)
 			if err != nil {


### PR DESCRIPTION
Currently we deploy into the default namespace, but the init message and README pointed to `actions-system`.

This PR fixes it and removed the `actions-system` namespace.