### PR TITLE
[Windows install script] add message to ensure docker desktop use linux container mode

### DIFF
--- a/install/install.ps1
+++ b/install/install.ps1
@@ -95,4 +95,5 @@ if($UserPathEnvionmentVar -like '*dapr*') {
 }
 
 Write-Output "`r`nDapr CLI is installed successfully."
-Write-Output "To get started with Dapr, please visit https://github.com/dapr/docs/tree/master/getting-started"
+Write-Output "To get started with Dapr, please visit https://github.com/dapr/docs/tree/master/getting-started ."
+Write-Output "Ensure that Docker Desktop use Linux containers mode when you run Dapr as a standalone mode."


### PR DESCRIPTION
# Description

Docker Desktop for Windows supports both Linux and Windows containers modes. When running Dapr via CLI as a standalone mode, dapr cli starts the container to run placement service. container image is built for linux container. therefore, Windows user needs to ensure that they are using Linux containers mode. 

This PR has windows install script to print out the message to ensure docker desktop use linux containers mode.

## Issue reference

https://github.com/dapr/docs/issues/162

https://github.com/dapr/docs/pull/163

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [x] Extended the documentation
