### PR TITLE
Add dapr control plane status for Kubernetes

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,9 +250,9 @@ To list all Dapr instances running in a Kubernetes cluster:
 $ dapr list --kubernetes
 ```
 
-### Check control plane status
+### Check system services (control plane) status
 
-Check Dapr's control plane health status in a Kubernetes cluster:
+Check Dapr's system services (control plane) health status in a Kubernetes cluster:
 
 ```
 $ dapr status --kubernetes

--- a/README.md
+++ b/README.md
@@ -250,6 +250,13 @@ To list all Dapr instances running in a Kubernetes cluster:
 $ dapr list --kubernetes
 ```
 
+### Check control plane status
+
+Check Dapr's control plane health status in a Kubernetes cluster:
+
+```
+$ dapr status --kubernetes
+```
 
 ### Check mTLS status
 

--- a/cmd/logs.go
+++ b/cmd/logs.go
@@ -32,7 +32,7 @@ var LogsCmd = &cobra.Command{
 }
 
 func init() {
-	LogsCmd.Flags().BoolVarP(&k8s, "kubernetes", "k", true, "Only works with a Kubernetes cluster")
+	LogsCmd.Flags().BoolVarP(&k8s, "kubernetes", "k", true, "only works with a Kubernetes cluster")
 	LogsCmd.Flags().StringVarP(&logsAppID, "app-id", "a", "", "The app id for which logs are needed")
 	LogsCmd.Flags().StringVarP(&podName, "pod-name", "p", "", "(optional) Name of the Pod. Use this in case you have multiple app instances (Pods)")
 	LogsCmd.Flags().StringVarP(&namespace, "namespace", "n", "", "(optional) Kubernetes namespace in which your application is deployed. default value is 'default'")

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -1,0 +1,41 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+// ------------------------------------------------------------
+
+package cmd
+
+import (
+	"os"
+
+	"github.com/dapr/cli/pkg/kubernetes"
+	"github.com/dapr/cli/pkg/print"
+	"github.com/dapr/cli/utils"
+	"github.com/gocarina/gocsv"
+	"github.com/spf13/cobra"
+)
+
+var StatusCmd = &cobra.Command{
+	Use:   "status",
+	Short: "Shows status and health of the Dapr control plane on Kubernetes",
+	Run: func(cmd *cobra.Command, args []string) {
+		status, err := kubernetes.Status()
+		if err != nil {
+			print.FailureStatusEvent(os.Stdout, err.Error())
+			os.Exit(1)
+		}
+		table, err := gocsv.MarshalString(status)
+		if err != nil {
+			print.FailureStatusEvent(os.Stdout, err.Error())
+			os.Exit(1)
+		}
+
+		utils.PrintTable(table)
+	},
+}
+
+func init() {
+	StatusCmd.Flags().BoolVarP(&k8s, "kubernetes", "k", true, "Only works with a Kubernetes cluster")
+	StatusCmd.MarkFlagRequired("kubernetes")
+	RootCmd.AddCommand(StatusCmd)
+}

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -35,7 +35,7 @@ var StatusCmd = &cobra.Command{
 }
 
 func init() {
-	StatusCmd.Flags().BoolVarP(&k8s, "kubernetes", "k", true, "Only works with a Kubernetes cluster")
+	StatusCmd.Flags().BoolVarP(&k8s, "kubernetes", "k", true, "only works with a Kubernetes cluster")
 	StatusCmd.MarkFlagRequired("kubernetes")
 	RootCmd.AddCommand(StatusCmd)
 }

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -17,7 +17,7 @@ import (
 
 var StatusCmd = &cobra.Command{
 	Use:   "status",
-	Short: "Shows the Dapr control plane health status.",
+	Short: "Shows the Dapr system services (control plane) health status.",
 	Run: func(cmd *cobra.Command, args []string) {
 		status, err := kubernetes.Status()
 		if err != nil {

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -17,7 +17,7 @@ import (
 
 var StatusCmd = &cobra.Command{
 	Use:   "status",
-	Short: "Shows status and health of the Dapr control plane on Kubernetes",
+	Short: "Shows the Dapr control plane health status.",
 	Run: func(cmd *cobra.Command, args []string) {
 		status, err := kubernetes.Status()
 		if err != nil {

--- a/pkg/kubernetes/list.go
+++ b/pkg/kubernetes/list.go
@@ -7,7 +7,6 @@ package kubernetes
 
 import (
 	"github.com/dapr/cli/pkg/age"
-	core_v1 "k8s.io/api/core/v1"
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -26,7 +25,7 @@ func List() ([]ListOutput, error) {
 		return nil, err
 	}
 
-	podList, err := client.CoreV1().Pods(core_v1.NamespaceAll).List(meta_v1.ListOptions{})
+	podList, err := ListPods(client, meta_v1.NamespaceAll, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/kubernetes/logs.go
+++ b/pkg/kubernetes/logs.go
@@ -11,7 +11,6 @@ import (
 	"os"
 
 	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 const (
@@ -30,7 +29,7 @@ func Logs(appID, podName, namespace string) error {
 		namespace = corev1.NamespaceDefault
 	}
 
-	pods, err := client.CoreV1().Pods(namespace).List(metav1.ListOptions{})
+	pods, err := ListPods(client, namespace, nil)
 	if err != nil {
 		return fmt.Errorf("could not get logs %v", err)
 	}

--- a/pkg/kubernetes/pods.go
+++ b/pkg/kubernetes/pods.go
@@ -1,0 +1,16 @@
+package kubernetes
+
+import (
+	core_v1 "k8s.io/api/core/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	k8s "k8s.io/client-go/kubernetes"
+)
+
+func ListPods(client *k8s.Clientset, namespace string, labelSelector map[string]string) (*core_v1.PodList, error) {
+	opts := v1.ListOptions{}
+	if labelSelector != nil {
+		opts.LabelSelector = labels.FormatLabels(labelSelector)
+	}
+	return client.CoreV1().Pods(v1.NamespaceAll).List(opts)
+}

--- a/pkg/kubernetes/status.go
+++ b/pkg/kubernetes/status.go
@@ -1,0 +1,98 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+// ------------------------------------------------------------
+
+package kubernetes
+
+import (
+	"fmt"
+	"strings"
+	"sync"
+
+	"github.com/dapr/cli/pkg/age"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+)
+
+var (
+	controlPlaneLabels = []string{"dapr-operator", "dapr-sentry", "dapr-placement", "dapr-sidecar-injector"}
+)
+
+// StatutOutput represents the status of a named Dapr resource.
+type StatusOutput struct {
+	Name      string `csv:"NAME"`
+	Namespace string `csv:"NAMESPACE"`
+	Healthy   string `csv:"HEALTHY"`
+	Status    string `csv:"STATUS"`
+	Version   string `csv:"VERSION"`
+	Age       string `csv:"AGE"`
+	Created   string `csv:"CREATED"`
+}
+
+// List status for Dapr resources.
+func Status() ([]StatusOutput, error) {
+	client, err := Client()
+	if err != nil {
+		return nil, err
+	}
+
+	var wg sync.WaitGroup
+	wg.Add(len(controlPlaneLabels))
+
+	m := sync.Mutex{}
+	statuses := []StatusOutput{}
+
+	for _, lbl := range controlPlaneLabels {
+		go func(label string) {
+			p, err := client.CoreV1().Pods(v1.NamespaceAll).List(v1.ListOptions{
+				LabelSelector: labels.FormatLabels(
+					map[string]string{
+						"app": label,
+					},
+				),
+			})
+			if err == nil && len(p.Items) == 1 {
+				pod := p.Items[0]
+
+				image := pod.Spec.Containers[0].Image
+				namespace := pod.GetNamespace()
+				age := age.GetAge(pod.CreationTimestamp.Time)
+				created := pod.CreationTimestamp.Format("2006-01-02 15:04.05")
+				version := image[strings.IndexAny(image, ":")+1:]
+				status := ""
+
+				if pod.Status.ContainerStatuses[0].State.Waiting != nil {
+					status = fmt.Sprintf("Waiting (%s)", pod.Status.ContainerStatuses[0].State.Waiting.Reason)
+				} else if pod.Status.ContainerStatuses[0].State.Running != nil {
+					status = "Running"
+				} else if pod.Status.ContainerStatuses[0].State.Terminated != nil {
+					status = "Terminated"
+				}
+
+				healthy := "False"
+				if pod.Status.ContainerStatuses[0].Ready {
+					healthy = "True"
+				}
+
+				s := StatusOutput{
+					Name:      label,
+					Namespace: namespace,
+					Created:   created,
+					Age:       age,
+					Status:    status,
+					Version:   version,
+					Healthy:   healthy,
+				}
+
+				m.Lock()
+				statuses = append(statuses, s)
+				m.Unlock()
+			}
+			wg.Done()
+		}(lbl)
+	}
+
+	wg.Wait()
+	return statuses, nil
+}

--- a/pkg/kubernetes/status.go
+++ b/pkg/kubernetes/status.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/dapr/cli/pkg/age"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/labels"
 )
 
 var (
@@ -45,12 +44,8 @@ func Status() ([]StatusOutput, error) {
 
 	for _, lbl := range controlPlaneLabels {
 		go func(label string) {
-			p, err := client.CoreV1().Pods(v1.NamespaceAll).List(v1.ListOptions{
-				LabelSelector: labels.FormatLabels(
-					map[string]string{
-						"app": label,
-					},
-				),
+			p, err := ListPods(client, v1.NamespaceAll, map[string]string{
+				"app": label,
 			})
 			if err == nil && len(p.Items) == 1 {
 				pod := p.Items[0]

--- a/pkg/kubernetes/status.go
+++ b/pkg/kubernetes/status.go
@@ -19,7 +19,7 @@ var (
 	controlPlaneLabels = []string{"dapr-operator", "dapr-sentry", "dapr-placement", "dapr-sidecar-injector"}
 )
 
-// StatutOutput represents the status of a named Dapr resource.
+// StatusOutput represents the status of a named Dapr resource.
 type StatusOutput struct {
 	Name      string `csv:"NAME"`
 	Namespace string `csv:"NAMESPACE"`


### PR DESCRIPTION
Closes #312 

This PR allows a user to see the Dapr control plane status when running on Kubernetes.

Command: `dapr status -k` or `dapr status --kubernetes`.

Output example: (2 services running, 2 failing):

```
  NAME                   NAMESPACE    HEALTHY  STATUS                      VERSION  AGE  CREATED              
  dapr-operator          dapr-system  False    Waiting (CrashLoopBackOff)  0.6.0    2d   2020-04-04 11:19.39  
  dapr-placement         dapr-system  True     Running                     0.6.0    2d   2020-04-04 11:19.39  
  dapr-sentry            dapr-system  False    Terminated                  0.6.0    2d   2020-04-04 11:19.39  
  dapr-sidecar-injector  dapr-system  True     Running                     0.6.0    2d   2020-04-04 11:19.39 
```