### PR TITLE
Add flag to provide custom components directory path for dapr run

### DIFF
--- a/cmd/run.go
+++ b/cmd/run.go
@@ -33,6 +33,7 @@ var image string
 var enableProfiling bool
 var logLevel string
 var protocol string
+var componentsPath string
 
 var RunCmd = &cobra.Command{
 	Use:   "run",
@@ -89,6 +90,7 @@ Run sidecar only:
 				Protocol:        protocol,
 				RedisHost:       viper.GetString("redis-host"),
 				PlacementHost:   viper.GetString("placement-host"),
+				ComponentsPath:  componentsPath,
 			})
 			if err != nil {
 				print.FailureStatusEvent(os.Stdout, err.Error())
@@ -243,6 +245,7 @@ func init() {
 	RunCmd.Flags().StringVarP(&logLevel, "log-level", "", "info", "Sets the log verbosity. Valid values are: debug, info, warn, error, fatal, or panic. Default is info")
 	RunCmd.Flags().IntVarP(&maxConcurrency, "max-concurrency", "", -1, "controls the concurrency level of the app. Default is unlimited")
 	RunCmd.Flags().StringVarP(&protocol, "protocol", "", "http", "tells Dapr to use HTTP or gRPC to talk to the app. Default is http")
+	RunCmd.Flags().StringVarP(&componentsPath, "components-path", "", "", "Path for components directory. Default is ./components.")
 	RunCmd.Flags().String("redis-host", "localhost", "the host on which the Redis service resides")
 	RunCmd.Flags().String("placement-host", "localhost", "the host on which the placement service resides")
 

--- a/docs/reference/dapr-run.md
+++ b/docs/reference/dapr-run.md
@@ -16,6 +16,7 @@ dapr run [flags] [command]
 | --- | --- | --- | --- |
 | `--app-id` | | | An ID for your application, used for service discovery |
 | `--app-port` | | `-1` | The port your application is listening on |
+| `--components-path` | | `./components` | Path for components directory |
 | `--config` | | | Dapr configuration file |
 | `--enable-profiling` | | | Enable `pprof` profiling via an HTTP endpoint |
 | `--grpc-port` | | `-1` | The gRPC port for Dapr to listen on |

--- a/pkg/standalone/run_test.go
+++ b/pkg/standalone/run_test.go
@@ -60,6 +60,7 @@ func TestRun(t *testing.T) {
 		assertArgument(t, "max-concurrency", "-1", output.DaprCMD.Args)
 		assertArgument(t, "protocol", "http", output.DaprCMD.Args)
 		assertArgument(t, "app-port", "3000", output.DaprCMD.Args)
+		assertArgument(t, "components-path", "", output.DaprCMD.Args)
 		if runtime.GOOS == "windows" {
 			assertArgument(t, "placement-address", "localhost:6050", output.DaprCMD.Args)
 		} else {
@@ -99,6 +100,7 @@ func TestRun(t *testing.T) {
 		assertArgument(t, "max-concurrency", "-1", output.DaprCMD.Args)
 		assertArgument(t, "protocol", "http", output.DaprCMD.Args)
 		assertArgument(t, "app-port", "3000", output.DaprCMD.Args)
+		assertArgument(t, "components-path", "", output.DaprCMD.Args)
 		if runtime.GOOS == "windows" {
 			assertArgument(t, "placement-address", "localhost:6050", output.DaprCMD.Args)
 		} else {


### PR DESCRIPTION
# Description

This PR adds `--components-path` flag to `dapr run` command

## Issue reference

Please reference the issue this PR will close: https://github.com/dapr/cli/issues/321

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Created/updated tests
* [x] Extended the documentation

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dapr/cli/326)
<!-- Reviewable:end -->
