### PR TITLE
Cosmetic endline fix for --version

### DIFF
--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -21,7 +21,7 @@ func GetRuntimeVersion() string {
 
 	out, err := exec.Command(runtimeName, "--version").Output()
 	if err != nil {
-		return "n/a"
+		return "n/a\n"
 	}
 	return string(out)
 }


### PR DESCRIPTION
# Description

This minor, cosmetic fix ensures the output of `--version` ends with a newline even when there's no runtime installed. Perhaps there is a better way, like ending L26 with a newline and chomping the output of `daprd --version`.

## Issue reference

Seeing this is a minor fix in a somehow obscure use case (I hit this bug when `dapr init` failed on me, so I still had no runtime version output) I didn't want to waste the team's time with an issue.

## Checklist

I built this with `REL_VERSION=foo make release` with no warnings and confirmed the built binary outputs an endline when `daprd` is not present in `PATH`.

Apologies for writing more in this text than in the actual code.
