### PR TITLE
Fix client initialization when KUBECONFIG OS path has : delimiter (#277)

### DIFF
--- a/pkg/kubernetes/client.go
+++ b/pkg/kubernetes/client.go
@@ -25,7 +25,8 @@ const kubeConfigDelimiter = ":"
 
 func getConfig() (*rest.Config, error) {
 	var kubeconfig *string
-	if home := homeDir(); home != "" {
+	var home string
+	if home = homeDir(); home != "" {
 		kubeconfig = flag.String("kubeconfig", filepath.Join(home, ".kube", "config"), "(optional) absolute path to the kubeconfig file")
 	} else {
 		kubeconfig = flag.String("kubeconfig", "", "absolute path to the kubeconfig file")
@@ -33,7 +34,9 @@ func getConfig() (*rest.Config, error) {
 	flag.Parse()
 
 	kubeConfigEnv := os.Getenv("KUBECONFIG")
-	if len(kubeConfigEnv) != 0 {
+	delimiterBelongsToPath := strings.Count(*kubeconfig, kubeConfigDelimiter) == 1 && strings.EqualFold(*kubeconfig, kubeConfigEnv)
+
+	if len(kubeConfigEnv) != 0 && !delimiterBelongsToPath {
 		kubeConfigs := strings.Split(kubeConfigEnv, kubeConfigDelimiter)
 		if len(kubeConfigs) > 1 {
 			return nil, fmt.Errorf("multiple kubeconfigs in KUBECONFIG environment variable - %s", kubeConfigEnv)

--- a/pkg/kubernetes/client.go
+++ b/pkg/kubernetes/client.go
@@ -25,8 +25,8 @@ const kubeConfigDelimiter = ":"
 
 func getConfig() (*rest.Config, error) {
 	var kubeconfig *string
-	var home string
-	if home = homeDir(); home != "" {
+
+	if home := homeDir(); home != "" {
 		kubeconfig = flag.String("kubeconfig", filepath.Join(home, ".kube", "config"), "(optional) absolute path to the kubeconfig file")
 	} else {
 		kubeconfig = flag.String("kubeconfig", "", "absolute path to the kubeconfig file")


### PR DESCRIPTION
# Description

I am unable to execute --kubernetes commands in windows as it splits wrong the home path.

![image](https://user-images.githubusercontent.com/16475649/75016484-62067880-548b-11ea-886b-60b7f42076bc.png)

With this change, if only one delimiter is found and it belongs to the user home path and also the KUBECONFIG env var is the same as the file path join of the user home kube config, no split is executed

## Issue reference

#277 

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [X] Code compiles correctly
* [ ] Created/updated tests (I've create tests that run locally, but they have not been commited because they would access local kube files in the CI)
* [ ] Extended the documentation
