### PR TITLE
Remove --kubernetes option from dapr run

### DIFF
--- a/cmd/run.go
+++ b/cmd/run.go
@@ -36,7 +36,7 @@ var protocol string
 
 var RunCmd = &cobra.Command{
 	Use:   "run",
-	Short: "Launches dapr and your app side by side",
+	Short: "Launches dapr and your app side by side.  For deploying to Kubernetes, use the Helm charts.",
 	Args:  cobra.MinimumNArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 		uuid, err := uuid.NewRandom()
@@ -211,7 +211,6 @@ func init() {
 	RunCmd.Flags().StringVarP(&image, "image", "", "", "the image to build the code in. input is repository/image")
 	RunCmd.Flags().BoolVar(&enableProfiling, "enable-profiling", false, "Enable pprof profiling via an HTTP endpoint")
 	RunCmd.Flags().IntVarP(&profilePort, "profile-port", "", -1, "the port for the profile server to listen on")
-	RunCmd.Flags().BoolVar(&kubernetesMode, "kubernetes", false, "build and deploy your app and Dapr to a Kubernetes cluster")
 	RunCmd.Flags().StringVarP(&logLevel, "log-level", "", "info", "Sets the log verbosity. Valid values are: debug, info, warning, error, fatal, or panic. Default is info")
 	RunCmd.Flags().IntVarP(&maxConcurrency, "max-concurrency", "", -1, "controls the concurrency level of the app. Default is unlimited")
 	RunCmd.Flags().StringVarP(&protocol, "protocol", "", "http", "tells Dapr to use HTTP or gRPC to talk to the app. Default is http")

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -36,7 +36,7 @@ var protocol string
 
 var RunCmd = &cobra.Command{
 	Use:   "run",
-	Short: "Launches dapr and your app side by side.  For deploying to Kubernetes, use the Helm charts.",
+	Short: "Launches dapr and your app side by side",
 	Args:  cobra.MinimumNArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 		uuid, err := uuid.NewRandom()


### PR DESCRIPTION
# Description

This removes the --kubernetes flag from dapr run, which was not used and confusing.  A comment was added to usage to point the user at helm charts, which is the preferred way.

## Issue reference

https://github.com/dapr/cli/issues/195

Please reference the issue this PR will close: #_195_

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Created/updated tests
* [ ] Extended the documentation
