### PR TITLE
More verbose log on failure of container uninstall

### DIFF
--- a/pkg/standalone/uninstall.go
+++ b/pkg/standalone/uninstall.go
@@ -18,7 +18,7 @@ func Uninstall(uninstallAll bool, dockerNetwork string) error {
 		utils.CreateContainerName(DaprPlacementContainerName, dockerNetwork))
 
 	if err != nil {
-		errs = append(errs, fmt.Errorf("could not remove %s: %s", DaprPlacementContainerName, err))
+		errs = append(errs, fmt.Errorf("could not remove %s container: %s", DaprPlacementContainerName, err))
 	}
 
 	_, err = utils.RunCmdAndWait(
@@ -27,7 +27,7 @@ func Uninstall(uninstallAll bool, dockerNetwork string) error {
 		daprDockerImageName)
 
 	if err != nil {
-		errs = append(errs, fmt.Errorf("could not remove %s: %s", daprDockerImageName, err))
+		errs = append(errs, fmt.Errorf("could not remove %s container: %s", daprDockerImageName, err))
 	}
 
 	if uninstallAll {
@@ -36,7 +36,7 @@ func Uninstall(uninstallAll bool, dockerNetwork string) error {
 			"--force",
 			utils.CreateContainerName(DaprRedisContainerName, dockerNetwork))
 		if err != nil {
-			errs = append(errs, fmt.Errorf("could not remove %s: %s", DaprRedisContainerName, err))
+			errs = append(errs, fmt.Errorf("could not remove %s container: %s", DaprRedisContainerName, err))
 		}
 	}
 

--- a/pkg/standalone/uninstall.go
+++ b/pkg/standalone/uninstall.go
@@ -18,9 +18,7 @@ func Uninstall(uninstallAll bool, dockerNetwork string) error {
 		utils.CreateContainerName(DaprPlacementContainerName, dockerNetwork))
 
 	if err != nil {
-		errs = append(
-			errs,
-			fmt.Errorf("could not remove container %s container: %s", DaprPlacementContainerName, err))
+		errs = append(errs, fmt.Errorf("could not remove %s: %s", DaprPlacementContainerName, err))
 	}
 
 	_, err = utils.RunCmdAndWait(
@@ -29,7 +27,7 @@ func Uninstall(uninstallAll bool, dockerNetwork string) error {
 		daprDockerImageName)
 
 	if err != nil {
-		errs = append(errs, fmt.Errorf("could not remove container %s container: %s", daprDockerImageName, err))
+		errs = append(errs, fmt.Errorf("could not remove %s: %s", daprDockerImageName, err))
 	}
 
 	if uninstallAll {
@@ -38,7 +36,7 @@ func Uninstall(uninstallAll bool, dockerNetwork string) error {
 			"--force",
 			utils.CreateContainerName(DaprRedisContainerName, dockerNetwork))
 		if err != nil {
-			errs = append(errs, fmt.Errorf("could not remove %s container: %s", DaprRedisContainerName, err))
+			errs = append(errs, fmt.Errorf("could not remove %s: %s", DaprRedisContainerName, err))
 		}
 	}
 
@@ -53,7 +51,7 @@ func Uninstall(uninstallAll bool, dockerNetwork string) error {
 
 	err = errors.New("uninstall failed")
 	for _, e := range errs {
-		err = fmt.Errorf("%w; %s", err, e)
+		err = fmt.Errorf("%w \n %s", err, e)
 	}
 	return err
 }

--- a/pkg/standalone/uninstall.go
+++ b/pkg/standalone/uninstall.go
@@ -1,8 +1,8 @@
 package standalone
 
 import (
+	"errors"
 	"fmt"
-	"strings"
 
 	"github.com/dapr/cli/pkg/rundata"
 	"github.com/dapr/cli/utils"
@@ -10,7 +10,7 @@ import (
 
 // Uninstall deletes all installed containers
 func Uninstall(uninstallAll bool, dockerNetwork string) error {
-	var failedContainers []string
+	var errs []error
 
 	_, err := utils.RunCmdAndWait(
 		"docker", "rm",
@@ -18,7 +18,9 @@ func Uninstall(uninstallAll bool, dockerNetwork string) error {
 		utils.CreateContainerName(DaprPlacementContainerName, dockerNetwork))
 
 	if err != nil {
-		failedContainers = append(failedContainers, DaprPlacementContainerName)
+		errs = append(
+			errs,
+			fmt.Errorf("could not remove container %s container: %s", DaprPlacementContainerName, err))
 	}
 
 	_, err = utils.RunCmdAndWait(
@@ -27,7 +29,7 @@ func Uninstall(uninstallAll bool, dockerNetwork string) error {
 		daprDockerImageName)
 
 	if err != nil {
-		failedContainers = append(failedContainers, daprDockerImageName)
+		errs = append(errs, fmt.Errorf("could not remove container %s container: %s", daprDockerImageName, err))
 	}
 
 	if uninstallAll {
@@ -36,7 +38,7 @@ func Uninstall(uninstallAll bool, dockerNetwork string) error {
 			"--force",
 			utils.CreateContainerName(DaprRedisContainerName, dockerNetwork))
 		if err != nil {
-			failedContainers = append(failedContainers, DaprRedisContainerName)
+			errs = append(errs, fmt.Errorf("could not remove %s container: %s", DaprRedisContainerName, err))
 		}
 	}
 
@@ -45,9 +47,13 @@ func Uninstall(uninstallAll bool, dockerNetwork string) error {
 		fmt.Println("WARNING: could not delete run data file")
 	}
 
-	if len(failedContainers) == 0 {
+	if len(errs) == 0 {
 		return nil
 	}
 
-	return fmt.Errorf("could not delete (%s)", strings.Join(failedContainers, ","))
+	err = errors.New("uninstall failed")
+	for _, e := range errs {
+		err = fmt.Errorf("%w; %s", err, e)
+	}
+	return err
 }


### PR DESCRIPTION
# Description

This PR adds a more verbose log on the failure of container uninstall. 

The error message would look like this:
```
➜  dapr uninstall
ℹ️  Removing Dapr from your cluster...
WARNING: could not delete run data file
❌  Error removing Dapr: uninstall failed 
 could not remove dapr_placement container: Error: No such container: dapr_placement
 
 could not remove dapr_redis container: Error: No such container: dapr_redis
```

## Issue reference

This PR will close: https://github.com/dapr/cli/issues/330

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [ ] Created/updated tests
* [ ] Extended the documentation

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dapr/cli/333)
<!-- Reviewable:end -->
