### PR TITLE
Add timeout for linter

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -95,7 +95,7 @@ $(CLI_BINARY):
 # Due to https://github.com/golangci/golangci-lint/issues/580, we need to add --fix for windows
 .PHONY: lint
 lint:
-	$(GOLANGCI_LINT) run --fix
+	$(GOLANGCI_LINT) run --fix --timeout=20m
 
 ################################################################################
 # Target: archive                                                              #


### PR DESCRIPTION
# Description

Add timeout for linter run. Similar to core dapr repo.
This was found as part of the previous run where the linter continued to run even after 20m in the workflow. 


Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [ ] Created/updated tests
* [ ] Extended the documentation
