### PR TITLE
Added command completion feature to Dapr CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -340,6 +340,16 @@ You can run Dapr's sidecar only (`daprd`) by omitting the application's command 
 $ dapr run --app-id myapp --port 3005 --grpc-port 50001
 ```
 
+### Generate shell completion scripts
+
+To generate shell completion scripts:
+
+```
+$ dapr completion
+```
+
+For more details, please run the command and check the examples to apply to your shell.
+
 ## Reference for the Dapr CLI
 
 See the [Reference Guide](docs/reference/reference.md) for more information about individual Dapr commands.

--- a/cmd/completion.go
+++ b/cmd/completion.go
@@ -1,0 +1,92 @@
+package cmd
+
+import (
+	"os"
+
+	"github.com/spf13/cobra"
+)
+
+var completionExample = `
+	# Installing bash completion on macOS using homebrew
+	## If running Bash 3.2 included with macOS
+	brew install bash-completion
+	## or, if running Bash 4.1+
+	brew install bash-completion@2
+	## Add the completion to your completion directory
+	dapr completion bash > $(brew --prefix)/etc/bash_completion.d/dapr
+	source ~/.bash_profile
+
+	# Installing bash completion on Linux
+	## If bash-completion is not installed on Linux, please install the 'bash-completion' package
+	## via your distribution's package manager.
+	## Load the dapr completion code for bash into the current shell
+	source <(dapr completion bash)
+	## Write bash completion code to a file and source if from .bash_profile
+	dapr completion bash > ~/.dapr/completion.bash.inc
+	printf "
+	## dapr shell completion
+	source '$HOME/.dapr/completion.bash.inc'
+	" >> $HOME/.bash_profile
+	source $HOME/.bash_profile
+
+	# Installing zsh completion on macOS using homebrew
+	## If zsh-completion is not installed on macOS, please install the 'zsh-completion' package
+	brew install zsh-completions
+	## Set the dapr completion code for zsh[1] to autoload on startup
+	dapr completion zsh > "${fpath[1]}/_dapr"
+	source ~/.zshrc
+
+	# Installing zsh completion on Linux
+	## If zsh-completion is not installed on Linux, please install the 'zsh-completion' package
+	## via your distribution's package manager.
+	## Load the dapr completion code for zsh into the current shell
+	source <(dapr completion zsh)
+	# Set the dapr completion code for zsh[1] to autoload on startup
+  	dapr completion zsh > "${fpath[1]}/_dapr"
+`
+
+func newCompletionCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "completion",
+		Short:   "Generates shell completion scripts",
+		Example: completionExample,
+		Run: func(cmd *cobra.Command, args []string) {
+			cmd.Help()
+		},
+	}
+
+	cmd.AddCommand(
+		newCompletionBashCmd(),
+		newCompletionZshCmd(),
+	)
+
+	return cmd
+}
+
+func newCompletionBashCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "bash",
+		Short: "Generates bash completion scripts",
+		Run: func(cmd *cobra.Command, args []string) {
+			RootCmd.GenBashCompletion(os.Stdout)
+		},
+	}
+
+	return cmd
+}
+
+func newCompletionZshCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "zsh",
+		Short: "Generates zsh completion scripts",
+		Run: func(cmd *cobra.Command, args []string) {
+			RootCmd.GenZshCompletion(os.Stdout)
+		},
+	}
+
+	return cmd
+}
+
+func init() {
+	RootCmd.AddCommand(newCompletionCmd())
+}

--- a/cmd/completion.go
+++ b/cmd/completion.go
@@ -1,3 +1,8 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+// ------------------------------------------------------------
+
 package cmd
 
 import (

--- a/cmd/completion.go
+++ b/cmd/completion.go
@@ -43,6 +43,12 @@ var completionExample = `
 	source <(dapr completion zsh)
 	# Set the dapr completion code for zsh[1] to autoload on startup
   	dapr completion zsh > "${fpath[1]}/_dapr"
+
+	# Installing powershell completion on Windows
+	## Create $PROFILE if it not exists
+	if (!(Test-Path -Path $PROFILE )){ New-Item -Type File -Path $PROFILE -Force }
+	## Add the completion to your profile
+	dapr completion powershell >> $PROFILE
 `
 
 func newCompletionCmd() *cobra.Command {
@@ -58,6 +64,7 @@ func newCompletionCmd() *cobra.Command {
 	cmd.AddCommand(
 		newCompletionBashCmd(),
 		newCompletionZshCmd(),
+		newCompletionPowerShellCmd(),
 	)
 
 	return cmd
@@ -81,6 +88,18 @@ func newCompletionZshCmd() *cobra.Command {
 		Short: "Generates zsh completion scripts",
 		Run: func(cmd *cobra.Command, args []string) {
 			RootCmd.GenZshCompletion(os.Stdout)
+		},
+	}
+
+	return cmd
+}
+
+func newCompletionPowerShellCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "powershell",
+		Short: "Generates powershell completion scripts",
+		Run: func(cmd *cobra.Command, args []string) {
+			RootCmd.GenPowerShellCompletion(os.Stdout)
 		},
 	}
 


### PR DESCRIPTION
# Description

For #197, added a feature to support "auto-completion" for Dapr CLI using the Tab key. In addition to that, updated the README.md to introduce the subcommand `dapr completion`.

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #197 

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [ ] Created/updated tests
* [x] Extended the documentation

I didn't come up with an idea to make this test code, so I checked the [kubectl repo](https://github.com/kubernetes/kubectl/tree/master/pkg/cmd/completion), but it looks that it doesn't test for the completion part.
