### PR TITLE
#222 dapr stop does not work on windows

### DIFF
--- a/pkg/standalone/stop.go
+++ b/pkg/standalone/stop.go
@@ -24,8 +24,8 @@ func Stop(appID string) error {
 			pid := fmt.Sprintf("%v", a.PID)
 
 			var err error
-			if runtime.GOOS == "windows" {
-				err = utils.RunCmdAndWait("taskkill", "/F", "/PID", pid)
+			if runtime.GOOS == "windows" {				
+				err = utils.RunCmdAndWait("taskkill", "/F", "/T", "/PID", pid)
 			} else {
 				err = utils.RunCmdAndWait("kill", pid)
 			}


### PR DESCRIPTION
# Description

Add /T to taskkill on Windows. 

The issue is that dapr stop operates on the dapr instance that is hosting the app we want to stop. On MacOS/Linux we send kill and dapr has a handler for this to kill its children daprd and app. On windows, taskkill sends WM_CLOSE. Rather than handling it the same way as the kill signal handlers, it's easier to just add /T to the taskkill command, which will terminate children processes.

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #222 

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [ ] Created/updated tests
* [ ] Extended the documentation
