### PR TITLE
Add Zipkin on dapr init. Add tracing config, zipkin component on init.

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,12 @@ $ dapr init
 ✅  Success! Dapr is up and running
 ```
 
-> Note: To see that Dapr has been installed successfully, from a command prompt run the `docker ps` command and check that the `daprio/dapr:latest`,  `dapr_redis` and `dapr_zipkin` container images are all running. Also, this step creates a default components folder which is later used at runtime unless the --components-path option is provided. For Linux/MacOS, the default components folder path is $HOME/.dapr/components and for Windows it is %USERPROFILE%\.dapr\components. This step also create default components files in the components folder called pubsub.yaml, statestore.yaml and zipkin.yaml. This step also creates a default config folder at $HOME/.dapr/config for Linux/MacOS or for Windows at %USERPROFILE%\.dapr\config. The config folder contains a default.yaml configuration file to enable tracing on `dapr init` call.
+> Note: To see that Dapr has been installed successfully, from a command prompt run the `docker ps` command and check that the `daprio/dapr:latest`,  `dapr_redis` and `dapr_zipkin` container images are all running.
+
+This step creates the following defaults:
+1. components folder which is later used at runtime unless the --components-path option is provided. For Linux/MacOS, the default components folder path is $HOME/.dapr/components and for Windows it is %USERPROFILE%\.dapr\components.
+2. component files in the components folder called pubsub.yaml, statestore.yaml and zipkin.yaml. 
+3. default config file $HOME/.dapr/config.yaml for Linux/MacOS or for Windows at %USERPROFILE%\.dapr\config.yaml to enable tracing on `dapr init` call. Can be overridden with the `--config` flag on `dapr run`.
 
 #### Install a specific runtime version
 
@@ -107,7 +112,7 @@ $ dapr uninstall
 ```
 
 
-The command above won't remove the redis container by default in case you were using it for other purposes.  To remove both the placement and redis container:
+The command above won't remove the redis or zipkin containers by default in case you were using it for other purposes.  It will also not remove the default dapr folder that was created on `dapr init`. To remove all the containers (placement, redis, zipkin) and also the default dapr folder created on init run:
 
 ```bash
 $ dapr uninstall --all

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ $ dapr init
 ✅  Success! Dapr is up and running
 ```
 
-> Note: To see that Dapr has been installed successfully, from a command prompt run the `docker ps` command and check that the `daprio/dapr:latest` and `redis` container images are both running. Also, this step creates a default components folder which is later used at runtime unless the --components-path option is provided. For Linux/MacOS, the default components folder path is $HOME/.dapr/components and for Windows it is %USERPROFILE%\.dapr\components.
+> Note: To see that Dapr has been installed successfully, from a command prompt run the `docker ps` command and check that the `daprio/dapr:latest`,  `dapr_redis` and `dapr_zipkin` container images are all running. Also, this step creates a default components folder which is later used at runtime unless the --components-path option is provided. For Linux/MacOS, the default components folder path is $HOME/.dapr/components and for Windows it is %USERPROFILE%\.dapr\components. This step also create default components files in the components folder called pubsub.yaml, statestore.yaml and zipkin.yaml. This step also creates a default config folder at $HOME/.dapr/config for Linux/MacOS or for Windows at %USERPROFILE%\.dapr\config. The config folder contains a default.yaml configuration file to enable tracing on `dapr init` call.
 
 #### Install a specific runtime version
 

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -245,7 +245,7 @@ func init() {
 	RunCmd.Flags().StringVarP(&logLevel, "log-level", "", "info", "Sets the log verbosity. Valid values are: debug, info, warn, error, fatal, or panic. Default is info")
 	RunCmd.Flags().IntVarP(&maxConcurrency, "max-concurrency", "", -1, "controls the concurrency level of the app. Default is unlimited")
 	RunCmd.Flags().StringVarP(&protocol, "protocol", "", "http", "tells Dapr to use HTTP or gRPC to talk to the app. Default is http")
-	RunCmd.Flags().StringVarP(&componentsPath, "components-path", "", standalone.GetDefaultComponentsFolder(), "Path for components directory. Default is ~/.dapr/components or %USERPROFILE%\\.dapr\\components")
+	RunCmd.Flags().StringVarP(&componentsPath, "components-path", "", standalone.GetDefaultFolderPath(standalone.DefaultComponentsDirName), "Path for components directory. Default is ~/.dapr/components or %USERPROFILE%\\.dapr\\components")
 	RunCmd.Flags().String("redis-host", "localhost", "the host on which the Redis service resides")
 	RunCmd.Flags().String("placement-host", "localhost", "the host on which the placement service resides")
 

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -234,7 +234,7 @@ Run sidecar only:
 func init() {
 	RunCmd.Flags().IntVarP(&appPort, "app-port", "", -1, "the port your application is listening on")
 	RunCmd.Flags().StringVarP(&appID, "app-id", "", "", "an id for your application, used for service discovery")
-	RunCmd.Flags().StringVarP(&configFile, "config", "", standalone.GetDefaultConfigFilePath(), "Dapr configuration file. Default is ~/.dapr/config/default.yaml or %USERPROFILE%\\.dapr\\config\\default.yaml")
+	RunCmd.Flags().StringVarP(&configFile, "config", "", standalone.DefaultConfigFilePath(), "Dapr configuration file. Default is ~/.dapr/config.yaml or %USERPROFILE%\\.dapr\\config.yaml")
 	RunCmd.Flags().IntVarP(&port, "port", "p", -1, "the HTTP port for Dapr to listen on")
 	RunCmd.Flags().IntVarP(&grpcPort, "grpc-port", "", -1, "the gRPC port for Dapr to listen on")
 	RunCmd.Flags().StringVarP(&image, "image", "", "", "the image to build the code in. input is repository/image")
@@ -243,7 +243,7 @@ func init() {
 	RunCmd.Flags().StringVarP(&logLevel, "log-level", "", "info", "Sets the log verbosity. Valid values are: debug, info, warn, error, fatal, or panic. Default is info")
 	RunCmd.Flags().IntVarP(&maxConcurrency, "max-concurrency", "", -1, "controls the concurrency level of the app. Default is unlimited")
 	RunCmd.Flags().StringVarP(&protocol, "protocol", "", "http", "tells Dapr to use HTTP or gRPC to talk to the app. Default is http")
-	RunCmd.Flags().StringVarP(&componentsPath, "components-path", "", standalone.GetDefaultFolderPath(standalone.DefaultComponentsDirName), "Path for components directory. Default is ~/.dapr/components or %USERPROFILE%\\.dapr\\components")
+	RunCmd.Flags().StringVarP(&componentsPath, "components-path", "", standalone.DefaultFolderPath(standalone.DefaultComponentsDirName), "Path for components directory. Default is ~/.dapr/components or %USERPROFILE%\\.dapr\\components")
 	RunCmd.Flags().String("placement-host", "localhost", "the host on which the placement service resides")
 
 	RootCmd.AddCommand(RunCmd)

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -234,7 +234,7 @@ Run sidecar only:
 func init() {
 	RunCmd.Flags().IntVarP(&appPort, "app-port", "", -1, "the port your application is listening on")
 	RunCmd.Flags().StringVarP(&appID, "app-id", "", "", "an id for your application, used for service discovery")
-	RunCmd.Flags().StringVarP(&configFile, "config", "", standalone.DefaultConfigFilePath(), "Dapr configuration file. Default is ~/.dapr/config.yaml or %USERPROFILE%\\.dapr\\config.yaml")
+	RunCmd.Flags().StringVarP(&configFile, "config", "", standalone.DefaultConfigFilePath(), "Dapr configuration file. Default is $HOME/.dapr/config.yaml or %USERPROFILE%\\.dapr\\config.yaml")
 	RunCmd.Flags().IntVarP(&port, "port", "p", -1, "the HTTP port for Dapr to listen on")
 	RunCmd.Flags().IntVarP(&grpcPort, "grpc-port", "", -1, "the gRPC port for Dapr to listen on")
 	RunCmd.Flags().StringVarP(&image, "image", "", "", "the image to build the code in. input is repository/image")
@@ -243,7 +243,7 @@ func init() {
 	RunCmd.Flags().StringVarP(&logLevel, "log-level", "", "info", "Sets the log verbosity. Valid values are: debug, info, warn, error, fatal, or panic. Default is info")
 	RunCmd.Flags().IntVarP(&maxConcurrency, "max-concurrency", "", -1, "controls the concurrency level of the app. Default is unlimited")
 	RunCmd.Flags().StringVarP(&protocol, "protocol", "", "http", "tells Dapr to use HTTP or gRPC to talk to the app. Default is http")
-	RunCmd.Flags().StringVarP(&componentsPath, "components-path", "", standalone.DefaultFolderPath(standalone.DefaultComponentsDirName), "Path for components directory. Default is ~/.dapr/components or %USERPROFILE%\\.dapr\\components")
+	RunCmd.Flags().StringVarP(&componentsPath, "components-path", "", standalone.DefaultComponentsDirPath(), "Path for components directory. Default is $HOME/.dapr/components or %USERPROFILE%\\.dapr\\components")
 	RunCmd.Flags().String("placement-host", "localhost", "the host on which the placement service resides")
 
 	RootCmd.AddCommand(RunCmd)

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -234,7 +234,7 @@ Run sidecar only:
 func init() {
 	RunCmd.Flags().IntVarP(&appPort, "app-port", "", -1, "the port your application is listening on")
 	RunCmd.Flags().StringVarP(&appID, "app-id", "", "", "an id for your application, used for service discovery")
-	RunCmd.Flags().StringVarP(&configFile, "config", "", "", "Dapr configuration file")
+	RunCmd.Flags().StringVarP(&configFile, "config", "", standalone.GetDefaultConfigFilePath(), "Dapr configuration file. Default is ~/.dapr/config/default.yaml or %USERPROFILE%\\.dapr\\config\\default.yaml")
 	RunCmd.Flags().IntVarP(&port, "port", "p", -1, "the HTTP port for Dapr to listen on")
 	RunCmd.Flags().IntVarP(&grpcPort, "grpc-port", "", -1, "the gRPC port for Dapr to listen on")
 	RunCmd.Flags().StringVarP(&image, "image", "", "", "the image to build the code in. input is repository/image")

--- a/docs/reference/dapr-run.md
+++ b/docs/reference/dapr-run.md
@@ -16,8 +16,8 @@ dapr run [flags] [command]
 | --- | --- | --- | --- |
 | `--app-id` | | | An ID for your application, used for service discovery |
 | `--app-port` | | `-1` | The port your application is listening on |
-| `--components-path` | | `~/.dapr/components or %USERPROFILE%\.dapr\components` | Path for components directory |
-| `--config` | | `~/.dapr/config.yaml or %USERPROFILE%\.dapr\config.yaml` | Dapr configuration file |
+| `--components-path` | | `$HOME/.dapr/components or %USERPROFILE%\.dapr\components` | Path for components directory |
+| `--config` | | `$HOME/.dapr/config.yaml or %USERPROFILE%\.dapr\config.yaml` | Dapr configuration file |
 | `--enable-profiling` | | | Enable `pprof` profiling via an HTTP endpoint |
 | `--grpc-port` | | `-1` | The gRPC port for Dapr to listen on |
 | `--help`, `-h` | | | Help for run |

--- a/docs/reference/dapr-run.md
+++ b/docs/reference/dapr-run.md
@@ -16,8 +16,8 @@ dapr run [flags] [command]
 | --- | --- | --- | --- |
 | `--app-id` | | | An ID for your application, used for service discovery |
 | `--app-port` | | `-1` | The port your application is listening on |
-| `--components-path` | | `./components` | Path for components directory |
-| `--config` | | | Dapr configuration file |
+| `--components-path` | | `~/.dapr/components or %USERPROFILE%\.dapr\components` | Path for components directory |
+| `--config` | | `~/.dapr/config/default.yaml or %USERPROFILE%\.dapr\config\default.yaml` | Dapr configuration file |
 | `--enable-profiling` | | | Enable `pprof` profiling via an HTTP endpoint |
 | `--grpc-port` | | `-1` | The gRPC port for Dapr to listen on |
 | `--help`, `-h` | | | Help for run |

--- a/docs/reference/dapr-run.md
+++ b/docs/reference/dapr-run.md
@@ -17,7 +17,7 @@ dapr run [flags] [command]
 | `--app-id` | | | An ID for your application, used for service discovery |
 | `--app-port` | | `-1` | The port your application is listening on |
 | `--components-path` | | `~/.dapr/components or %USERPROFILE%\.dapr\components` | Path for components directory |
-| `--config` | | `~/.dapr/config/default.yaml or %USERPROFILE%\.dapr\config\default.yaml` | Dapr configuration file |
+| `--config` | | `~/.dapr/config.yaml or %USERPROFILE%\.dapr\config.yaml` | Dapr configuration file |
 | `--enable-profiling` | | | Enable `pprof` profiling via an HTTP endpoint |
 | `--grpc-port` | | `-1` | The gRPC port for Dapr to listen on |
 | `--help`, `-h` | | | Help for run |

--- a/docs/reference/dapr-uninstall.md
+++ b/docs/reference/dapr-uninstall.md
@@ -14,7 +14,7 @@ dapr uninstall [flags]
 
 | Name | Environment Variable | Default | Description
 | --- | --- | --- | --- |
-| `--all` | | `false` | Remove Redis, Zipkin containers in addition to actor placement container. Remove default dapr dir located at `~/.dapr or %USERPROFILE%\.dapr\`. |
+| `--all` | | `false` | Remove Redis, Zipkin containers in addition to actor placement container. Remove default dapr dir located at `$HOME/.dapr or %USERPROFILE%\.dapr\`. |
 | `--help`, `-h` | | | Help for uninstall |
 | `--kubernetes` | | `false` | Uninstall Dapr from a Kubernetes cluster |
 | `--network` | `DAPR_NETWORK` | | The Docker network from which to remove the Dapr runtime |

--- a/docs/reference/dapr-uninstall.md
+++ b/docs/reference/dapr-uninstall.md
@@ -14,7 +14,7 @@ dapr uninstall [flags]
 
 | Name | Environment Variable | Default | Description
 | --- | --- | --- | --- |
-| `--all` | | `false` | Remove Redis container in addition to actor placement container |
+| `--all` | | `false` | Remove Redis, Zipkin containers in addition to actor placement container. Remove default dapr dir located at `~/.dapr or %USERPROFILE%\.dapr\`. |
 | `--help`, `-h` | | | Help for uninstall |
 | `--kubernetes` | | `false` | Uninstall Dapr from a Kubernetes cluster |
 | `--network` | `DAPR_NETWORK` | | The Docker network from which to remove the Dapr runtime |

--- a/pkg/standalone/common.go
+++ b/pkg/standalone/common.go
@@ -6,15 +6,25 @@ import (
 	"runtime"
 )
 
-// getDefaultComponentsFolder returns the hidden .components folder created at init time
-func GetDefaultComponentsFolder() string {
-	const daprDirName = ".dapr"
-	const componentsDirName = "components"
-	daprDirPath := os.Getenv("HOME")
-	if runtime.GOOS == daprWindowsOS {
-		daprDirPath = os.Getenv("USERPROFILE")
-	}
+const (
+	defaultDaprDirName       = ".dapr"
+	DefaultComponentsDirName = "components"
+	defaultConfigDirName     = "config"
+)
 
-	defaultComponentsPath := path_filepath.Join(daprDirPath, daprDirName, componentsDirName)
-	return defaultComponentsPath
+func getHomeFolder() string {
+	homePath := os.Getenv("HOME")
+	if runtime.GOOS == daprWindowsOS {
+		homePath = os.Getenv("USERPROFILE")
+	}
+	return homePath
+}
+
+// GetDefaultFolderPath returns the default requested path to the requested path
+func GetDefaultFolderPath(dirName string) string {
+	homePath := getHomeFolder()
+	if dirName == defaultDaprDirName {
+		return path_filepath.Join(homePath, defaultDaprDirName)
+	}
+	return path_filepath.Join(homePath, defaultDaprDirName, dirName)
 }

--- a/pkg/standalone/common.go
+++ b/pkg/standalone/common.go
@@ -28,3 +28,9 @@ func GetDefaultFolderPath(dirName string) string {
 	}
 	return path_filepath.Join(homePath, defaultDaprDirName, dirName)
 }
+
+func GetDefaultConfigFilePath() string {
+	configPath := GetDefaultFolderPath(defaultConfigDirName)
+	filePath := path_filepath.Join(configPath, defaultConfigFileName)
+	return filePath
+}

--- a/pkg/standalone/common.go
+++ b/pkg/standalone/common.go
@@ -9,10 +9,10 @@ import (
 const (
 	defaultDaprDirName       = ".dapr"
 	DefaultComponentsDirName = "components"
-	defaultConfigDirName     = "config"
+	defaultConfigFileName    = "config.yaml"
 )
 
-func getHomeFolder() string {
+func homeFolder() string {
 	homePath := os.Getenv("HOME")
 	if runtime.GOOS == daprWindowsOS {
 		homePath = os.Getenv("USERPROFILE")
@@ -20,17 +20,17 @@ func getHomeFolder() string {
 	return homePath
 }
 
-// GetDefaultFolderPath returns the default requested path to the requested path
-func GetDefaultFolderPath(dirName string) string {
-	homePath := getHomeFolder()
+// DefaultFolderPath returns the default requested path to the requested path
+func DefaultFolderPath(dirName string) string {
+	homePath := homeFolder()
 	if dirName == defaultDaprDirName {
 		return path_filepath.Join(homePath, defaultDaprDirName)
 	}
 	return path_filepath.Join(homePath, defaultDaprDirName, dirName)
 }
 
-func GetDefaultConfigFilePath() string {
-	configPath := GetDefaultFolderPath(defaultConfigDirName)
+func DefaultConfigFilePath() string {
+	configPath := DefaultFolderPath(defaultDaprDirName)
 	filePath := path_filepath.Join(configPath, defaultConfigFileName)
 	return filePath
 }

--- a/pkg/standalone/common.go
+++ b/pkg/standalone/common.go
@@ -8,7 +8,7 @@ import (
 
 const (
 	defaultDaprDirName       = ".dapr"
-	DefaultComponentsDirName = "components"
+	defaultComponentsDirName = "components"
 	defaultConfigFileName    = "config.yaml"
 )
 
@@ -21,7 +21,7 @@ func homeFolder() string {
 }
 
 // DefaultFolderPath returns the default requested path to the requested path
-func DefaultFolderPath(dirName string) string {
+func defaultFolderPath(dirName string) string {
 	homePath := homeFolder()
 	if dirName == defaultDaprDirName {
 		return path_filepath.Join(homePath, defaultDaprDirName)
@@ -29,8 +29,12 @@ func DefaultFolderPath(dirName string) string {
 	return path_filepath.Join(homePath, defaultDaprDirName, dirName)
 }
 
+func DefaultComponentsDirPath() string {
+	return defaultFolderPath(defaultComponentsDirName)
+}
+
 func DefaultConfigFilePath() string {
-	configPath := DefaultFolderPath(defaultDaprDirName)
+	configPath := defaultFolderPath(defaultDaprDirName)
 	filePath := path_filepath.Join(configPath, defaultConfigFileName)
 	return filePath
 }

--- a/pkg/standalone/run.go
+++ b/pkg/standalone/run.go
@@ -10,7 +10,6 @@ import (
 	"io/ioutil"
 	"os"
 	"os/exec"
-	"path/filepath"
 	"runtime"
 	"strings"
 
@@ -187,12 +186,7 @@ func Run(config *RunConfig) (*RunOutput, error) {
 		return nil, err
 	}
 
-	configFile, err := getConfigFilePath(config)
-	if err != nil {
-		return nil, err
-	}
-
-	daprCMD, daprHTTPPort, daprGRPCPort, metricsPort, err := getDaprCommand(appID, config.HTTPPort, config.GRPCPort, config.AppPort, configFile, config.Protocol, config.EnableProfiling, config.ProfilePort, config.LogLevel, config.MaxConcurrency, config.PlacementHost, config.ComponentsPath)
+	daprCMD, daprHTTPPort, daprGRPCPort, metricsPort, err := getDaprCommand(appID, config.HTTPPort, config.GRPCPort, config.AppPort, config.ConfigFile, config.Protocol, config.EnableProfiling, config.ProfilePort, config.LogLevel, config.MaxConcurrency, config.PlacementHost, config.ComponentsPath)
 
 	if err != nil {
 		return nil, err
@@ -229,17 +223,4 @@ func Run(config *RunConfig) (*RunOutput, error) {
 		DaprHTTPPort: daprHTTPPort,
 		DaprGRPCPort: daprGRPCPort,
 	}, nil
-}
-
-func getConfigFilePath(config *RunConfig) (string, error) {
-	if config.ConfigFile == "" {
-		configPath := GetDefaultFolderPath(defaultConfigDirName)
-		filePath := filepath.Join(configPath, defaultConfigFileName)
-		_, err := os.Stat(filePath)
-		fmt.Printf("INFO: using default configuration file  %s \n", filePath)
-		return filePath, err
-	}
-
-	_, err := os.Stat(config.ConfigFile)
-	return config.ConfigFile, err
 }

--- a/pkg/standalone/run_test.go
+++ b/pkg/standalone/run_test.go
@@ -31,13 +31,13 @@ func assertArgument(t *testing.T, key string, expectedValue string, args []strin
 }
 
 func setupRun(t *testing.T) {
-	componentsDir := GetDefaultComponentsFolder()
+	componentsDir := GetDefaultFolderPath(DefaultComponentsDirName)
 	err := os.MkdirAll(componentsDir, 0700)
 	assert.Equal(t, nil, err, "Unable to setup components dir before running test")
 }
 
 func tearDownRun(t *testing.T) {
-	componentsDir := GetDefaultComponentsFolder()
+	componentsDir := GetDefaultFolderPath(DefaultComponentsDirName)
 	err := os.RemoveAll(componentsDir)
 	assert.Equal(t, nil, err, "Unable to delete components dir after running test")
 }
@@ -62,7 +62,7 @@ func TestRun(t *testing.T) {
 			Protocol:        "http",
 			RedisHost:       "localhost",
 			PlacementHost:   "localhost",
-			ComponentsPath:  GetDefaultComponentsFolder(),
+			ComponentsPath:  GetDefaultFolderPath(DefaultComponentsDirName),
 		})
 
 		assert.Nil(t, err)
@@ -80,7 +80,7 @@ func TestRun(t *testing.T) {
 		assertArgument(t, "max-concurrency", "-1", output.DaprCMD.Args)
 		assertArgument(t, "protocol", "http", output.DaprCMD.Args)
 		assertArgument(t, "app-port", "3000", output.DaprCMD.Args)
-		assertArgument(t, "components-path", GetDefaultComponentsFolder(), output.DaprCMD.Args)
+		assertArgument(t, "components-path", GetDefaultFolderPath(DefaultComponentsDirName), output.DaprCMD.Args)
 		if runtime.GOOS == "windows" {
 			assertArgument(t, "placement-address", "localhost:6050", output.DaprCMD.Args)
 		} else {
@@ -103,7 +103,7 @@ func TestRun(t *testing.T) {
 			Protocol:        "http",
 			RedisHost:       "localhost",
 			PlacementHost:   "localhost",
-			ComponentsPath:  GetDefaultComponentsFolder(),
+			ComponentsPath:  GetDefaultFolderPath(DefaultComponentsDirName),
 		})
 
 		assert.Nil(t, err)
@@ -121,7 +121,7 @@ func TestRun(t *testing.T) {
 		assertArgument(t, "max-concurrency", "-1", output.DaprCMD.Args)
 		assertArgument(t, "protocol", "http", output.DaprCMD.Args)
 		assertArgument(t, "app-port", "3000", output.DaprCMD.Args)
-		assertArgument(t, "components-path", GetDefaultComponentsFolder(), output.DaprCMD.Args)
+		assertArgument(t, "components-path", GetDefaultFolderPath(DefaultComponentsDirName), output.DaprCMD.Args)
 		if runtime.GOOS == "windows" {
 			assertArgument(t, "placement-address", "localhost:6050", output.DaprCMD.Args)
 		} else {

--- a/pkg/standalone/run_test.go
+++ b/pkg/standalone/run_test.go
@@ -32,24 +32,18 @@ func assertArgument(t *testing.T, key string, expectedValue string, args []strin
 }
 
 func setupRun(t *testing.T) {
-	configDir := GetDefaultFolderPath(defaultConfigDirName)
-	componentsDir := GetDefaultFolderPath(DefaultComponentsDirName)
-	configFile := path_filepath.Join(configDir, defaultConfigFileName)
+	componentsDir := DefaultFolderPath(DefaultComponentsDirName)
+	configFile := path_filepath.Join(DefaultFolderPath(defaultDaprDirName), defaultConfigFileName)
 	err := os.MkdirAll(componentsDir, 0700)
 	assert.Equal(t, nil, err, "Unable to setup components dir before running test")
-	err = os.MkdirAll(configDir, 0700)
-	assert.Equal(t, nil, err, "Unable to setup config dir before running test")
 	_, err = os.Create(configFile)
 	assert.Equal(t, nil, err, "Unable to create config file before running test")
 }
 
 func tearDownRun(t *testing.T) {
-	configDir := GetDefaultFolderPath(defaultConfigDirName)
-	componentsDir := GetDefaultFolderPath(DefaultComponentsDirName)
+	componentsDir := DefaultFolderPath(DefaultComponentsDirName)
 	err := os.RemoveAll(componentsDir)
 	assert.Equal(t, nil, err, "Unable to delete components dir after running test")
-	err = os.RemoveAll(configDir)
-	assert.Equal(t, nil, err, "Unable to delete config dir after running test")
 }
 
 func TestRun(t *testing.T) {
@@ -71,7 +65,7 @@ func TestRun(t *testing.T) {
 			ProfilePort:     9090,
 			Protocol:        "http",
 			PlacementHost:   "localhost",
-			ComponentsPath:  GetDefaultFolderPath(DefaultComponentsDirName),
+			ComponentsPath:  DefaultFolderPath(DefaultComponentsDirName),
 		})
 
 		assert.Nil(t, err)
@@ -89,7 +83,7 @@ func TestRun(t *testing.T) {
 		assertArgument(t, "max-concurrency", "-1", output.DaprCMD.Args)
 		assertArgument(t, "protocol", "http", output.DaprCMD.Args)
 		assertArgument(t, "app-port", "3000", output.DaprCMD.Args)
-		assertArgument(t, "components-path", GetDefaultFolderPath(DefaultComponentsDirName), output.DaprCMD.Args)
+		assertArgument(t, "components-path", DefaultFolderPath(DefaultComponentsDirName), output.DaprCMD.Args)
 		if runtime.GOOS == "windows" {
 			assertArgument(t, "placement-address", "localhost:6050", output.DaprCMD.Args)
 		} else {
@@ -111,8 +105,8 @@ func TestRun(t *testing.T) {
 			ProfilePort:     9090,
 			Protocol:        "http",
 			PlacementHost:   "localhost",
-			ConfigFile:      GetDefaultConfigFilePath(),
-			ComponentsPath:  GetDefaultFolderPath(DefaultComponentsDirName),
+			ConfigFile:      DefaultConfigFilePath(),
+			ComponentsPath:  DefaultFolderPath(DefaultComponentsDirName),
 		})
 
 		assert.Nil(t, err)
@@ -130,8 +124,8 @@ func TestRun(t *testing.T) {
 		assertArgument(t, "max-concurrency", "-1", output.DaprCMD.Args)
 		assertArgument(t, "protocol", "http", output.DaprCMD.Args)
 		assertArgument(t, "app-port", "3000", output.DaprCMD.Args)
-		assertArgument(t, "config", GetDefaultConfigFilePath(), output.DaprCMD.Args)
-		assertArgument(t, "components-path", GetDefaultFolderPath(DefaultComponentsDirName), output.DaprCMD.Args)
+		assertArgument(t, "config", DefaultConfigFilePath(), output.DaprCMD.Args)
+		assertArgument(t, "components-path", DefaultFolderPath(DefaultComponentsDirName), output.DaprCMD.Args)
 		if runtime.GOOS == "windows" {
 			assertArgument(t, "placement-address", "localhost:6050", output.DaprCMD.Args)
 		} else {

--- a/pkg/standalone/run_test.go
+++ b/pkg/standalone/run_test.go
@@ -7,7 +7,6 @@ package standalone
 
 import (
 	"os"
-	path_filepath "path/filepath"
 	"runtime"
 	"strings"
 	"testing"
@@ -32,8 +31,8 @@ func assertArgument(t *testing.T, key string, expectedValue string, args []strin
 }
 
 func setupRun(t *testing.T) {
-	componentsDir := DefaultFolderPath(DefaultComponentsDirName)
-	configFile := path_filepath.Join(DefaultFolderPath(defaultDaprDirName), defaultConfigFileName)
+	componentsDir := DefaultComponentsDirPath()
+	configFile := DefaultConfigFilePath()
 	err := os.MkdirAll(componentsDir, 0700)
 	assert.Equal(t, nil, err, "Unable to setup components dir before running test")
 	_, err = os.Create(configFile)
@@ -41,9 +40,10 @@ func setupRun(t *testing.T) {
 }
 
 func tearDownRun(t *testing.T) {
-	componentsDir := DefaultFolderPath(DefaultComponentsDirName)
-	err := os.RemoveAll(componentsDir)
-	assert.Equal(t, nil, err, "Unable to delete components dir after running test")
+	err := os.RemoveAll(DefaultComponentsDirPath())
+	assert.Equal(t, nil, err, "Unable to delete default components dir after running test")
+	err = os.Remove(DefaultConfigFilePath())
+	assert.Equal(t, nil, err, "Unable to delete default config file after running test")
 }
 
 func TestRun(t *testing.T) {
@@ -65,7 +65,7 @@ func TestRun(t *testing.T) {
 			ProfilePort:     9090,
 			Protocol:        "http",
 			PlacementHost:   "localhost",
-			ComponentsPath:  DefaultFolderPath(DefaultComponentsDirName),
+			ComponentsPath:  DefaultComponentsDirPath(),
 		})
 
 		assert.Nil(t, err)
@@ -83,7 +83,7 @@ func TestRun(t *testing.T) {
 		assertArgument(t, "max-concurrency", "-1", output.DaprCMD.Args)
 		assertArgument(t, "protocol", "http", output.DaprCMD.Args)
 		assertArgument(t, "app-port", "3000", output.DaprCMD.Args)
-		assertArgument(t, "components-path", DefaultFolderPath(DefaultComponentsDirName), output.DaprCMD.Args)
+		assertArgument(t, "components-path", DefaultComponentsDirPath(), output.DaprCMD.Args)
 		if runtime.GOOS == "windows" {
 			assertArgument(t, "placement-address", "localhost:6050", output.DaprCMD.Args)
 		} else {
@@ -106,7 +106,7 @@ func TestRun(t *testing.T) {
 			Protocol:        "http",
 			PlacementHost:   "localhost",
 			ConfigFile:      DefaultConfigFilePath(),
-			ComponentsPath:  DefaultFolderPath(DefaultComponentsDirName),
+			ComponentsPath:  DefaultComponentsDirPath(),
 		})
 
 		assert.Nil(t, err)
@@ -125,7 +125,7 @@ func TestRun(t *testing.T) {
 		assertArgument(t, "protocol", "http", output.DaprCMD.Args)
 		assertArgument(t, "app-port", "3000", output.DaprCMD.Args)
 		assertArgument(t, "config", DefaultConfigFilePath(), output.DaprCMD.Args)
-		assertArgument(t, "components-path", DefaultFolderPath(DefaultComponentsDirName), output.DaprCMD.Args)
+		assertArgument(t, "components-path", DefaultComponentsDirPath(), output.DaprCMD.Args)
 		if runtime.GOOS == "windows" {
 			assertArgument(t, "placement-address", "localhost:6050", output.DaprCMD.Args)
 		} else {

--- a/pkg/standalone/run_test.go
+++ b/pkg/standalone/run_test.go
@@ -7,6 +7,7 @@ package standalone
 
 import (
 	"os"
+	path_filepath "path/filepath"
 	"runtime"
 	"strings"
 	"testing"
@@ -33,10 +34,13 @@ func assertArgument(t *testing.T, key string, expectedValue string, args []strin
 func setupRun(t *testing.T) {
 	configDir := GetDefaultFolderPath(defaultConfigDirName)
 	componentsDir := GetDefaultFolderPath(DefaultComponentsDirName)
+	configFile := path_filepath.Join(configDir, defaultConfigFileName)
 	err := os.MkdirAll(componentsDir, 0700)
 	assert.Equal(t, nil, err, "Unable to setup components dir before running test")
 	err = os.MkdirAll(configDir, 0700)
 	assert.Equal(t, nil, err, "Unable to setup config dir before running test")
+	_, err = os.Create(configFile)
+	assert.Equal(t, nil, err, "Unable to create config file before running test")
 }
 
 func tearDownRun(t *testing.T) {

--- a/pkg/standalone/run_test.go
+++ b/pkg/standalone/run_test.go
@@ -111,6 +111,7 @@ func TestRun(t *testing.T) {
 			ProfilePort:     9090,
 			Protocol:        "http",
 			PlacementHost:   "localhost",
+			ConfigFile:      GetDefaultConfigFilePath(),
 			ComponentsPath:  GetDefaultFolderPath(DefaultComponentsDirName),
 		})
 
@@ -129,6 +130,7 @@ func TestRun(t *testing.T) {
 		assertArgument(t, "max-concurrency", "-1", output.DaprCMD.Args)
 		assertArgument(t, "protocol", "http", output.DaprCMD.Args)
 		assertArgument(t, "app-port", "3000", output.DaprCMD.Args)
+		assertArgument(t, "config", GetDefaultConfigFilePath(), output.DaprCMD.Args)
 		assertArgument(t, "components-path", GetDefaultFolderPath(DefaultComponentsDirName), output.DaprCMD.Args)
 		if runtime.GOOS == "windows" {
 			assertArgument(t, "placement-address", "localhost:6050", output.DaprCMD.Args)

--- a/pkg/standalone/standalone.go
+++ b/pkg/standalone/standalone.go
@@ -485,7 +485,7 @@ func createComponentsAndConfiguration(wg *sync.WaitGroup, errorChan chan<- error
 	var err error
 
 	// Make default components directory
-	componentsDir := DefaultFolderPath(DefaultComponentsDirName)
+	componentsDir := DefaultComponentsDirPath()
 	_, err = os.Stat(componentsDir)
 	if os.IsNotExist(err) {
 		errDir := os.MkdirAll(componentsDir, 0755)

--- a/pkg/standalone/uninstall.go
+++ b/pkg/standalone/uninstall.go
@@ -62,7 +62,7 @@ func removeContainers(uninstallAll bool, dockerNetwork string) []error {
 }
 
 func removeDefaultDaprDir(uninstallAll bool) (string, error) {
-	if uninstallAll == false {
+	if !uninstallAll {
 		return "", nil
 	}
 	defaultDaprPath := GetDefaultFolderPath(defaultDaprDirName)

--- a/pkg/standalone/uninstall.go
+++ b/pkg/standalone/uninstall.go
@@ -53,7 +53,7 @@ func removeDefaultDaprDir(uninstallAll bool) (string, error) {
 	if !uninstallAll {
 		return "", nil
 	}
-	defaultDaprPath := DefaultFolderPath(defaultDaprDirName)
+	defaultDaprPath := defaultFolderPath(defaultDaprDirName)
 	fmt.Println("removing folder: ", defaultDaprPath)
 	err := os.RemoveAll(defaultDaprPath)
 

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -36,7 +36,6 @@ func GetRuntimeVersion() string {
 		return "n/a\n"
 	}
 	return string(out)
-
 }
 
 type githubRepoReleaseItem struct {


### PR DESCRIPTION
# Description
This is to run zipkin and enable tracing by default on `dapr init`

This also deletes the `.dapr` folder on `dapr uninstall --al`

Working on the docs now.

## Issue reference

Please reference the issue this PR will close: #342 

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Created/updated tests
* [x] Extended the documentation https://github.com/dapr/docs/pull/648
