### PR TITLE
Add Kubernetes shorthand k to init, list and logs cli commands #267

### DIFF
--- a/cmd/init.go
+++ b/cmd/init.go
@@ -51,7 +51,7 @@ var InitCmd = &cobra.Command{
 }
 
 func init() {
-	InitCmd.Flags().BoolVar(&kubernetesMode, "kubernetes", false, "Deploy Dapr to a Kubernetes cluster")
+	InitCmd.Flags().BoolVarP(&kubernetesMode, "kubernetes", "k", false, "Deploy Dapr to a Kubernetes cluster")
 	InitCmd.Flags().StringVarP(&runtimeVersion, "runtime-version", "", "latest", "The version of the Dapr runtime to install. for example: v0.1.0-alpha")
 	InitCmd.Flags().String("network", "", "The Docker network on which to deploy the Dapr runtime")
 	InitCmd.Flags().String("install-path", "", "The optional location to install Dapr to.  The default is /usr/local/bin for Linux/Mac and C:\\dapr for Windows")

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -59,6 +59,6 @@ var ListCmd = &cobra.Command{
 }
 
 func init() {
-	ListCmd.Flags().BoolVar(&kubernetesMode, "kubernetes", false, "List all Dapr pods in a k8s cluster")
+	ListCmd.Flags().BoolVarP(&kubernetesMode, "kubernetes", "k", false, "List all Dapr pods in a k8s cluster")
 	RootCmd.AddCommand(ListCmd)
 }

--- a/cmd/logs.go
+++ b/cmd/logs.go
@@ -32,7 +32,7 @@ var LogsCmd = &cobra.Command{
 }
 
 func init() {
-	LogsCmd.Flags().BoolVar(&k8s, "kubernetes", true, "Only works with a Kubernetes cluster")
+	LogsCmd.Flags().BoolVarP(&k8s, "kubernetes", "k", true, "Only works with a Kubernetes cluster")
 	LogsCmd.Flags().StringVarP(&logsAppID, "app-id", "a", "", "The app id for which logs are needed")
 	LogsCmd.Flags().StringVarP(&podName, "pod-name", "p", "", "(optional) Name of the Pod. Use this in case you have multiple app instances (Pods)")
 	LogsCmd.Flags().StringVarP(&namespace, "namespace", "n", "", "(optional) Kubernetes namespace in which your application is deployed. default value is 'default'")


### PR DESCRIPTION
# Description

Add --kubernetes shorthand (k) to list, init and logs cli commands.

Other commands like components, configuration and mtls already have this shorthand

## Issue reference

#267

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [X] Code compiles correctly
* [ ] Created/updated tests
* [ ] Extended the documentation
