### PR TITLE
Adding support for --runtime-version flag for dapr init k8s

### DIFF
--- a/cmd/init.go
+++ b/cmd/init.go
@@ -31,7 +31,7 @@ var InitCmd = &cobra.Command{
 		installLocation := viper.GetString("install-path")
 		if kubernetesMode {
 			print.InfoStatusEvent(os.Stdout, "Note: this installation is recommended for testing purposes. For production environments, please use Helm \n")
-			err := kubernetes.Init()
+			err := kubernetes.Init(runtimeVersion)
 			if err != nil {
 				print.FailureStatusEvent(os.Stdout, err.Error())
 				return

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -52,7 +52,7 @@ var InitCmd = &cobra.Command{
 
 func init() {
 	InitCmd.Flags().BoolVarP(&kubernetesMode, "kubernetes", "k", false, "Deploy Dapr to a Kubernetes cluster")
-	InitCmd.Flags().StringVarP(&runtimeVersion, "runtime-version", "", "latest", "The version of the Dapr runtime to install. for example: v0.1.0-alpha")
+	InitCmd.Flags().StringVarP(&runtimeVersion, "runtime-version", "", "latest", "The version of the Dapr runtime to install. for example: v0.1.0")
 	InitCmd.Flags().String("network", "", "The Docker network on which to deploy the Dapr runtime")
 	InitCmd.Flags().String("install-path", "", "The optional location to install Dapr to.  The default is /usr/local/bin for Linux/Mac and C:\\dapr for Windows")
 

--- a/pkg/kubernetes/kubernetes.go
+++ b/pkg/kubernetes/kubernetes.go
@@ -20,16 +20,24 @@ import (
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-// Init deploys the Dapr operator
-func Init() error {
+const (
+	daprLatestVersion = "latest"
+)
+
+// Init deploys the Dapr operator using the supplied runtime version.
+func Init(version string) error {
 	client, err := DaprClient()
 	if err != nil {
 		return fmt.Errorf("can't connect to a Kubernetes cluster: %v", err)
 	}
 
-	version, err := cli_ver.GetLatestRelease(cli_ver.DaprGitHubOrg, cli_ver.DaprGitHubRepo)
-	if err != nil {
-		return fmt.Errorf("cannot get the manifest file: %s", err)
+	if version == daprLatestVersion {
+		v, err := cli_ver.GetLatestRelease(cli_ver.DaprGitHubOrg, cli_ver.DaprGitHubRepo)
+		if err != nil {
+			return fmt.Errorf("cannot get the manifest file: %s", err)
+		}
+
+		version = v
 	}
 
 	var daprManifestPath string = "https://github.com/dapr/dapr/releases/download/" + version + "/dapr-operator.yaml"

--- a/pkg/kubernetes/kubernetes.go
+++ b/pkg/kubernetes/kubernetes.go
@@ -32,7 +32,8 @@ func Init(version string) error {
 	}
 
 	if version == daprLatestVersion {
-		v, err := cli_ver.GetLatestRelease(cli_ver.DaprGitHubOrg, cli_ver.DaprGitHubRepo)
+		var v string
+		v, err = cli_ver.GetLatestRelease(cli_ver.DaprGitHubOrg, cli_ver.DaprGitHubRepo)
 		if err != nil {
 			return fmt.Errorf("cannot get the manifest file: %s", err)
 		}


### PR DESCRIPTION
# Description

To support honoring the --runtime-version flag for kubernetes init

## Issue reference

Closes #307

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [ ] Created/updated tests
* [ ] Extended the documentation
