### PR TITLE
remove Dapr placement image on uninstall and init

### DIFF
--- a/cmd/init.go
+++ b/cmd/init.go
@@ -33,6 +33,7 @@ var InitCmd = &cobra.Command{
 			}
 			print.SuccessStatusEvent(os.Stdout, "Success! Dapr has been installed. To verify, run 'kubectl get pods -w' in your terminal")
 		} else {
+			standalone.Uninstall(false, dockerNetwork)
 			err := standalone.Init(runtimeVersion, dockerNetwork)
 			if err != nil {
 				print.FailureStatusEvent(os.Stdout, err.Error())

--- a/cmd/uninstall.go
+++ b/cmd/uninstall.go
@@ -44,7 +44,7 @@ var UninstallCmd = &cobra.Command{
 
 func init() {
 	UninstallCmd.Flags().BoolVar(&uninstallKubernetes, "kubernetes", false, "Uninstall Dapr from a Kubernetes cluster")
-	UninstallCmd.Flags().BoolVar(&uninstallAll, "all", false, "Remove the redis container as well")
+	UninstallCmd.Flags().BoolVar(&uninstallAll, "all", false, "Remove Redis container in addition to actor placement container")
 	UninstallCmd.Flags().StringVarP(&uninstallDockerNetwork, "network", "", "", "The Docker network from which to remove the Dapr runtime")
 	RootCmd.AddCommand(UninstallCmd)
 }

--- a/pkg/standalone/uninstall.go
+++ b/pkg/standalone/uninstall.go
@@ -2,6 +2,7 @@ package standalone
 
 import (
 	"errors"
+	"fmt"
 
 	"github.com/dapr/cli/utils"
 )
@@ -15,6 +16,16 @@ func Uninstall(uninstallAll bool, dockerNetwork string) error {
 	errorMessage := ""
 	if err != nil {
 		errorMessage += "Could not delete Dapr Placement Container - it may not have been running "
+	}
+
+	err = utils.RunCmdAndWait(
+		"docker", "rmi",
+		"--force",
+		daprDockerImageName)
+
+	errorMessage = ""
+	if err != nil {
+		errorMessage += fmt.Sprintf("Could not delete image %s - it may not be present on the host", daprDockerImageName)
 	}
 
 	if uninstallAll {


### PR DESCRIPTION
This PR cleans the `daprio/dapr` image on `uninstall` and `init`, allowing the Docker Daemon to re-pull the image.

Closes #204 