### PR TITLE
kubernetes: adding support for KUBECONFIG environment variable

### DIFF
--- a/pkg/kubernetes/client.go
+++ b/pkg/kubernetes/client.go
@@ -25,6 +25,10 @@ func Client() (*k8s.Clientset, error) {
 	}
 	flag.Parse()
 
+	if kubeConfigEnv := os.Getenv("KUBECONFIG"); len(kubeConfigEnv) != 0 {
+		kubeconfig = &kubeConfigEnv
+	}
+
 	config, err := clientcmd.BuildConfigFromFlags("", *kubeconfig)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
# Description

Adding support for cli users that are supplying kubeconfig using `KUBECONFIG` environment variable. Currently, `dapr` cli fails to deploy to Kubernetes if the user doesn't have a valid kubeconfig in their `~/.kube/config` directory. 

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [ ] Created/updated tests
* [ ] Extended the documentation
