### PR TITLE
Implementing #344

### DIFF
--- a/cmd/run.go
+++ b/cmd/run.go
@@ -34,7 +34,7 @@ var enableProfiling bool
 var logLevel string
 var protocol string
 var componentsPath string
-var enableDevSecretStore bool
+var enableJSONSecretStore bool
 
 var RunCmd = &cobra.Command{
 	Use:   "run",
@@ -78,21 +78,21 @@ Run sidecar only:
 			print.InfoStatusEvent(os.Stdout, output.Message)
 		} else {
 			output, err := standalone.Run(&standalone.RunConfig{
-				AppID:                appID,
-				AppPort:              appPort,
-				HTTPPort:             port,
-				GRPCPort:             grpcPort,
-				ConfigFile:           configFile,
-				Arguments:            args,
-				EnableProfiling:      enableProfiling,
-				ProfilePort:          profilePort,
-				LogLevel:             logLevel,
-				MaxConcurrency:       maxConcurrency,
-				Protocol:             protocol,
-				RedisHost:            viper.GetString("redis-host"),
-				PlacementHost:        viper.GetString("placement-host"),
-				ComponentsPath:       componentsPath,
-				EnableDevSecretStore: enableDevSecretStore,
+				AppID:                 appID,
+				AppPort:               appPort,
+				HTTPPort:              port,
+				GRPCPort:              grpcPort,
+				ConfigFile:            configFile,
+				Arguments:             args,
+				EnableProfiling:       enableProfiling,
+				ProfilePort:           profilePort,
+				LogLevel:              logLevel,
+				MaxConcurrency:        maxConcurrency,
+				Protocol:              protocol,
+				RedisHost:             viper.GetString("redis-host"),
+				PlacementHost:         viper.GetString("placement-host"),
+				ComponentsPath:        componentsPath,
+				EnableJSONSecretStore: enableJSONSecretStore,
 			})
 			if err != nil {
 				print.FailureStatusEvent(os.Stdout, err.Error())
@@ -250,7 +250,7 @@ func init() {
 	RunCmd.Flags().StringVarP(&componentsPath, "components-path", "", "", "Path for components directory. Default is ./components.")
 	RunCmd.Flags().String("redis-host", "localhost", "the host on which the Redis service resides")
 	RunCmd.Flags().String("placement-host", "localhost", "the host on which the placement service resides")
-	RunCmd.Flags().BoolVar(&enableDevSecretStore, "enable-dev-secretstore", false, "Enable Developer Secret Store")
+	RunCmd.Flags().BoolVar(&enableJSONSecretStore, "enable-json-secretstore", false, "Enable JSON Secret Store")
 
 	RootCmd.AddCommand(RunCmd)
 }

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -34,6 +34,7 @@ var enableProfiling bool
 var logLevel string
 var protocol string
 var componentsPath string
+var enableDevSecretStore bool
 
 var RunCmd = &cobra.Command{
 	Use:   "run",
@@ -77,20 +78,21 @@ Run sidecar only:
 			print.InfoStatusEvent(os.Stdout, output.Message)
 		} else {
 			output, err := standalone.Run(&standalone.RunConfig{
-				AppID:           appID,
-				AppPort:         appPort,
-				HTTPPort:        port,
-				GRPCPort:        grpcPort,
-				ConfigFile:      configFile,
-				Arguments:       args,
-				EnableProfiling: enableProfiling,
-				ProfilePort:     profilePort,
-				LogLevel:        logLevel,
-				MaxConcurrency:  maxConcurrency,
-				Protocol:        protocol,
-				RedisHost:       viper.GetString("redis-host"),
-				PlacementHost:   viper.GetString("placement-host"),
-				ComponentsPath:  componentsPath,
+				AppID:                appID,
+				AppPort:              appPort,
+				HTTPPort:             port,
+				GRPCPort:             grpcPort,
+				ConfigFile:           configFile,
+				Arguments:            args,
+				EnableProfiling:      enableProfiling,
+				ProfilePort:          profilePort,
+				LogLevel:             logLevel,
+				MaxConcurrency:       maxConcurrency,
+				Protocol:             protocol,
+				RedisHost:            viper.GetString("redis-host"),
+				PlacementHost:        viper.GetString("placement-host"),
+				ComponentsPath:       componentsPath,
+				EnableDevSecretStore: enableDevSecretStore,
 			})
 			if err != nil {
 				print.FailureStatusEvent(os.Stdout, err.Error())
@@ -248,6 +250,7 @@ func init() {
 	RunCmd.Flags().StringVarP(&componentsPath, "components-path", "", "", "Path for components directory. Default is ./components.")
 	RunCmd.Flags().String("redis-host", "localhost", "the host on which the Redis service resides")
 	RunCmd.Flags().String("placement-host", "localhost", "the host on which the placement service resides")
+	RunCmd.Flags().BoolVar(&enableDevSecretStore, "enable-dev-secretstore", false, "Enable Developer Secret Store")
 
 	RootCmd.AddCommand(RunCmd)
 }

--- a/docs/reference/dapr-run.md
+++ b/docs/reference/dapr-run.md
@@ -29,4 +29,4 @@ dapr run [flags] [command]
 | `--profile-port` | | `-1` | The port for the profile server to listen on |
 | `--protocol` | | `http` | Tells Dapr to use HTTP or gRPC to talk to the app. Valid values are: `http` or `grpc` |
 | `--redis-host` | `DAPR_REDIS_HOST` | `localhost` | The host on which the Redis service resides |
-| `--enable-dev-secretstore` |  | false | Enable Developer Secret Store |
+| `--enable-json-secretstore` |  | false | Enable JSON Secret Store |

--- a/docs/reference/dapr-run.md
+++ b/docs/reference/dapr-run.md
@@ -29,3 +29,4 @@ dapr run [flags] [command]
 | `--profile-port` | | `-1` | The port for the profile server to listen on |
 | `--protocol` | | `http` | Tells Dapr to use HTTP or gRPC to talk to the app. Valid values are: `http` or `grpc` |
 | `--redis-host` | `DAPR_REDIS_HOST` | `localhost` | The host on which the Redis service resides |
+| `--enable-dev-secretstore` |  | false | Enable Developer Secret Store |

--- a/pkg/standalone/run.go
+++ b/pkg/standalone/run.go
@@ -33,20 +33,21 @@ const (
 
 // RunConfig represents the application configuration parameters.
 type RunConfig struct {
-	AppID           string
-	AppPort         int
-	HTTPPort        int
-	GRPCPort        int
-	ConfigFile      string
-	Protocol        string
-	Arguments       []string
-	EnableProfiling bool
-	ProfilePort     int
-	LogLevel        string
-	MaxConcurrency  int
-	RedisHost       string
-	PlacementHost   string
-	ComponentsPath  string
+	AppID                string
+	AppPort              int
+	HTTPPort             int
+	GRPCPort             int
+	ConfigFile           string
+	Protocol             string
+	Arguments            []string
+	EnableProfiling      bool
+	ProfilePort          int
+	LogLevel             string
+	MaxConcurrency       int
+	RedisHost            string
+	PlacementHost        string
+	ComponentsPath       string
+	EnableDevSecretStore bool
 }
 
 // RunOutput represents the run output.
@@ -330,6 +331,10 @@ func Run(config *RunConfig) (*RunOutput, error) {
 		if err != nil {
 			return nil, err
 		}
+	}
+
+	if config.EnableDevSecretStore {
+		os.Setenv("DAPR_ENABLE_JSON_SECRET_STORE", "1")
 	}
 
 	daprCMD, daprHTTPPort, daprGRPCPort, metricsPort, err := getDaprCommand(appID, config.HTTPPort, config.GRPCPort, config.AppPort, config.ConfigFile, config.Protocol, config.EnableProfiling, config.ProfilePort, config.LogLevel, config.MaxConcurrency, config.PlacementHost)

--- a/pkg/standalone/run.go
+++ b/pkg/standalone/run.go
@@ -33,21 +33,21 @@ const (
 
 // RunConfig represents the application configuration parameters.
 type RunConfig struct {
-	AppID                string
-	AppPort              int
-	HTTPPort             int
-	GRPCPort             int
-	ConfigFile           string
-	Protocol             string
-	Arguments            []string
-	EnableProfiling      bool
-	ProfilePort          int
-	LogLevel             string
-	MaxConcurrency       int
-	RedisHost            string
-	PlacementHost        string
-	ComponentsPath       string
-	EnableDevSecretStore bool
+	AppID                 string
+	AppPort               int
+	HTTPPort              int
+	GRPCPort              int
+	ConfigFile            string
+	Protocol              string
+	Arguments             []string
+	EnableProfiling       bool
+	ProfilePort           int
+	LogLevel              string
+	MaxConcurrency        int
+	RedisHost             string
+	PlacementHost         string
+	ComponentsPath        string
+	EnableJSONSecretStore bool
 }
 
 // RunOutput represents the run output.
@@ -333,7 +333,7 @@ func Run(config *RunConfig) (*RunOutput, error) {
 		}
 	}
 
-	if config.EnableDevSecretStore {
+	if config.EnableJSONSecretStore {
 		os.Setenv("DAPR_ENABLE_JSON_SECRET_STORE", "1")
 	}
 

--- a/pkg/standalone/run_test.go
+++ b/pkg/standalone/run_test.go
@@ -111,20 +111,20 @@ func TestRun(t *testing.T) {
 		assert.Nil(t, output.AppCMD)
 	})
 
-	t.Run("run enabling dev secret store", func(t *testing.T) {
+	t.Run("run enabling json secret store", func(t *testing.T) {
 		output, err := Run(&RunConfig{
-			AppID:                "MyID",
-			AppPort:              3000,
-			HTTPPort:             8000,
-			GRPCPort:             50001,
-			LogLevel:             "WARN",
-			Arguments:            []string{"MyCommand", "--my-arg"},
-			EnableProfiling:      false,
-			ProfilePort:          9090,
-			Protocol:             "http",
-			RedisHost:            "localhost",
-			PlacementHost:        "localhost",
-			EnableDevSecretStore: true,
+			AppID:                 "MyID",
+			AppPort:               3000,
+			HTTPPort:              8000,
+			GRPCPort:              50001,
+			LogLevel:              "WARN",
+			Arguments:             []string{"MyCommand", "--my-arg"},
+			EnableProfiling:       false,
+			ProfilePort:           9090,
+			Protocol:              "http",
+			RedisHost:             "localhost",
+			PlacementHost:         "localhost",
+			EnableJSONSecretStore: true,
 		})
 
 		assert.Nil(t, err)

--- a/pkg/standalone/run_test.go
+++ b/pkg/standalone/run_test.go
@@ -6,6 +6,7 @@
 package standalone
 
 import (
+	"os"
 	"runtime"
 	"strings"
 	"testing"
@@ -108,5 +109,48 @@ func TestRun(t *testing.T) {
 		}
 
 		assert.Nil(t, output.AppCMD)
+	})
+
+	t.Run("run enabling dev secret store", func(t *testing.T) {
+		output, err := Run(&RunConfig{
+			AppID:                "MyID",
+			AppPort:              3000,
+			HTTPPort:             8000,
+			GRPCPort:             50001,
+			LogLevel:             "WARN",
+			Arguments:            []string{"MyCommand", "--my-arg"},
+			EnableProfiling:      false,
+			ProfilePort:          9090,
+			Protocol:             "http",
+			RedisHost:            "localhost",
+			PlacementHost:        "localhost",
+			EnableDevSecretStore: true,
+		})
+
+		assert.Nil(t, err)
+		assert.NotNil(t, output)
+
+		assert.Equal(t, "MyID", output.AppID)
+		assert.Equal(t, 8000, output.DaprHTTPPort)
+		assert.Equal(t, 50001, output.DaprGRPCPort)
+
+		assert.Contains(t, output.DaprCMD.Args[0], "daprd")
+		assertArgument(t, "app-id", "MyID", output.DaprCMD.Args)
+		assertArgument(t, "dapr-http-port", "8000", output.DaprCMD.Args)
+		assertArgument(t, "dapr-grpc-port", "50001", output.DaprCMD.Args)
+		assertArgument(t, "log-level", "WARN", output.DaprCMD.Args)
+		assertArgument(t, "max-concurrency", "-1", output.DaprCMD.Args)
+		assertArgument(t, "protocol", "http", output.DaprCMD.Args)
+		assertArgument(t, "app-port", "3000", output.DaprCMD.Args)
+		assertArgument(t, "components-path", "", output.DaprCMD.Args)
+		if runtime.GOOS == "windows" {
+			assertArgument(t, "placement-address", "localhost:6050", output.DaprCMD.Args)
+		} else {
+			assertArgument(t, "placement-address", "localhost:50005", output.DaprCMD.Args)
+		}
+
+		assert.Equal(t, "MyCommand", output.AppCMD.Args[0])
+		assert.Equal(t, "--my-arg", output.AppCMD.Args[1])
+		assert.Equal(t, "1", os.Getenv("DAPR_ENABLE_JSON_SECRET_STORE"))
 	})
 }


### PR DESCRIPTION
# Description

Now it´s possible to run `dapr run` with the following flag: `--enable-dev-secretstore` which will enable the new json secret store: https://github.com/dapr/components-contrib/pull/328

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #344

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Created/updated tests
* [x] Extended the documentation
