### PR TITLE
Warn yaml + some unit tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,6 @@
 
 # Visual Studio 2015/2017/2019 cache/options directory
 .vs/
+
+# CLI's auto-generated components directory
+**/components

--- a/go.mod
+++ b/go.mod
@@ -22,6 +22,7 @@ require (
 	github.com/phayes/freeport v0.0.0-20171002181615-b8543db493a5
 	github.com/spf13/cobra v0.0.5
 	github.com/spf13/viper v1.5.0
+	github.com/stretchr/testify v1.4.0
 	gopkg.in/yaml.v2 v2.2.4
 	k8s.io/api v0.17.0
 	k8s.io/apimachinery v0.17.0

--- a/pkg/standalone/run.go
+++ b/pkg/standalone/run.go
@@ -11,7 +11,7 @@ import (
 	"io/ioutil"
 	"os"
 	"os/exec"
-	"path"
+	"path/filepath"
 	"runtime"
 	"strings"
 
@@ -27,7 +27,7 @@ import (
 
 const (
 	componentsDirName      = "components"
-	messageBusYamlFileName = "messagebus.yaml"
+	messageBusYamlFileName = "pubsub.yaml"
 	stateStoreYamlFileName = "statestore.yaml"
 	sentryDefaultAddress   = "localhost:50001"
 )
@@ -183,7 +183,7 @@ func absoluteComponentsDir() (string, error) {
 		return "", err
 	}
 
-	return path.Join(wd, componentsDirName), nil
+	return filepath.Join(wd, componentsDirName), nil
 }
 
 func createRedisStateStore(redisHost string) error {
@@ -219,7 +219,9 @@ func createRedisStateStore(redisHost string) error {
 		return err
 	}
 
-	err = ioutil.WriteFile(path.Join(componentsDir, stateStoreYamlFileName), b, 0644)
+	filePath := filepath.Join(componentsDir, stateStoreYamlFileName)
+	fmt.Printf("WARNING: Redis State Store file is being overwritten: %s\n", filePath)
+	err = ioutil.WriteFile(filePath, b, 0644)
 	if err != nil {
 		return err
 	}
@@ -256,7 +258,9 @@ func createRedisPubSub(redisHost string) error {
 		return err
 	}
 
-	err = ioutil.WriteFile(path.Join(componentsDir, messageBusYamlFileName), b, 0644)
+	filePath := filepath.Join(componentsDir, messageBusYamlFileName)
+	fmt.Printf("WARNING: Redis PubSub file is being overwritten: %s\n", filePath)
+	err = ioutil.WriteFile(filePath, b, 0644)
 	if err != nil {
 		return err
 	}
@@ -285,6 +289,7 @@ func Run(config *RunConfig) (*RunOutput, error) {
 	if err != nil {
 		return nil, err
 	}
+
 	err = utils.CreateDirectory(componentsDir)
 	if err != nil {
 		return nil, err

--- a/pkg/standalone/run_test.go
+++ b/pkg/standalone/run_test.go
@@ -1,0 +1,90 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+// ------------------------------------------------------------
+
+package standalone
+
+import (
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func assertArgument(t *testing.T, key string, expectedValue string, args []string) {
+	var value string
+	for index, arg := range args {
+		if arg == "--"+key {
+			nextIndex := index + 1
+			if nextIndex < len(args) {
+				if !strings.HasPrefix(args[nextIndex], "--") {
+					value = args[nextIndex]
+				}
+			}
+		}
+	}
+
+	assert.Equal(t, expectedValue, value)
+}
+
+func TestRun(t *testing.T) {
+	t.Run("run happy http", func(t *testing.T) {
+		output, err := Run(&RunConfig{
+			AppID:           "MyID",
+			AppPort:         3000,
+			HTTPPort:        8000,
+			GRPCPort:        50001,
+			LogLevel:        "WARN",
+			Arguments:       []string{"MyCommand", "--my-arg"},
+			EnableProfiling: false,
+			ProfilePort:     9090,
+			Protocol:        "http",
+			RedisHost:       "localhost",
+			PlacementHost:   "localhost",
+		})
+
+		assert.Nil(t, err)
+		assert.NotNil(t, output)
+
+		assert.Equal(t, "MyID", output.AppID)
+		assert.Equal(t, 8000, output.DaprHTTPPort)
+		assert.Equal(t, 50001, output.DaprGRPCPort)
+
+		assert.Contains(t, output.DaprCMD.Args[0], "daprd")
+		assertArgument(t, "dapr-id", "MyID", output.DaprCMD.Args)
+		assertArgument(t, "dapr-http-port", "8000", output.DaprCMD.Args)
+		assertArgument(t, "dapr-grpc-port", "50001", output.DaprCMD.Args)
+		assertArgument(t, "log-level", "WARN", output.DaprCMD.Args)
+		assertArgument(t, "max-concurrency", "-1", output.DaprCMD.Args)
+		assertArgument(t, "protocol", "http", output.DaprCMD.Args)
+		assertArgument(t, "app-port", "3000", output.DaprCMD.Args)
+		if runtime.GOOS == "windows" {
+			assertArgument(t, "placement-address", "localhost:6050", output.DaprCMD.Args)
+		} else {
+			assertArgument(t, "placement-address", "localhost:50005", output.DaprCMD.Args)
+		}
+
+		assert.Equal(t, "MyCommand", output.AppCMD.Args[0])
+		assert.Equal(t, "--my-arg", output.AppCMD.Args[1])
+	})
+
+	t.Run("run without app command", func(t *testing.T) {
+		output, err := Run(&RunConfig{
+			AppID:           "my app id",
+			AppPort:         3000,
+			HTTPPort:        8000,
+			GRPCPort:        50001,
+			EnableProfiling: false,
+			ProfilePort:     9090,
+			Protocol:        "http",
+			RedisHost:       "localhost",
+			PlacementHost:   "localhost",
+		})
+
+		assert.NotNil(t, err)
+		assert.Nil(t, output)
+		assert.EqualError(t, err, "no app entrypoint given")
+	})
+}


### PR DESCRIPTION
# Description

Warning about yaml files being overwritten.
Use filepath.Join() instead of path.Join() in run.go
Started some unit tests for standalone/run.go

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #262 

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [X] Code compiles correctly
* [X] Created/updated tests
* [ ] Extended the documentation
