### PR TITLE
enable mTLS support for CLI

### DIFF
--- a/pkg/standalone/mtls_config.go
+++ b/pkg/standalone/mtls_config.go
@@ -1,4 +1,10 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+// ------------------------------------------------------------
+
 package standalone
+
 type mtlsConfig struct {
 	Spec struct {
 		MTLS struct {

--- a/pkg/standalone/mtls_config.go
+++ b/pkg/standalone/mtls_config.go
@@ -1,0 +1,8 @@
+package standalone
+type mtlsConfig struct {
+	Spec struct {
+		MTLS struct {
+			Enabled bool `yaml:"enabled"`
+		} `yaml:"mtls"`
+	} `yaml:"spec"`
+}


### PR DESCRIPTION
This PR reads the configuration file, if supplied, and enables mTLS on `daprd` with the default address for Sentry.