### PR TITLE
Add InvokeGet and Post, refactor Invoke.

### DIFF
--- a/cmd/invoke.go
+++ b/cmd/invoke.go
@@ -20,9 +20,9 @@ var invokePayload string
 
 var InvokeCmd = &cobra.Command{
 	Use:   "invoke",
-	Short: "Invokes a Dapr app with an optional payload",
+	Short: "Invokes a Dapr app with an optional payload (deprecated, use invokePost)",
 	Run: func(cmd *cobra.Command, args []string) {
-		response, err := invoke.InvokeApp(invokeAppID, invokeAppMethod, invokePayload)
+		response, err := invoke.Post(invokeAppID, invokeAppMethod, invokePayload)
 		if err != nil {
 			print.FailureStatusEvent(os.Stdout, fmt.Sprintf("Error invoking app %s: %s", invokeAppID, err))
 			return

--- a/cmd/invokeGet.go
+++ b/cmd/invokeGet.go
@@ -1,0 +1,40 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/dapr/cli/pkg/invoke"
+	"github.com/dapr/cli/pkg/print"
+	"github.com/spf13/cobra"
+)
+
+// invokeGetCmd represents the invokeGet command
+var invokeGetCmd = &cobra.Command{
+	Use:   "invokeGet",
+	Short: "Issue HTTP GET to Dapr app",
+	Run: func(cmd *cobra.Command, args []string) {
+		response, err := invoke.Get(invokeAppID, invokeAppMethod)
+		if err != nil {
+			print.FailureStatusEvent(os.Stdout, fmt.Sprintf("Error invoking app %s: %s", invokeAppID, err))
+
+			return
+		}
+
+		if response != "" {
+			fmt.Println(response)
+		}
+
+		print.SuccessStatusEvent(os.Stdout, fmt.Sprintf("HTTP Get to method %s invoked successfully", invokeAppMethod))
+	},
+}
+
+func init() {
+	invokeGetCmd.Flags().StringVarP(&invokeAppID, "app-id", "a", "", "the app id to invoke")
+	invokeGetCmd.Flags().StringVarP(&invokeAppMethod, "method", "m", "", "the method to invoke")
+
+	invokeGetCmd.MarkFlagRequired("app-id")
+	invokeGetCmd.MarkFlagRequired("method")
+
+	RootCmd.AddCommand(invokeGetCmd)
+}

--- a/cmd/invokePost.go
+++ b/cmd/invokePost.go
@@ -1,0 +1,49 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+// ------------------------------------------------------------
+
+package cmd
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/dapr/cli/pkg/invoke"
+	"github.com/dapr/cli/pkg/print"
+	"github.com/spf13/cobra"
+)
+
+var (
+	invokePostCmd = &cobra.Command{
+		Use:   "invokePost",
+		Short: "Issue HTTP POST to Dapr app with an optional payload",
+		Run: func(cmd *cobra.Command, args []string) {
+
+			response, err := invoke.Post(invokeAppID, invokeAppMethod, invokePayload)
+			if err != nil {
+				print.FailureStatusEvent(os.Stdout, fmt.Sprintf("Error invoking app %s: %s", invokeAppID, err))
+
+				return
+			}
+
+			if response != "" {
+				fmt.Println(response)
+			}
+
+			print.SuccessStatusEvent(os.Stdout, fmt.Sprintf("HTTP Post to method %s invoked successfully", invokeAppMethod))
+
+		},
+	}
+)
+
+func init() {
+	invokePostCmd.Flags().StringVarP(&invokeAppID, "app-id", "a", "", "the app id to invoke")
+	invokePostCmd.Flags().StringVarP(&invokeAppMethod, "method", "m", "", "the method to invoke")
+	invokePostCmd.Flags().StringVarP(&invokePayload, "payload", "p", "", "(optional) a json payload")
+
+	invokePostCmd.MarkFlagRequired("app-id")
+	invokePostCmd.MarkFlagRequired("method")
+
+	RootCmd.AddCommand(invokePostCmd)
+}


### PR DESCRIPTION
# Description

This proposal adds support for HTTP GET to invoke commands. In order to avoid breaking existing scripts using Invoke, I added commands InvokeGet and InvokePost and updated the description to make Invoke obsolete. I also refactored pkg/invoke to accommodate the new commands.

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #224 

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x ] Code compiles correctly
* [ ] Created/updated tests
* [ ] Extended the documentation
