### PR TITLE
[Windows Install Script] Support TLS 1.2/1.1/1.0

### DIFF
--- a/install/install.ps1
+++ b/install/install.ps1
@@ -29,6 +29,9 @@ if((Get-ExecutionPolicy) -gt 'RemoteSigned' -or (Get-ExecutionPolicy) -eq 'ByPas
     break
 }
 
+# Change security protocol to support TLS 1.2 / 1.1 / 1.0 - old powershell uses TLS 1.0 as a default protocol
+[Net.ServicePointManager]::SecurityProtocol = "tls12, tls11, tls"
+
 # Check if Dapr cli is installed.
 if (Test-Path $DaprCliFilePath -PathType Leaf) {
     Write-Warning "Dapr is detected - $DaprCliFilePath"


### PR DESCRIPTION
# Description

Old version of powershell uses TLS 1.0 as a default secure protocol. This PR forces to support TLS 1.2, 1.1, and 1.0.

# Issue

#166 

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Created/updated tests
* [ ] Extended the documentation
