### PR TITLE
[WIP] Added 'logs' command to dapr cli

### DIFF
--- a/cmd/logs.go
+++ b/cmd/logs.go
@@ -16,6 +16,7 @@ import (
 var logsAppID string
 var podName string
 var namespace string
+var k8s bool
 
 var LogsCmd = &cobra.Command{
 	Use:   "logs",
@@ -31,9 +32,11 @@ var LogsCmd = &cobra.Command{
 }
 
 func init() {
+	LogsCmd.Flags().BoolVar(&k8s, "kubernetes", true, "Only works with a Kubernetes cluster")
 	LogsCmd.Flags().StringVarP(&logsAppID, "app-id", "a", "", "The app id for which logs are needed")
 	LogsCmd.Flags().StringVarP(&podName, "pod-name", "p", "", "(optional) Name of the Pod. Use this in case you have multiple app instances (Pods)")
 	LogsCmd.Flags().StringVarP(&namespace, "namespace", "n", "", "(optional) Kubernetes namespace in which your application is deployed. default value is 'default'")
 	LogsCmd.MarkFlagRequired("app-id")
+	LogsCmd.MarkFlagRequired("kubernetes")
 	RootCmd.AddCommand(LogsCmd)
 }

--- a/cmd/logs.go
+++ b/cmd/logs.go
@@ -14,14 +14,14 @@ import (
 )
 
 var logsAppID string
-var logsFor string
+var podName string
 var namespace string
 
 var LogsCmd = &cobra.Command{
 	Use:   "logs",
-	Short: "Gets logs for a Dapr app in Kubernetes",
+	Short: "Gets Dapr sidecar logs for an app in Kubernetes",
 	Run: func(cmd *cobra.Command, args []string) {
-		err := kubernetes.Logs(logsAppID, logsFor, namespace)
+		err := kubernetes.Logs(logsAppID, podName, namespace)
 		if err != nil {
 			print.FailureStatusEvent(os.Stdout, err.Error())
 			os.Exit(1)
@@ -31,10 +31,9 @@ var LogsCmd = &cobra.Command{
 }
 
 func init() {
-	LogsCmd.Flags().StringVarP(&logsAppID, "app-id", "a", "", "the app id for which logs are needed")
-	LogsCmd.Flags().StringVarP(&logsFor, "for", "f", "", "logs for? possible values: dapr or app")
-	LogsCmd.Flags().StringVarP(&namespace, "namespace", "n", "", "kubernetes namespace in which your application is deployed. default value is 'default'")
+	LogsCmd.Flags().StringVarP(&logsAppID, "app-id", "a", "", "The app id for which logs are needed")
+	LogsCmd.Flags().StringVarP(&podName, "pod-name", "p", "", "(optional) Name of the Pod. Use this in case you have multiple app instances (Pods)")
+	LogsCmd.Flags().StringVarP(&namespace, "namespace", "n", "", "(optional) Kubernetes namespace in which your application is deployed. default value is 'default'")
 	LogsCmd.MarkFlagRequired("app-id")
-	LogsCmd.MarkFlagRequired("for")
 	RootCmd.AddCommand(LogsCmd)
 }

--- a/cmd/logs.go
+++ b/cmd/logs.go
@@ -1,0 +1,40 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+// ------------------------------------------------------------
+
+package cmd
+
+import (
+	"os"
+
+	"github.com/dapr/cli/pkg/kubernetes"
+	"github.com/dapr/cli/pkg/print"
+	"github.com/spf13/cobra"
+)
+
+var logsAppID string
+var logsFor string
+var namespace string
+
+var LogsCmd = &cobra.Command{
+	Use:   "logs",
+	Short: "Gets logs for a Dapr app in Kubernetes",
+	Run: func(cmd *cobra.Command, args []string) {
+		err := kubernetes.Logs(logsAppID, logsFor, namespace)
+		if err != nil {
+			print.FailureStatusEvent(os.Stdout, err.Error())
+			os.Exit(1)
+		}
+		print.SuccessStatusEvent(os.Stdout, "Fetched logs")
+	},
+}
+
+func init() {
+	LogsCmd.Flags().StringVarP(&logsAppID, "app-id", "a", "", "the app id for which logs are needed")
+	LogsCmd.Flags().StringVarP(&logsFor, "for", "f", "", "logs for? possible values: dapr or app")
+	LogsCmd.Flags().StringVarP(&namespace, "namespace", "n", "", "kubernetes namespace in which your application is deployed. default value is 'default'")
+	LogsCmd.MarkFlagRequired("app-id")
+	LogsCmd.MarkFlagRequired("for")
+	RootCmd.AddCommand(LogsCmd)
+}

--- a/pkg/kubernetes/logs.go
+++ b/pkg/kubernetes/logs.go
@@ -1,0 +1,97 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+// ------------------------------------------------------------
+
+package kubernetes
+
+import (
+	"fmt"
+	"io"
+	"os"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+const daprdContainerName = "daprd"
+const daprIDContainerArgName = "--dapr-id"
+const logsForDaprOption = "dapr"
+const logsForAppOption = "app"
+
+// Logs fetches Dapr app logs from Kubernetes.
+func Logs(appID, _for, namespace string) error {
+
+	client, err := Client()
+	if err != nil {
+		return err
+	}
+
+	if namespace == "" {
+		namespace = corev1.NamespaceDefault
+	}
+
+	pods, err := client.CoreV1().Pods(namespace).List(metav1.ListOptions{})
+	if err != nil {
+		return fmt.Errorf("Could not get logs %v", err)
+	}
+	var podName string
+	var foundDaprPod bool
+	for _, pod := range pods.Items {
+		if foundDaprPod {
+			break
+		}
+		for _, container := range pod.Spec.Containers {
+			if container.Name == daprdContainerName {
+				//find app ID
+				for i, arg := range container.Args {
+					if arg == daprIDContainerArgName {
+						id := container.Args[i+1]
+						if id == appID {
+							podName = pod.Name
+							foundDaprPod = true
+							break
+						}
+					}
+				}
+			}
+		}
+	}
+	if !foundDaprPod {
+		return fmt.Errorf("Could not get logs. Please check app-id (%s) and namespace (%s)", appID, namespace)
+	}
+	var containerName string
+
+	if _for == logsForDaprOption {
+		containerName = daprdContainerName
+	} else if _for == logsForAppOption { //app logs are needed
+		pod, err := client.CoreV1().Pods(namespace).Get(podName, metav1.GetOptions{})
+		if err != nil {
+			return fmt.Errorf("Could not get logs %v", err)
+		}
+		for _, container := range pod.Spec.Containers {
+			if container.Name != daprdContainerName {
+				containerName = container.Name
+				break
+			}
+		}
+	}
+	if containerName == "" {
+		return fmt.Errorf("Could not get logs. Please check the command")
+	}
+
+	//fmt.Printf("Getting logs for container %s in pod %s\n", containerName, podName)
+
+	getLogsRequest := client.CoreV1().Pods(namespace).GetLogs(podName, &corev1.PodLogOptions{Container: containerName, Follow: false})
+	logStream, err := getLogsRequest.Stream()
+	if err != nil {
+		return fmt.Errorf("Could not get logs %v", err)
+	}
+	defer logStream.Close()
+	_, err = io.Copy(os.Stdout, logStream)
+	if err != nil {
+		return fmt.Errorf("Could not get logs %v", err)
+	}
+
+	return nil
+}


### PR DESCRIPTION
# Description

Added `logs` command to `dapr`

```
dapr logs -h

Gets Dapr sidecar logs for an app in Kubernetes

Usage:
  dapr logs [flags]

Flags:
  -a, --app-id string      The app id for which logs are needed
  -h, --help               help for logs
      --kubernetes         Only works with a Kubernetes cluster (default true)
  -n, --namespace string   (optional) Kubernetes namespace in which your application is deployed. default value is 'default'
  -p, --pod-name string    (optional) Name of the Pod. Use this in case you have multiple app instances (Pods)
```

## Issue reference

Issue #189 

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [ ] Created/updated tests
* [ ] Extended the documentation

## Usage

- `dapr logs --app-id nodeapp --kubernetes` - fetch `daprd` logs from `nodeapp`
- `dapr logs --app-id nodeapp --pod-name nodeapp-8544f8bf6b-cvz2x --kubernetes` - fetch `daprd` logs from a specific Pod (if you ahve multiple such Pods)


