### PR TITLE
Fix Standalone dapr init behavior.

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ removing archive /Users/msundar/.dapr/daprd_darwin_amd64.tar.gz
 installing Dapr to /usr/local/bin
 
 removing extracted binary /Users/msundar/.dapr/daprd
-✅  Downloading binaries and setting up components...
+✅  Downloaded binaries and completed components set up.
 ℹ️  daprd binary has been installed.
 
 ℹ️  dapr_placement container is running.

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ removing extracted binary /Users/msundar/.dapr/daprd
 > Note: To see that Dapr has been installed successfully, from a command prompt run the `docker ps` command and check that the `daprio/dapr:latest`,  `dapr_redis` and `dapr_zipkin` container images are all running.
 
 This step creates the following defaults:
-1. components folder which is later used at runtime unless the `--components-path` option is provided. For Linux/MacOS, the default components folder path is `$HOME/.dapr/components` and for Windows it is `%USERPROFILE%\.dapr\components`.
+1. components folder which is later used during `dapr run` unless the `--components-path` option is provided. For Linux/MacOS, the default components folder path is `$HOME/.dapr/components` and for Windows it is `%USERPROFILE%\.dapr\components`.
 2. component files in the components folder called `pubsub.yaml`, `statestore.yaml` and `zipkin.yaml`. 
 3. default config file `$HOME/.dapr/config.yaml` for Linux/MacOS or for Windows at `%USERPROFILE%\.dapr\config.yaml` to enable tracing on `dapr init` call. Can be overridden with the `--config` flag on `dapr run`.
 
@@ -137,10 +137,10 @@ You should always run a `dapr uninstall` before running another `dapr init`.
 
 #### Uninstall Dapr from a specific install path 
 
-If previously installed to a specific location, Dapr can be unsintalled with the `--install-path` argument
+If previously installed to a specific location for eg: `~/dapr_bin`, Dapr can be unsintalled with the `--install-path` argument
 
 ```bash
-dapr uninstall --install-path ~/.dapr
+dapr uninstall --install-path ~/dapr_bin
 ```
 
 #### Uninstall Dapr from a specific Docker network

--- a/README.md
+++ b/README.md
@@ -56,16 +56,32 @@ Each release of Dapr CLI includes various OSes and architectures. These binary v
 ```
 $ dapr init
 ⌛  Making the jump to hyperspace...
-↗   Downloading binaries and setting up components...
-✅  Success! Dapr is up and running
+↓  Downloading binaries and setting up components...
+removing archive /Users/msundar/.dapr/daprd_darwin_amd64.tar.gz
+↙  Downloading binaries and setting up components...
+installing Dapr to /usr/local/bin
+
+removing extracted binary /Users/msundar/.dapr/daprd
+✅  Downloading binaries and setting up components...
+ℹ️  daprd binary has been installed.
+
+ℹ️  dapr_placement container is running.
+
+ℹ️  dapr_redis container is running.
+
+ℹ️  dapr_zipkin container is running.
+
+ℹ️  Use `docker ps` to check running containers.
+
+✅  Success! Dapr is up and running. To get started, go here: https://aka.ms/dapr-getting-started
 ```
 
 > Note: To see that Dapr has been installed successfully, from a command prompt run the `docker ps` command and check that the `daprio/dapr:latest`,  `dapr_redis` and `dapr_zipkin` container images are all running.
 
 This step creates the following defaults:
-1. components folder which is later used at runtime unless the --components-path option is provided. For Linux/MacOS, the default components folder path is $HOME/.dapr/components and for Windows it is %USERPROFILE%\.dapr\components.
-2. component files in the components folder called pubsub.yaml, statestore.yaml and zipkin.yaml. 
-3. default config file $HOME/.dapr/config.yaml for Linux/MacOS or for Windows at %USERPROFILE%\.dapr\config.yaml to enable tracing on `dapr init` call. Can be overridden with the `--config` flag on `dapr run`.
+1. components folder which is later used at runtime unless the `--components-path` option is provided. For Linux/MacOS, the default components folder path is `$HOME/.dapr/components` and for Windows it is `%USERPROFILE%\.dapr\components`.
+2. component files in the components folder called `pubsub.yaml`, `statestore.yaml` and `zipkin.yaml`. 
+3. default config file `$HOME/.dapr/config.yaml` for Linux/MacOS or for Windows at `%USERPROFILE%\.dapr\config.yaml` to enable tracing on `dapr init` call. Can be overridden with the `--config` flag on `dapr run`.
 
 #### Install a specific runtime version
 
@@ -104,13 +120,12 @@ $ dapr init --redis-host 10.0.0.1
 ### Uninstall Dapr in a standalone mode
 
 
-Uninstalling will remove the placement container.  
+Uninstalling will remove the placement container and the daprd binary installed in either the provided `--install-path` on `dapr init` or the default path `/usr/local/bin` for Linux/MacOS or `C:\dapr` for Windows. 
 
 
 ```bash
 $ dapr uninstall
 ```
-
 
 The command above won't remove the redis or zipkin containers by default in case you were using it for other purposes.  It will also not remove the default dapr folder that was created on `dapr init`. To remove all the containers (placement, redis, zipkin) and also the default dapr folder created on init run:
 
@@ -119,6 +134,14 @@ $ dapr uninstall --all
 ```
 
 You should always run a `dapr uninstall` before running another `dapr init`.	
+
+#### Uninstall Dapr from a specific install path 
+
+If previously installed to a specific location, Dapr can be unsintalled with the `--install-path` argument
+
+```bash
+dapr uninstall --install-path ~/.dapr
+```
 
 #### Uninstall Dapr from a specific Docker network
 

--- a/README.md
+++ b/README.md
@@ -57,11 +57,11 @@ Each release of Dapr CLI includes various OSes and architectures. These binary v
 $ dapr init
 ⌛  Making the jump to hyperspace...
 ↓  Downloading binaries and setting up components...
-removing archive /Users/msundar/.dapr/daprd_darwin_amd64.tar.gz
+removing archive ~/.dapr/daprd_darwin_amd64.tar.gz
 ↙  Downloading binaries and setting up components...
 installing Dapr to /usr/local/bin
 
-removing extracted binary /Users/msundar/.dapr/daprd
+removing extracted binary ~/.dapr/daprd
 ✅  Downloaded binaries and completed components set up.
 ℹ️  daprd binary has been installed.
 

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -40,7 +40,6 @@ var InitCmd = &cobra.Command{
 			print.SuccessStatusEvent(os.Stdout, "Success! Dapr has been installed. To verify, run 'kubectl get pods -w' or 'dapr status -k' in your terminal. To get started, go here: https://aka.ms/dapr-getting-started")
 		} else {
 			dockerNetwork := viper.GetString("network")
-			standalone.Uninstall(true, dockerNetwork)
 			redisHost := viper.GetString("redis-host")
 			err := standalone.Init(runtimeVersion, dockerNetwork, installLocation, redisHost)
 			if err != nil {
@@ -56,7 +55,7 @@ func init() {
 	InitCmd.Flags().BoolVarP(&kubernetesMode, "kubernetes", "k", false, "Deploy Dapr to a Kubernetes cluster")
 	InitCmd.Flags().StringVarP(&runtimeVersion, "runtime-version", "", "latest", "The version of the Dapr runtime to install. for example: v0.1.0")
 	InitCmd.Flags().String("network", "", "The Docker network on which to deploy the Dapr runtime")
-	InitCmd.Flags().String("install-path", "", "The optional location to install Dapr to.  The default is /usr/local/bin for Linux/Mac and C:\\dapr for Windows")
+	InitCmd.Flags().String("install-path", "", "The optional location to install Daprd binary to.  The default is /usr/local/bin for Linux/Mac and C:\\dapr for Windows")
 	InitCmd.Flags().String("redis-host", "localhost", "The host on which the Redis service resides")
 
 	RootCmd.AddCommand(InitCmd)

--- a/cmd/uninstall.go
+++ b/cmd/uninstall.go
@@ -25,6 +25,7 @@ var UninstallCmd = &cobra.Command{
 	Short: "Removes a Dapr installation",
 	PreRun: func(cmd *cobra.Command, args []string) {
 		viper.BindPFlag("network", cmd.Flags().Lookup("network"))
+		viper.BindPFlag("install-path", cmd.Flags().Lookup("install-path"))
 	},
 	Run: func(cmd *cobra.Command, args []string) {
 
@@ -36,7 +37,8 @@ var UninstallCmd = &cobra.Command{
 		} else {
 			print.InfoStatusEvent(os.Stdout, "Removing Dapr from your machine...")
 			dockerNetwork := viper.GetString("network")
-			err = standalone.Uninstall(uninstallAll, dockerNetwork)
+			installLocation := viper.GetString("install-path")
+			err = standalone.Uninstall(uninstallAll, installLocation, dockerNetwork)
 		}
 
 		if err != nil {
@@ -50,6 +52,7 @@ var UninstallCmd = &cobra.Command{
 func init() {
 	UninstallCmd.Flags().BoolVar(&uninstallKubernetes, "kubernetes", false, "Uninstall Dapr from a Kubernetes cluster")
 	UninstallCmd.Flags().BoolVar(&uninstallAll, "all", false, "Remove Redis container in addition to actor placement container")
+	UninstallCmd.Flags().String("install-path", "", "The optional location to uninstall Daprd binary from.  The default is /usr/local/bin for Linux/Mac and C:\\dapr for Windows")
 	UninstallCmd.Flags().String("network", "", "The Docker network from which to remove the Dapr runtime")
 	RootCmd.AddCommand(UninstallCmd)
 }

--- a/docs/reference/dapr-init.md
+++ b/docs/reference/dapr-init.md
@@ -19,3 +19,4 @@ dapr init [flags]
 | `--network` | `DAPR_NETWORK` | | The Docker network on which to deploy the Dapr runtime |
 | `--runtime-version` | | `latest` | The version of the Dapr runtime to install, for example: `v0.1.0-alpha` |
 | `--redis-host` | `DAPR_REDIS_HOST` | `localhost` | The host on which the Redis service resides |
+| `--install-path` |  | `/usr/local/bin` for Linux/Mac and `C:\dapr` for Windows | The optional location to install Dapr to. |

--- a/docs/reference/dapr-uninstall.md
+++ b/docs/reference/dapr-uninstall.md
@@ -18,3 +18,4 @@ dapr uninstall [flags]
 | `--help`, `-h` | | | Help for uninstall |
 | `--kubernetes` | | `false` | Uninstall Dapr from a Kubernetes cluster |
 | `--network` | `DAPR_NETWORK` | | The Docker network from which to remove the Dapr runtime |
+| `--install-path` |  | `/usr/local/bin` for Linux/Mac and `C:\dapr` for Windows | The optional location to uninstall Dapr from. Use if provided during `dapr init`|

--- a/pkg/standalone/common.go
+++ b/pkg/standalone/common.go
@@ -29,6 +29,25 @@ func defaultFolderPath(dirName string) string {
 	return path_filepath.Join(homePath, defaultDaprDirName, dirName)
 }
 
+func binaryInstallationPath(installLocation string) string {
+	if installLocation != "" {
+		return installLocation
+	}
+	if runtime.GOOS == daprWindowsOS {
+		return daprDefaultWindowsInstallPath
+	}
+	return daprDefaultLinuxAndMacInstallPath
+}
+
+func daprdBinaryFilePath(installLocation string) string {
+	destDir := binaryInstallationPath(installLocation)
+	daprdBinaryPath := path_filepath.Join(destDir, daprRuntimeFilePrefix)
+	if runtime.GOOS == daprWindowsOS {
+		daprdBinaryPath = path_filepath.Join(daprdBinaryPath, ".exe")
+	}
+	return daprdBinaryPath
+}
+
 func DefaultComponentsDirPath() string {
 	return defaultFolderPath(defaultComponentsDirName)
 }

--- a/pkg/standalone/standalone.go
+++ b/pkg/standalone/standalone.go
@@ -157,6 +157,7 @@ func Init(runtimeVersion string, dockerNetwork string, installLocation string, r
 		s.Stop()
 	}
 
+	msg = "Downloaded binaries and completed components set up."
 	print.SuccessStatusEvent(os.Stdout, msg)
 	print.InfoStatusEvent(os.Stdout, "%s binary has been installed.\n", daprRuntimeFilePrefix)
 	for _, container := range dockerContainerNames {


### PR DESCRIPTION
Remove uninstall all from init path. Add install path arg to uninstall cmd. Cleanup binaries, archive correctly.

# Description

Removed `uninstall(true)` from standalone init path. 
Removed archive, binary from default `.dapr` folder. 
Remove binary from default installation path or custom installation path specified by `--install-path` arg. 
Do not create/run `dapr_zipkin`, `dapr_redis` containers if already exists rather start it if already exists. 
Do not initialize dapr again if `daprd` is installed or `dapr_palcement` exists/running.

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #380 

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Created/updated tests
* [x] Extended the documentation
