### PR TITLE
Check if docker is running on uninstall

### DIFF
--- a/pkg/standalone/standalone.go
+++ b/pkg/standalone/standalone.go
@@ -9,7 +9,6 @@ import (
 	"archive/tar"
 	"archive/zip"
 	"compress/gzip"
-	"context"
 	"errors"
 	"fmt"
 	"io"
@@ -25,7 +24,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/docker/docker/client"
 	"github.com/fatih/color"
 
 	"github.com/briandowns/spinner"
@@ -108,7 +106,7 @@ func isInstallationRequired(installLocation, requestedVersion string) bool {
 
 // Init installs Dapr on a local machine using the supplied runtimeVersion.
 func Init(runtimeVersion string, dockerNetwork string, installLocation string) error {
-	dockerInstalled := isDockerInstalled()
+	dockerInstalled := utils.IsDockerInstalled()
 	if !dockerInstalled {
 		return errors.New("could not connect to Docker. Docker may not be installed or running")
 	}
@@ -166,15 +164,6 @@ func Init(runtimeVersion string, dockerNetwork string, installLocation string) e
 	}
 
 	return nil
-}
-
-func isDockerInstalled() bool {
-	cli, err := client.NewEnvClient()
-	if err != nil {
-		return false
-	}
-	_, err = cli.Ping(context.Background())
-	return err == nil
 }
 
 func getDaprDir() (string, error) {

--- a/pkg/standalone/uninstall.go
+++ b/pkg/standalone/uninstall.go
@@ -8,49 +8,53 @@ import (
 	"github.com/dapr/cli/utils"
 )
 
+func removeContainers(uninstallAll bool, dockerNetwork string) []error {
+	var containerErrs []error
+
+	_, err := utils.RunCmdAndWait(
+		"docker", "rm",
+		"--force",
+		utils.CreateContainerName(DaprPlacementContainerName, dockerNetwork))
+
+	if err != nil {
+		containerErrs = append(
+			containerErrs,
+			fmt.Errorf("could not remove %s container: %s", DaprPlacementContainerName, err))
+	}
+
+	_, err = utils.RunCmdAndWait(
+		"docker", "rmi",
+		"--force",
+		daprDockerImageName)
+
+	if err != nil {
+		containerErrs = append(
+			containerErrs,
+			fmt.Errorf("could not remove %s image: %s", daprDockerImageName, err))
+	}
+
+	if uninstallAll {
+		_, err = utils.RunCmdAndWait(
+			"docker", "rm",
+			"--force",
+			utils.CreateContainerName(DaprRedisContainerName, dockerNetwork))
+		if err != nil {
+			containerErrs = append(
+				containerErrs,
+				fmt.Errorf("could not remove %s container: %s", DaprRedisContainerName, err))
+		}
+	}
+
+	return containerErrs
+}
+
 // Uninstall deletes all installed containers
 func Uninstall(uninstallAll bool, dockerNetwork string) error {
 	var containerErrs []error
 
 	dockerInstalled := utils.IsDockerInstalled()
-	if !dockerInstalled {
-		containerErrs = append(
-			containerErrs,
-			fmt.Errorf("could not connect to Docker. Docker may not be installed or running"))
-	} else {
-		_, err := utils.RunCmdAndWait(
-			"docker", "rm",
-			"--force",
-			utils.CreateContainerName(DaprPlacementContainerName, dockerNetwork))
-
-		if err != nil {
-			containerErrs = append(
-				containerErrs,
-				fmt.Errorf("could not remove %s container: %s", DaprPlacementContainerName, err))
-		}
-
-		_, err = utils.RunCmdAndWait(
-			"docker", "rmi",
-			"--force",
-			daprDockerImageName)
-
-		if err != nil {
-			containerErrs = append(
-				containerErrs,
-				fmt.Errorf("could not remove %s container: %s", daprDockerImageName, err))
-		}
-
-		if uninstallAll {
-			_, err = utils.RunCmdAndWait(
-				"docker", "rm",
-				"--force",
-				utils.CreateContainerName(DaprRedisContainerName, dockerNetwork))
-			if err != nil {
-				containerErrs = append(
-					containerErrs,
-					fmt.Errorf("could not remove %s container: %s", DaprRedisContainerName, err))
-			}
-		}
+	if dockerInstalled {
+		containerErrs = removeContainers(uninstallAll, dockerNetwork)
 	}
 
 	err := rundata.DeleteRunDataFile()
@@ -58,11 +62,15 @@ func Uninstall(uninstallAll bool, dockerNetwork string) error {
 		fmt.Println("WARNING: could not delete run data file")
 	}
 
+	err = errors.New("uninstall failed")
+	if !dockerInstalled {
+		return fmt.Errorf("%w \n could not connect to Docker. Docker may not be installed or running", err)
+	}
+
 	if len(containerErrs) == 0 {
 		return nil
 	}
 
-	err = errors.New("uninstall failed")
 	for _, e := range containerErrs {
 		err = fmt.Errorf("%w \n %s", err, e)
 	}

--- a/pkg/standalone/uninstall.go
+++ b/pkg/standalone/uninstall.go
@@ -10,6 +10,11 @@ import (
 
 // Uninstall deletes all installed containers
 func Uninstall(uninstallAll bool, dockerNetwork string) error {
+	dockerInstalled := utils.IsDockerInstalled()
+	if !dockerInstalled {
+		return errors.New("could not connect to Docker. Docker may not be installed or running")
+	}
+
 	var errs []error
 
 	_, err := utils.RunCmdAndWait(

--- a/pkg/standalone/uninstall.go
+++ b/pkg/standalone/uninstall.go
@@ -10,52 +10,60 @@ import (
 
 // Uninstall deletes all installed containers
 func Uninstall(uninstallAll bool, dockerNetwork string) error {
+	var containerErrs []error
+
 	dockerInstalled := utils.IsDockerInstalled()
 	if !dockerInstalled {
-		return errors.New("could not connect to Docker. Docker may not be installed or running.")
-	}
-
-	var errs []error
-
-	_, err := utils.RunCmdAndWait(
-		"docker", "rm",
-		"--force",
-		utils.CreateContainerName(DaprPlacementContainerName, dockerNetwork))
-
-	if err != nil {
-		errs = append(errs, fmt.Errorf("could not remove %s container: %s", DaprPlacementContainerName, err))
-	}
-
-	_, err = utils.RunCmdAndWait(
-		"docker", "rmi",
-		"--force",
-		daprDockerImageName)
-
-	if err != nil {
-		errs = append(errs, fmt.Errorf("could not remove %s container: %s", daprDockerImageName, err))
-	}
-
-	if uninstallAll {
-		_, err = utils.RunCmdAndWait(
+		containerErrs = append(
+			containerErrs,
+			fmt.Errorf("could not connect to Docker. Docker may not be installed or running"))
+	} else {
+		_, err := utils.RunCmdAndWait(
 			"docker", "rm",
 			"--force",
-			utils.CreateContainerName(DaprRedisContainerName, dockerNetwork))
+			utils.CreateContainerName(DaprPlacementContainerName, dockerNetwork))
+
 		if err != nil {
-			errs = append(errs, fmt.Errorf("could not remove %s container: %s", DaprRedisContainerName, err))
+			containerErrs = append(
+				containerErrs,
+				fmt.Errorf("could not remove %s container: %s", DaprPlacementContainerName, err))
+		}
+
+		_, err = utils.RunCmdAndWait(
+			"docker", "rmi",
+			"--force",
+			daprDockerImageName)
+
+		if err != nil {
+			containerErrs = append(
+				containerErrs,
+				fmt.Errorf("could not remove %s container: %s", daprDockerImageName, err))
+		}
+
+		if uninstallAll {
+			_, err = utils.RunCmdAndWait(
+				"docker", "rm",
+				"--force",
+				utils.CreateContainerName(DaprRedisContainerName, dockerNetwork))
+			if err != nil {
+				containerErrs = append(
+					containerErrs,
+					fmt.Errorf("could not remove %s container: %s", DaprRedisContainerName, err))
+			}
 		}
 	}
 
-	err = rundata.DeleteRunDataFile()
+	err := rundata.DeleteRunDataFile()
 	if err != nil {
 		fmt.Println("WARNING: could not delete run data file")
 	}
 
-	if len(errs) == 0 {
+	if len(containerErrs) == 0 {
 		return nil
 	}
 
 	err = errors.New("uninstall failed")
-	for _, e := range errs {
+	for _, e := range containerErrs {
 		err = fmt.Errorf("%w \n %s", err, e)
 	}
 	return err

--- a/pkg/standalone/uninstall.go
+++ b/pkg/standalone/uninstall.go
@@ -12,7 +12,7 @@ import (
 func Uninstall(uninstallAll bool, dockerNetwork string) error {
 	dockerInstalled := utils.IsDockerInstalled()
 	if !dockerInstalled {
-		return errors.New("could not connect to Docker. Docker may not be installed or running")
+		return errors.New("could not connect to Docker. Docker may not be installed or running.")
 	}
 
 	var errs []error

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -109,6 +109,7 @@ func CreateDirectory(dir string) error {
 	return os.Mkdir(dir, 0777)
 }
 
+// IsDockerInstalled checks whether docker is installed/running
 func IsDockerInstalled() bool {
 	cli, err := client.NewEnvClient()
 	if err != nil {

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -7,6 +7,7 @@ package utils
 
 import (
 	"bufio"
+	"context"
 	"errors"
 	"fmt"
 	"io/ioutil"
@@ -14,6 +15,7 @@ import (
 	"os/exec"
 	"strings"
 
+	"github.com/docker/docker/client"
 	"github.com/olekukonko/tablewriter"
 )
 
@@ -105,4 +107,13 @@ func CreateDirectory(dir string) error {
 		return nil
 	}
 	return os.Mkdir(dir, 0777)
+}
+
+func IsDockerInstalled() bool {
+	cli, err := client.NewEnvClient()
+	if err != nil {
+		return false
+	}
+	_, err = cli.Ping(context.Background())
+	return err == nil
 }


### PR DESCRIPTION
# Description

This PR adds a check if docker is running while doing `dapr uninstall` similar to `dapr init`. 
If docker is not running, the error message would look like this: 
```
➜  dapr uninstall
ℹ️  Removing Dapr from your cluster...
WARNING: could not delete run data file
❌  Error removing Dapr: uninstall failed 
 could not connect to Docker. Docker may not be installed or running

```

If docker is running, the error message would look like this: 
```
➜  dapr uninstall
ℹ️  Removing Dapr from your cluster...
WARNING: could not delete run data file
❌  Error removing Dapr: uninstall failed 
 could not remove dapr_placement container: Error: No such container: dapr_placement
 
 could not remove dapr_redis container: Error: No such container: dapr_redis
```

## Issue reference

This PR will close: https://github.com/dapr/cli/issues/300


## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [ ] Extended the documentation

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dapr/cli/334)
<!-- Reviewable:end -->
