### PR TITLE
Adds tar.gz for Homebrew.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -112,6 +112,9 @@ archive-$(CLI_BINARY).tar.gz:
 	chmod +x $(BINS_OUT_DIR)/$(CLI_BINARY)$(BINARY_EXT)
 	tar czf "$(ARCHIVE_OUT_DIR)/$(CLI_BINARY)_$(GOOS)_$(GOARCH)$(ARCHIVE_EXT)" -C "$(BINS_OUT_DIR)" "$(CLI_BINARY)$(BINARY_EXT)"
 endif
+ifeq ($(GOOS),darwin)
+	cp "$(ARCHIVE_OUT_DIR)/$(CLI_BINARY)_$(GOOS)_$(GOARCH)$(ARCHIVE_EXT)" "$(ARCHIVE_OUT_DIR)/dapr-cli-$(CLI_VERSION).catalina.bottle.tar.gz"
+endif
 
 ################################################################################
 # Target: release                                                              #


### PR DESCRIPTION
# Description

Adds tar.gz for Homebrew on Catalina. It will allow installation via binary instead of source code on Catalina macOS.

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #171 

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [X] Code compiles correctly
* [ ] Created/updated tests
* [ ] Extended the documentation
