### PR TITLE
Enable Dapr to stop multiple apps

### DIFF
--- a/README.md
+++ b/README.md
@@ -289,9 +289,12 @@ Use ```dapr list``` to get a list of all running instances.
 To stop a Dapr app on your machine:
 
 ```
-$ dapr stop --app-id myAppID
+$ dapr stop myAppID
 ```
-
+You can also stop multiple Dapr apps
+```
+$ dapr stop myAppID1 myAppID2
+```
 ### Enable profiling
 
 In order to enable profiling, use the `enable-profiling` flag:

--- a/cmd/stop.go
+++ b/cmd/stop.go
@@ -17,7 +17,7 @@ var stopAppID string
 
 var StopCmd = &cobra.Command{
 	Use:   "stop",
-	Short: "Stops a running Dapr instance and its associated app",
+	Short: "Stops multiple running Dapr instances and their associated apps",
 	Run: func(cmd *cobra.Command, args []string) {
 		if stopAppID != "" {
 			args = append(args, stopAppID)

--- a/cmd/stop.go
+++ b/cmd/stop.go
@@ -19,11 +19,16 @@ var StopCmd = &cobra.Command{
 	Use:   "stop",
 	Short: "Stops a running Dapr instance and its associated app",
 	Run: func(cmd *cobra.Command, args []string) {
-		err := standalone.Stop(stopAppID)
-		if err != nil {
-			print.FailureStatusEvent(os.Stdout, "failed to stop app id %s: %s", stopAppID, err)
-		} else {
-			print.SuccessStatusEvent(os.Stdout, "app stopped successfully")
+		if stopAppID != "" {
+			args = append(args, stopAppID)
+		}
+		for _, appID := range args {
+			err := standalone.Stop(appID)
+			if err != nil {
+				print.FailureStatusEvent(os.Stdout, "failed to stop app id %s: %s", appID, err)
+			} else {
+				print.SuccessStatusEvent(os.Stdout, "app stopped successfully: %s", appID)
+			}
 		}
 	},
 }

--- a/docs/reference/dapr-stop.md
+++ b/docs/reference/dapr-stop.md
@@ -2,12 +2,12 @@
 
 ## Description
 
-Stops a running Dapr instance and its associated app
+Stops running Dapr instances and their associated apps
 
 ## Usage
 
 ```bash
-dapr stop [flags]
+dapr stop <appID1> <appID2> [flags]
 ```
 
 ## Flags


### PR DESCRIPTION
# Description

I added the functionality of stopping multiple apps using `dapr stop`.
```
dapr stop pythonapp nodeapp blahblah

✅  app stopped successfully: pythonapp

✅  app stopped successfully: nodeapp

❌  failed to stop app id : couldn't find app id blahblah
```
This also works.
```
dapr stop pythonapp --app-id blahblah

✅  app stopped successfully: pythonapp

❌  failed to stop app id : couldn't find app id blahblah
```


## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #247 

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

I may need some advice on what tests and documentation to write for this functionality.

* [X] Code compiles correctly
* [ ] Created/updated tests
* [X] Extended the documentation
