### PR TITLE
remove redis on local init

### DIFF
--- a/cmd/init.go
+++ b/cmd/init.go
@@ -33,7 +33,7 @@ var InitCmd = &cobra.Command{
 			}
 			print.SuccessStatusEvent(os.Stdout, "Success! Dapr has been installed. To verify, run 'kubectl get pods -w' in your terminal")
 		} else {
-			standalone.Uninstall(false, dockerNetwork)
+			standalone.Uninstall(true, dockerNetwork)
 			err := standalone.Init(runtimeVersion, dockerNetwork)
 			if err != nil {
 				print.FailureStatusEvent(os.Stdout, err.Error())


### PR DESCRIPTION
On `dapr init`, Redis is not installed if a previous image already exists, because a fixed container name has been introduced in [this](https://github.com/dapr/cli/pull/192) PR.

This change removes any existing redis container on init.