### PR TITLE
Improve message when docker is not installed or not running

### DIFF
--- a/pkg/standalone/standalone.go
+++ b/pkg/standalone/standalone.go
@@ -32,7 +32,7 @@ const daprImageURL = "actionscore.azurecr.io/dapr"
 func Init(runtimeVersion string) error {
 	dockerInstalled := isDockerInstalled()
 	if !dockerInstalled {
-		return errors.New("Could not connect to Docker.  Is Docker is installed and running?")
+		return errors.New("Could not connect to Docker.  Is Docker installed and running?")
 	}
 
 	dir, err := getDaprDir()


### PR DESCRIPTION
I tried out these scenarios on Linux and Windows.  I don't have a Mac but the behavior is likely effectively the same:
- `dapr init`  when Docker is not running
- `dapr init` when Docker is not installed

On each OS the error/message returned from docker client.Ping() the same for both situations above.  The message from client.Ping() is not the same across OSes (that is, the error from Windows differs from the one on Linux), but we don't show this to the user - we print a higher level message.

The existing code already handles these situations and and prints an error message.  This edit just slightly improves the error message the user sees, which will be the same for all OSes.