### PR TITLE
Use the full container name when checking redis

### DIFF
--- a/pkg/standalone/standalone.go
+++ b/pkg/standalone/standalone.go
@@ -100,7 +100,7 @@ func Init(runtimeVersion string, dockerNetwork string, installLocation string) e
 
 	if s != nil {
 		s.Stop()
-		err = confirmContainerIsRunning(DaprRedisContainerName)
+		err = confirmContainerIsRunning(utils.CreateContainerName(DaprRedisContainerName, dockerNetwork))
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
# Description

When the redis container is created, the potential custom docker
network is appended to the container name. This change uses the
same convention when checking that the redis container is running.

## Issue reference

Fixes #302.

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [ ] Created/updated tests
* [ ] Extended the documentation
