### PR TITLE
Download location is hardcoded while path to copy daprd to is not.  M…

### DIFF
--- a/pkg/standalone/standalone.go
+++ b/pkg/standalone/standalone.go
@@ -59,7 +59,9 @@ func isInstallationRequired(installLocation, requestedVersion string) bool {
 			destDir = daprDefaultLinuxAndMacInstallPath
 		}
 	}
-	daprdBinaryPath := path_filepath.Join(destDir, daprRuntimeFilePrefix) //e.g. /usr/local/bin/daprd or c:\\daprd
+
+	// e.g. /usr/local/bin/daprd or c:\dapr, which are the defaults unless overridden by "installLocation"
+	daprdBinaryPath := path_filepath.Join(destDir, daprRuntimeFilePrefix)
 
 	// first time install?
 	_, err := os.Stat(daprdBinaryPath)

--- a/pkg/standalone/standalone.go
+++ b/pkg/standalone/standalone.go
@@ -166,15 +166,6 @@ func Init(runtimeVersion string, dockerNetwork string, installLocation string) e
 	return nil
 }
 
-func isDockerInstalled() bool {
-	cli, err := client.NewEnvClient()
-	if err != nil {
-		return false
-	}
-	_, err = cli.Ping(context.Background())
-	return err == nil
-}
-
 func getDownloadDest(installLocation string) (string, error) {
 	p := ""
 


### PR DESCRIPTION
# Description

Download location is hardcoded while path to copy daprd to is not.  Make them the same and configurable thru --install-path.

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #335

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Created/updated tests
* [ ] Extended the documentation
