### PR TITLE
Resolve #221 Installation Failure

### DIFF
--- a/install/install.ps1
+++ b/install/install.ps1
@@ -71,7 +71,7 @@ if (!(Test-Path $zipFilePath -PathType Leaf)) {
 
 # Extract Dapr CLI to c:\dapr
 Write-Output "Extracting $zipFilePath..."
-Expand-Archive -Force -Path $zipFilePath -DestinationPath $DaprRoot
+Microsoft.Powershell.Archive\Expand-Archive -Force -Path $zipFilePath -DestinationPath $DaprRoot
 if (!(Test-Path $DaprCliFilePath -PathType Leaf)) {
     throw "Failed to download Dapr Cli archieve - $zipFilePath"
 }


### PR DESCRIPTION
If a user has both PSCX and Microsoft.Powershell.Archive installed on their machine, the Expand-Archive call defaults to PSCX's version of Expand-Archive, with using -OutputPath instead of -DestinationPath. By specifying the module name before the call, we can ensure the proper version is always called and prevent an error for some users.

This will resolve issue #221

# Description

Modified install.ps1 script to change an error that occurs for users who have Powershell Community Extensions installed.

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #221

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [X] Code compiles correctly
* [N/A] Created/updated tests
* [N/A ] Extended the documentation
