### PR TITLE
Enable actorStateStore by default in standalone mode

### DIFF
--- a/pkg/standalone/run.go
+++ b/pkg/standalone/run.go
@@ -26,7 +26,7 @@ import (
 )
 
 const (
-	componentsDirName           = "components"
+	componentsDirName      = "components"
 	messageBusYamlFileName = "messagebus.yaml"
 	stateStoreYamlFileName = "statestore.yaml"
 )
@@ -174,6 +174,11 @@ func createRedisStateStore(redisHost string) error {
 	redisStore.Spec.Metadata = append(redisStore.Spec.Metadata, componentMetadataItem{
 		Name:  "redisPassword",
 		Value: "",
+	})
+
+	redisStore.Spec.Metadata = append(redisStore.Spec.Metadata, componentMetadataItem{
+		Name:  "actorStateStore",
+		Value: "true",
 	})
 
 	b, err := yaml.Marshal(&redisStore)


### PR DESCRIPTION
With this change, user has to provide 'enable-actorstore' to configure actor state persistence in actors.

## Issue reference

Closes #230 

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [ ] Created/updated tests
* [ ] Extended the documentation
