### PR TITLE
Fix client initialization when KUBECONFIG OS path has : delimiter (#277)

### DIFF
--- a/pkg/kubernetes/client.go
+++ b/pkg/kubernetes/client.go
@@ -25,7 +25,8 @@ const kubeConfigDelimiter = ":"
 
 func getConfig() (*rest.Config, error) {
 	var kubeconfig *string
-	if home := homeDir(); home != "" {
+	var home string
+	if home = homeDir(); home != "" {
 		kubeconfig = flag.String("kubeconfig", filepath.Join(home, ".kube", "config"), "(optional) absolute path to the kubeconfig file")
 	} else {
 		kubeconfig = flag.String("kubeconfig", "", "absolute path to the kubeconfig file")
@@ -33,7 +34,9 @@ func getConfig() (*rest.Config, error) {
 	flag.Parse()
 
 	kubeConfigEnv := os.Getenv("KUBECONFIG")
-	if len(kubeConfigEnv) != 0 {
+	delimiterBelongsToPath := strings.Count(*kubeconfig, kubeConfigDelimiter) == 1 && strings.EqualFold(*kubeconfig, kubeConfigEnv)
+
+	if len(kubeConfigEnv) != 0 && !delimiterBelongsToPath {
 		kubeConfigs := strings.Split(kubeConfigEnv, kubeConfigDelimiter)
 		if len(kubeConfigs) > 1 {
 			return nil, fmt.Errorf("multiple kubeconfigs in KUBECONFIG environment variable - %s", kubeConfigEnv)

--- a/pkg/kubernetes/client_test.go
+++ b/pkg/kubernetes/client_test.go
@@ -1,0 +1,39 @@
+package kubernetes
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/magiconair/properties/assert"
+)
+
+func KubernetesClientConfig(t *testing.T) {
+
+	t.Run("Initialize client when the only path is configured", func(t *testing.T) {
+		os.Setenv("KUBECONFIG", "/home/user/.kube/config")
+		_, err := Client()
+		assert.Equal(t, err, nil)
+	})
+
+	t.Run("Initialize client when only one path is configured and the only one delimiter found belongs to the os path", func(t *testing.T) {
+		os.Setenv("KUBECONFIG", "C:\\Users\\DummyUser\\.kube\\config")
+		_, err := Client()
+		assert.Equal(t, err, nil)
+	})
+
+	t.Run("Return error when multiple kubeconfigs are configured", func(t *testing.T) {
+
+		config := "C:\\Users\\DummyUser\\.kube\\config:C:\\Config\\.kube\\config"
+		os.Setenv("KUBECONFIG", config)
+		_, err := Client()
+
+		assert.Equal(t, err.Error(), fmt.Sprintf("multiple kubeconfigs in KUBECONFIG environment variable - %s", config))
+
+		config = "/home/dummy/.kube/config:/home/dummy/k8s/.kube/config"
+		os.Setenv("KUBECONFIG", config)
+		_, err = Client()
+
+		assert.Equal(t, err.Error(), fmt.Sprintf("multiple kubeconfigs in KUBECONFIG environment variable - %s", config))
+	})
+}


### PR DESCRIPTION
# Description

The client now checks if KUBECONFIG env has only one delimiter, and if it's belong to the OS home dir it does not try to split the env var configuration causing this:

[0] C:
[1} Users\DummyUser\.kube\config

## Issue reference

Please reference the issue this PR will close: #277 

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [X] Code compiles correctly
* [X] Created/updated tests
* [ ] Extended the documentation
