### PR TITLE
Allow alternate install path

### DIFF
--- a/cmd/init.go
+++ b/cmd/init.go
@@ -23,10 +23,12 @@ var InitCmd = &cobra.Command{
 	Short: "Setup dapr in Kubernetes or Standalone modes",
 	PreRun: func(cmd *cobra.Command, args []string) {
 		viper.BindPFlag("network", cmd.Flags().Lookup("network"))
+		viper.BindPFlag("install-path", cmd.Flags().Lookup("install-path"))
 	},
 	Run: func(cmd *cobra.Command, args []string) {
 		print.PendingStatusEvent(os.Stdout, "Making the jump to hyperspace...")
 
+		installLocation := viper.GetString("install-path")
 		if kubernetesMode {
 			print.InfoStatusEvent(os.Stdout, "Note: this installation is recommended for testing purposes. For production environments, please use Helm \n")
 			err := kubernetes.Init()
@@ -38,7 +40,7 @@ var InitCmd = &cobra.Command{
 		} else {
 			dockerNetwork := viper.GetString("network")
 			standalone.Uninstall(true, dockerNetwork)
-			err := standalone.Init(runtimeVersion, dockerNetwork)
+			err := standalone.Init(runtimeVersion, dockerNetwork, installLocation)
 			if err != nil {
 				print.FailureStatusEvent(os.Stdout, err.Error())
 				return
@@ -52,6 +54,7 @@ func init() {
 	InitCmd.Flags().BoolVar(&kubernetesMode, "kubernetes", false, "Deploy Dapr to a Kubernetes cluster")
 	InitCmd.Flags().StringVarP(&runtimeVersion, "runtime-version", "", "latest", "The version of the Dapr runtime to install. for example: v0.1.0-alpha")
 	InitCmd.Flags().String("network", "", "The Docker network on which to deploy the Dapr runtime")
+	InitCmd.Flags().String("install-path", "", "The optional location to install Dapr to.  The default is /usr/local/bin for Linux/Mac and C:\\dapr for Windows")
 
 	RootCmd.AddCommand(InitCmd)
 }

--- a/pkg/standalone/run.go
+++ b/pkg/standalone/run.go
@@ -20,6 +20,7 @@ import (
 	"github.com/Pallinder/sillyname-go"
 	"github.com/phayes/freeport"
 
+	"github.com/dapr/cli/utils"
 	"github.com/dapr/dapr/pkg/components"
 	modes "github.com/dapr/dapr/pkg/config/modes"
 )
@@ -193,13 +194,6 @@ func createRedisStateStore(redisHost string) error {
 	return nil
 }
 
-func createDirectory(dir string) error {
-	if _, err := os.Stat(dir); !os.IsNotExist(err) {
-		return nil
-	}
-	return os.Mkdir(dir, 0777)
-}
-
 func createRedisPubSub(redisHost string) error {
 	redisMessageBus := component{
 		APIVersion: "dapr.io/v1alpha1",
@@ -257,7 +251,7 @@ func Run(config *RunConfig) (*RunOutput, error) {
 	if err != nil {
 		return nil, err
 	}
-	err = createDirectory(componentsDir)
+	err = utils.CreateDirectory(componentsDir)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/standalone/standalone.go
+++ b/pkg/standalone/standalone.go
@@ -137,6 +137,8 @@ func getDaprDir() (string, error) {
 	return p, nil
 }
 
+// installLocation is not used, but it is present because it's required to fit the initSteps func above.  If the number of args
+// increases more, we may consider passing in a struct instead of individual args.
 func runRedis(wg *sync.WaitGroup, errorChan chan<- error, dir, version string, dockerNetwork string, installLocation string) {
 	defer wg.Done()
 

--- a/pkg/standalone/standalone.go
+++ b/pkg/standalone/standalone.go
@@ -27,6 +27,7 @@ import (
 	"time"
 
 	"github.com/docker/docker/client"
+	"github.com/fatih/color"
 
 	"github.com/briandowns/spinner"
 	"github.com/dapr/cli/pkg/print"
@@ -34,18 +35,20 @@ import (
 )
 
 const (
-	daprGitHubOrg              = "dapr"
-	daprGitHubRepo             = "dapr"
-	daprDockerImageName        = "daprio/dapr"
-	daprRuntimeFilePrefix      = "daprd"
-	daprWindowsOS              = "windows"
-	daprLatestVersion          = "latest"
-	DaprPlacementContainerName = "dapr_placement"
-	DaprRedisContainerName     = "dapr_redis"
+	daprGitHubOrg                     = "dapr"
+	daprGitHubRepo                    = "dapr"
+	daprDockerImageName               = "daprio/dapr"
+	daprRuntimeFilePrefix             = "daprd"
+	daprWindowsOS                     = "windows"
+	daprLatestVersion                 = "latest"
+	DaprPlacementContainerName        = "dapr_placement"
+	DaprRedisContainerName            = "dapr_redis"
+	daprDefaultLinuxAndMacInstallPath = "/usr/local/bin"
+	daprDefaultWindowsInstallPath     = "c:\\dapr"
 )
 
 // Init installs Dapr on a local machine using the supplied runtimeVersion
-func Init(runtimeVersion string, dockerNetwork string) error {
+func Init(runtimeVersion string, dockerNetwork string, installLocation string) error {
 	dockerInstalled := isDockerInstalled()
 	if !dockerInstalled {
 		return errors.New("Could not connect to Docker.  Is Docker installed and running?")
@@ -59,7 +62,7 @@ func Init(runtimeVersion string, dockerNetwork string) error {
 	var wg sync.WaitGroup
 	errorChan := make(chan error)
 
-	initSteps := []func(*sync.WaitGroup, chan<- error, string, string, string){}
+	initSteps := []func(*sync.WaitGroup, chan<- error, string, string, string, string){}
 	initSteps = append(initSteps, installDaprBinary)
 	initSteps = append(initSteps, runPlacementService)
 	initSteps = append(initSteps, runRedis)
@@ -79,7 +82,7 @@ func Init(runtimeVersion string, dockerNetwork string) error {
 	}
 
 	for _, step := range initSteps {
-		go step(&wg, errorChan, dir, runtimeVersion, dockerNetwork)
+		go step(&wg, errorChan, dir, runtimeVersion, dockerNetwork, installLocation)
 	}
 
 	go func() {
@@ -134,7 +137,7 @@ func getDaprDir() (string, error) {
 	return p, nil
 }
 
-func runRedis(wg *sync.WaitGroup, errorChan chan<- error, dir, version string, dockerNetwork string) {
+func runRedis(wg *sync.WaitGroup, errorChan chan<- error, dir, version string, dockerNetwork string, installLocation string) {
 	defer wg.Done()
 
 	args := []string{
@@ -191,7 +194,7 @@ func isContainerRunError(err error) bool {
 	return false
 }
 
-func runPlacementService(wg *sync.WaitGroup, errorChan chan<- error, dir, version string, dockerNetwork string) {
+func runPlacementService(wg *sync.WaitGroup, errorChan chan<- error, dir, version string, dockerNetwork string, installLocation string) {
 	defer wg.Done()
 
 	image := fmt.Sprintf("%s:%s", daprDockerImageName, version)
@@ -239,7 +242,7 @@ func runPlacementService(wg *sync.WaitGroup, errorChan chan<- error, dir, versio
 	errorChan <- nil
 }
 
-func installDaprBinary(wg *sync.WaitGroup, errorChan chan<- error, dir, version string, dockerNetwork string) {
+func installDaprBinary(wg *sync.WaitGroup, errorChan chan<- error, dir, version string, dockerNetwork string, installLocation string) {
 	defer wg.Done()
 
 	archiveExt := "tar.gz"
@@ -287,7 +290,7 @@ func installDaprBinary(wg *sync.WaitGroup, errorChan chan<- error, dir, version 
 		return
 	}
 
-	daprPath, err := moveFileToPath(extractedFilePath)
+	daprPath, err := moveFileToPath(extractedFilePath, installLocation)
 	if err != nil {
 		errorChan <- fmt.Errorf("Error moving dapr binary to path: %s", err)
 		return
@@ -403,31 +406,59 @@ func untar(filepath, targetDir string) (string, error) {
 	}
 }
 
-func moveFileToPath(filepath string) (string, error) {
+func moveFileToPath(filepath string, installLocation string) (string, error) {
+	destDir := daprDefaultLinuxAndMacInstallPath
+	if runtime.GOOS == daprWindowsOS {
+		destDir = daprDefaultWindowsInstallPath
+		filepath = strings.Replace(filepath, "/", "\\", -1)
+	}
+
 	fileName := path_filepath.Base(filepath)
 	destFilePath := ""
 
-	if runtime.GOOS == daprWindowsOS {
-		p := os.Getenv("PATH")
-		if !strings.Contains(strings.ToLower(string(p)), strings.ToLower("c:\\dapr")) {
-			err := utils.RunCmdAndWait("SETX", "PATH", p+";c:\\dapr")
-			if err != nil {
-				return "", err
-			}
-		}
-		return "c:\\dapr\\daprd.exe", nil
+	// if user specified --install-path, use that
+	if installLocation != "" {
+		destDir = installLocation
 	}
 
-	destFilePath = path.Join("/usr/local/bin", fileName)
+	destFilePath = path.Join(destDir, fileName)
 
 	input, err := ioutil.ReadFile(filepath)
 	if err != nil {
 		return "", err
 	}
 
-	err = ioutil.WriteFile(destFilePath, input, 0644)
+	fmt.Printf("Installing Dapr to %s\n", destDir)
+	err = utils.CreateDirectory(destDir)
 	if err != nil {
 		return "", err
+	}
+
+	if err = ioutil.WriteFile(destFilePath, input, 0644); err != nil {
+		if runtime.GOOS != daprWindowsOS && strings.Contains(err.Error(), "permission denied") {
+			err = errors.New(err.Error() + " - please run with sudo")
+		}
+		return "", err
+	}
+
+	if runtime.GOOS == daprWindowsOS {
+		p := os.Getenv("PATH")
+
+		if !strings.Contains(strings.ToLower(string(p)), strings.ToLower(destDir)) {
+			err := utils.RunCmdAndWait("SETX", "PATH", p+fmt.Sprintf(";%s", destDir))
+			if err != nil {
+				return "", err
+			}
+		}
+
+		return fmt.Sprintf("%s\\daprd.exe", destDir), nil
+	}
+
+	if installLocation != "" {
+		color.Set(color.FgYellow)
+		fmt.Printf("\nDapr installed to %s, please run the following to add it to your path:\n", destDir)
+		fmt.Printf("    export PATH=$PATH:%s\n", destDir)
+		color.Unset()
 	}
 
 	return destFilePath, nil

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -76,3 +76,10 @@ func CreateContainerName(serviceContainerName string, dockerNetwork string) stri
 
 	return serviceContainerName
 }
+
+func CreateDirectory(dir string) error {
+	if _, err := os.Stat(dir); !os.IsNotExist(err) {
+		return nil
+	}
+	return os.Mkdir(dir, 0777)
+}


### PR DESCRIPTION
# Description

Add an `--install-path` arg to allow users to install Dapr to a different dir.

Also, add more detailed message if the install to /usr/local/bin (the default) fails because of permissions.

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: https://github.com/dapr/cli/issues/79, https://github.com/dapr/cli/issues/168

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [ ] Created/updated tests
* [ ] Extended the documentation
