### PR TITLE
Allow 'dapr init' to specify kubernetes namespace for installation

### DIFF
--- a/cmd/init.go
+++ b/cmd/init.go
@@ -17,6 +17,7 @@ import (
 
 var kubernetesMode bool
 var runtimeVersion string
+var kubernetesNamespace string
 
 var InitCmd = &cobra.Command{
 	Use:   "init",
@@ -31,7 +32,7 @@ var InitCmd = &cobra.Command{
 		installLocation := viper.GetString("install-path")
 		if kubernetesMode {
 			print.InfoStatusEvent(os.Stdout, "Note: this installation is recommended for testing purposes. For production environments, please use Helm \n")
-			err := kubernetes.Init()
+			err := kubernetes.Init(kubernetesNamespace)
 			if err != nil {
 				print.FailureStatusEvent(os.Stdout, err.Error())
 				return
@@ -53,6 +54,7 @@ var InitCmd = &cobra.Command{
 func init() {
 	InitCmd.Flags().BoolVarP(&kubernetesMode, "kubernetes", "k", false, "Deploy Dapr to a Kubernetes cluster")
 	InitCmd.Flags().StringVarP(&runtimeVersion, "runtime-version", "", "latest", "The version of the Dapr runtime to install. for example: v0.1.0-alpha")
+	InitCmd.Flags().StringVarP(&kubernetesNamespace, "namespace", "", "default", "(Optional) Existing Kubernetes namespace for Dapr installation. The 'default' namespace is used if not specified")
 	InitCmd.Flags().String("network", "", "The Docker network on which to deploy the Dapr runtime")
 	InitCmd.Flags().String("install-path", "", "The optional location to install Dapr to.  The default is /usr/local/bin for Linux/Mac and C:\\dapr for Windows")
 


### PR DESCRIPTION
# Description

Add `--namespace` flag to `dapr init` to specify kubernetes namespace for dapr installation

e.g. 

`dapr init --kubernetes --namespace dapr` - will use `dapr` namespace (should already exist)
`dapr init --kubernetes` - will use `default` namespace

## Issue reference

Issue #281 

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [ ] Extended the documentation
