### PR TITLE
Make release process consistent with dapr release

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -36,11 +36,8 @@ jobs:
         echo $RELVERSION > $(Build.ArtifactStagingDirectory)/release_version.txt
         echo $(Build.SourceVersion) > $(Build.ArtifactStagingDirectory)/release_commit_id.txt
 
-        if [ "$LATEST_RELEASE" == "true" ]; then
-          echo Checking release note for $RELVERSION...
-          RELNOTE_PATH="docs/release_notes/v$RELVERSION.md"
-          [ ! -f "$RELNOTE_PATH" ] && echo "$RELNOTE_PATH not found" && exit 1
-
+        # Check if RELVERSION is not release candidates
+        if [[ "$RELVERSION" != *-rc.* ]]; then
           echo Add release tag
           echo "##vso[build.addbuildtag]release"
         fi
@@ -79,13 +76,6 @@ jobs:
     targetArch: arm
     dependStep: release_environment
     relVersion: $[ dependencies.release_environment.outputs['env_var_step.REL_VERSION'] ]
-- template: 'build-template.yml'
-  parameters:
-    poolImage: ubuntu-latest
-    targetOS: linux
-    targetArch: arm64
-    dependStep: release_environment
-    relVersion: $[ dependencies.release_environment.outputs['env_var_step.REL_VERSION'] ]
 - job: 'release_to_github'
   pool:
     vmImage: ubuntu-latest
@@ -93,10 +83,9 @@ jobs:
     - build_darwin_amd64_dapr	
     - build_linux_amd64_dapr	
     - build_windows_amd64_dapr	
-    - build_linux_arm_dapr	
-    - build_linux_arm64_dapr
+    - build_linux_arm_dapr
     - release_environment
-  condition: and(startsWith(variables['Build.SourceBranch'], 'refs/tags/v'), eq(variables['LATEST_RELEASE'], 'true'))
+  condition: startsWith(variables['Build.SourceBranch'], 'refs/tags/v')
   variables:
     REL_VERSION: $[ dependencies.release_environment.outputs['env_var_step.REL_VERSION'] ]
   steps:
@@ -106,6 +95,23 @@ jobs:
         itemPattern: '**'
         targetPath: '$(Pipeline.Workspace)'
     - task: GitHubRelease@0
+      condition: and(startsWith(variables['Build.SourceBranch'], 'refs/tags/v'), contains(variables['Build.SourceBranch'], '-rc'))
+      displayName: 'Upload Dapr CLI binaries to GitHub Pre-release'
+      inputs:
+        gitHubConnection: 'GitHub'
+        repositoryName: '$(Build.Repository.Name)'
+        action: 'create'
+        target: '$(Build.SourceVersion)'
+        tagSource: 'manual'
+        tag: 'v$(REL_VERSION)'
+        title: 'Dapr CLI $(REL_VERSION)'
+        assets: |
+          $(Pipeline.Workspace)/drop/*.zip
+          $(Pipeline.Workspace)/drop/*.tar.gz
+        isPreRelease: true
+        addChangeLog: true
+    - task: GitHubRelease@0
+      condition: and(startsWith(variables['Build.SourceBranch'], 'refs/tags/v'), not(contains(variables['Build.SourceBranch'], '-rc')))
       displayName: 'Upload Dapr CLI binaries to GitHub Release'
       inputs:
         gitHubConnection: 'GitHub'
@@ -118,6 +124,5 @@ jobs:
         assets: |
           $(Pipeline.Workspace)/drop/*.zip
           $(Pipeline.Workspace)/drop/*.tar.gz
-        releaseNotesFile: './docs/release_notes/v$(REL_VERSION).md'
-        isPreRelease: true
-        addChangeLog: false
+        isPreRelease: false
+        addChangeLog: true


### PR DESCRIPTION
* Make release process consistent with dapr release
* Remove unused arm64 binary build
* Release pre-release if tag have -rc
* Release normal release if tag doesn't have -rc