### PR TITLE
Setx truncates path. Use a powershell command instead

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ The Dapr CLI allows you to setup Dapr on your local dev machine or on a Kubernet
 
 **Windows**
 
-Install the latest windows Dapr CLI to `c:\dapr` and add this directory to User PATH environment variable.
+Install the latest windows Dapr CLI to `c:\dapr` and add this directory to User PATH environment variable. Use `-DaprRoot [path]` to change the default installation directory
 
 ```powershell
 powershell -Command "iwr -useb https://raw.githubusercontent.com/dapr/cli/master/install/install.ps1 | iex"

--- a/pkg/standalone/standalone.go
+++ b/pkg/standalone/standalone.go
@@ -59,7 +59,9 @@ func isInstallationRequired(installLocation, requestedVersion string) bool {
 			destDir = daprDefaultLinuxAndMacInstallPath
 		}
 	}
-	daprdBinaryPath := path_filepath.Join(destDir, daprRuntimeFilePrefix) //e.g. /usr/local/bin/daprd or c:\\daprd
+
+	// e.g. /usr/local/bin/daprd or c:\dapr, which are the defaults unless overridden by "installLocation"
+	daprdBinaryPath := path_filepath.Join(destDir, daprRuntimeFilePrefix)
 
 	// first time install?
 	_, err := os.Stat(daprdBinaryPath)
@@ -111,7 +113,7 @@ func Init(runtimeVersion string, dockerNetwork string, installLocation string) e
 		return errors.New("could not connect to Docker. Docker may not be installed or running")
 	}
 
-	dir, err := getDaprDir()
+	downloadDest, err := getDownloadDest(installLocation)
 	if err != nil {
 		return err
 	}
@@ -137,7 +139,7 @@ func Init(runtimeVersion string, dockerNetwork string, installLocation string) e
 	}
 
 	for _, step := range initSteps {
-		go step(&wg, errorChan, dir, runtimeVersion, dockerNetwork, installLocation)
+		go step(&wg, errorChan, downloadDest, runtimeVersion, dockerNetwork, installLocation)
 	}
 
 	go func() {
@@ -166,11 +168,17 @@ func Init(runtimeVersion string, dockerNetwork string, installLocation string) e
 	return nil
 }
 
-func getDaprDir() (string, error) {
+func getDownloadDest(installLocation string) (string, error) {
 	p := ""
 
+	// use the install location passed in for Windows.  This can't
+	// be done for other environments because the install location default to a privileged dir: /usr/local/bin
 	if runtime.GOOS == daprWindowsOS {
-		p = path_filepath.FromSlash("c:/dapr")
+		if installLocation == "" {
+			p = daprDefaultWindowsInstallPath
+		} else {
+			p = installLocation
+		}
 	} else {
 		usr, err := user.Current()
 		if err != nil {


### PR DESCRIPTION
# Description

Old code uses "setx" to set the dapr path. However, setx has a limitation of 1024 characters due to which the path is truncated after running dapr init. This PR adds code to use a powershell command which bypasses the 1024 character limitation

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #286 

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [* ] Code compiles correctly
* [ ] Created/updated tests
* [ ] Extended the documentation
