### PR TITLE
add grpc support

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,11 +68,27 @@ Example of launching Dapr with a node app listening on port 3000:
 $ dapr run --app-id nodeapp --app-port 3000 node app.js
 ```
 
-Example of launching Dapr on port 6000:
+Example of launching Dapr on HTTP port 6000:
 
 ```
 $ dapr run --app-id nodeapp --app-port 3000 --port 6000 node app.js
 ```
+
+Example of launching Dapr on gRPC port 50002:
+
+```
+$ dapr run --app-id nodeapp --app-port 3000 --grpc-port 50002 node app.js
+```
+
+### Use gRPC
+
+If your app uses gRPC instead of HTTP to receive Dapr events, run the CLI with the following command:
+
+```
+dapr run --app-id nodeapp --protocol grpc --app-port 6000 node app.js
+```
+
+The example above assumed your app port is 6000.
 
 ### Publish/Subscribe
 

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"fmt"
 	"os"
 
 	"github.com/dapr/cli/pkg/kubernetes"
@@ -37,7 +38,7 @@ var ListCmd = &cobra.Command{
 			}
 
 			if len(list) == 0 {
-				println("No Dapr found.")
+				fmt.Println("No dapr instances found.")
 				return
 			}
 

--- a/pkg/kubernetes/run.go
+++ b/pkg/kubernetes/run.go
@@ -3,7 +3,8 @@ package kubernetes
 type RunConfig struct {
 	AppID         string
 	AppPort       int
-	Port          int
+	HTTPPort      int
+	GRPCPort      int
 	CodeDirectory string
 	Arguments     []string
 	Image         string

--- a/pkg/publish/publish.go
+++ b/pkg/publish/publish.go
@@ -31,7 +31,7 @@ func PublishTopic(topic, payload string) error {
 		b = []byte(payload)
 	}
 
-	url := fmt.Sprintf("http://localhost:%s/v%s/publish/%s", fmt.Sprintf("%v", app.DaprPort), api.RuntimeAPIVersion, topic)
+	url := fmt.Sprintf("http://localhost:%s/v%s/publish/%s", fmt.Sprintf("%v", app.HTTPPort), api.RuntimeAPIVersion, topic)
 	_, err = http.Post(url, "application/json", bytes.NewBuffer(b))
 	if err != nil {
 		return err

--- a/pkg/rundata/rundata.go
+++ b/pkg/rundata/rundata.go
@@ -24,8 +24,9 @@ var (
 )
 
 type RunData struct {
-	DaprRunId string
-	DaprPort  int
+	DaprRunId    string
+	DaprHTTPPort int
+	DaprGRPCPort int
 	AppId        string
 	AppPort      int
 	Command      string

--- a/pkg/send/send.go
+++ b/pkg/send/send.go
@@ -19,7 +19,7 @@ func InvokeApp(appID, method, payload string) (string, error) {
 
 	for _, lo := range list {
 		if lo.AppID == appID {
-			r, err := http.Post(fmt.Sprintf("http://localhost:%s/v%s/invoke/%s/method/%s", fmt.Sprintf("%v", lo.DaprPort), api.RuntimeAPIVersion, lo.AppID, method), "application/json", bytes.NewBuffer([]byte(payload)))
+			r, err := http.Post(fmt.Sprintf("http://localhost:%s/v%s/invoke/%s/method/%s", fmt.Sprintf("%v", lo.HTTPPort), api.RuntimeAPIVersion, lo.AppID, method), "application/json", bytes.NewBuffer([]byte(payload)))
 			if err != nil {
 				return "", err
 			}

--- a/pkg/standalone/list.go
+++ b/pkg/standalone/list.go
@@ -8,13 +8,14 @@ import (
 )
 
 type ListOutput struct {
-	AppID       string `csv:"APP ID"`
-	DaprPort int    `csv:"DAPR PORT"`
-	AppPort     int    `csv:"APP PORT"`
-	Command     string `csv:"COMMAND"`
-	Age         string `csv:"AGE"`
-	Created     string `csv:"CREATED"`
-	PID         int
+	AppID    string `csv:"APP ID"`
+	HTTPPort int    `csv:"HTTP PORT"`
+	GRPCPort int    `csv:"GRPC PORT"`
+	AppPort  int    `csv:"APP PORT"`
+	Command  string `csv:"COMMAND"`
+	Age      string `csv:"AGE"`
+	Created  string `csv:"CREATED"`
+	PID      int
 }
 
 func List() ([]ListOutput, error) {
@@ -33,11 +34,12 @@ func List() ([]ListOutput, error) {
 
 		// TODO: Call to /metadata and validate the runtime data
 		var listRow = ListOutput{
-			AppID:       runtimeLine.AppId,
-			DaprPort: runtimeLine.DaprPort,
-			Command:     utils.TruncateString(runtimeLine.Command, 20),
-			Created:     runtimeLine.Created.Format("2006-01-02 15:04.05"),
-			PID:         runtimeLine.PID,
+			AppID:    runtimeLine.AppId,
+			HTTPPort: runtimeLine.DaprHTTPPort,
+			GRPCPort: runtimeLine.DaprGRPCPort,
+			Command:  utils.TruncateString(runtimeLine.Command, 20),
+			Created:  runtimeLine.Created.Format("2006-01-02 15:04.05"),
+			PID:      runtimeLine.PID,
 		}
 		if runtimeLine.AppPort > 0 {
 			listRow.AppPort = runtimeLine.AppPort


### PR DESCRIPTION
This PR introduces a new `grpc-port` flag to set the grpc port for Dapr and a `protocol` flag to tell Dapr which protocol it should communicate with the app (default is `http`).