### PR TITLE
Dashboard integration: Updating user requirements and port-forwarding correct namespace

### DIFF
--- a/cmd/dashboard.go
+++ b/cmd/dashboard.go
@@ -48,7 +48,7 @@ var DashboardCmd = &cobra.Command{
 
 		config, client, err := kubernetes.GetKubeConfigClient()
 		if err != nil {
-			print.FailureStatusEvent(os.Stdout, "Failed to initialize kubernetes client")
+			print.FailureStatusEvent(os.Stdout, "Failed to initialize kubernetes client: %s", err.Error())
 			os.Exit(1)
 		}
 

--- a/cmd/dashboard.go
+++ b/cmd/dashboard.go
@@ -26,8 +26,11 @@ const (
 	// defaultLocalPort is the default local port used for port forwarding for `dapr dashboard`
 	defaultLocalPort = 8080
 
-	// defaultNamespace is the default namespace where the dashboard is deployed
-	defaultNamespace = "dapr-system"
+	// daprSystemNamespace is the namespace "dapr-system" (recommended Dapr install namespace)
+	daprSystemNamespace = "dapr-system"
+
+	// defaultNamespace is the default namespace (dapr init -k installation)
+	defaultNamespace = "default"
 
 	// remotePort is the port dapr dashboard pod is listening on
 	remotePort = 8080
@@ -55,10 +58,12 @@ var DashboardCmd = &cobra.Command{
 		// search for dashboard service namespace in order:
 		// user-supplied namespace, dapr-system, default
 		namespaces := []string{dashboardNamespace}
+		if dashboardNamespace != daprSystemNamespace {
+			namespaces = append(namespaces, daprSystemNamespace)
+		}
 		if dashboardNamespace != defaultNamespace {
 			namespaces = append(namespaces, defaultNamespace)
 		}
-		namespaces = append(namespaces, "default")
 
 		foundNamespace := ""
 		for _, namespace := range namespaces {

--- a/cmd/dashboard.go
+++ b/cmd/dashboard.go
@@ -35,7 +35,7 @@ var localPort int
 
 var DashboardCmd = &cobra.Command{
 	Use:   "dashboard",
-	Short: "Runs the Dapr dashboard on a Kubernetes cluster",
+	Short: "Start Dapr dashboard",
 	Run: func(cmd *cobra.Command, args []string) {
 		if port < 0 {
 			localPort = defaultLocalPort

--- a/cmd/dashboard.go
+++ b/cmd/dashboard.go
@@ -80,7 +80,6 @@ var DashboardCmd = &cobra.Command{
 
 			// if the service is found, tell the user to try with the found namespace
 			// if the service is still not found, throw an error
-			// if the service is still not found, throw an error
 			if ok {
 				print.InfoStatusEvent(os.Stdout, "Dapr dashboard found in namespace: %s. Run dapr dashboard -k -n %s to use this namespace.", nspace, nspace)
 

--- a/cmd/dashboard.go
+++ b/cmd/dashboard.go
@@ -54,7 +54,7 @@ var DashboardCmd = &cobra.Command{
 
 		// search for dashboard service namespace in order:
 		// user-supplied namespace, dapr-system, default
-		namespaces := []string{defaultNamespace}
+		namespaces := []string{dashboardNamespace}
 		if dashboardNamespace != defaultNamespace {
 			namespaces = append(namespaces, defaultNamespace)
 		}
@@ -115,7 +115,7 @@ var DashboardCmd = &cobra.Command{
 		// url for dashboard after port forwarding
 		var webURL string = fmt.Sprintf("http://%s:%d", defaultHost, localPort)
 
-		print.InfoStatusEvent(os.Stdout, fmt.Sprintf("Dapr dashboard found in namespace:\t%s\n", foundNamespace))
+		print.InfoStatusEvent(os.Stdout, fmt.Sprintf("Dapr dashboard found in namespace:\t%s", foundNamespace))
 		print.InfoStatusEvent(os.Stdout, fmt.Sprintf("Dapr dashboard available at:\t%s\n", webURL))
 
 		err = browser.OpenURL(webURL)

--- a/cmd/dashboard.go
+++ b/cmd/dashboard.go
@@ -77,13 +77,17 @@ var DashboardCmd = &cobra.Command{
 		// if the service is not found, try to search all pods
 		if foundNamespace == "" {
 			ok, nspace := kubernetes.CheckPodExists(client, "", nil, dashboardSvc)
-			foundNamespace = nspace
 
+			// if the service is found, tell the user to try with the found namespace
 			// if the service is still not found, throw an error
-			if !ok {
-				print.FailureStatusEvent(os.Stdout, "Failed to find Dapr dashboard in cluster. Please check status of dapr dashboard in the cluster.")
-				os.Exit(1)
+			// if the service is still not found, throw an error
+			if ok {
+				print.InfoStatusEvent(os.Stdout, "Dapr dashboard found in namespace: %s. Run dapr dashboard -k -n %s to use this namespace.", nspace, nspace)
+
+			} else {
+				print.FailureStatusEvent(os.Stdout, "Failed to find Dapr dashboard in cluster. Check status of dapr dashboard in the cluster.")
 			}
+			os.Exit(1)
 		}
 
 		// manage termination of port forwarding connection on interrupt
@@ -136,7 +140,7 @@ var DashboardCmd = &cobra.Command{
 func init() {
 	DashboardCmd.Flags().BoolVarP(&kubernetesMode, "kubernetes", "k", false, "Start Dapr dashboard in local browser")
 	DashboardCmd.Flags().IntVarP(&port, "port", "p", defaultLocalPort, "The local port on which to serve dashboard")
-	DashboardCmd.Flags().StringVarP(&dashboardNamespace, "namespace", "n", defaultNamespace, "The namespace where Dapr dashboard is running")
+	DashboardCmd.Flags().StringVarP(&dashboardNamespace, "namespace", "n", daprSystemNamespace, "The namespace where Dapr dashboard is running")
 	DashboardCmd.MarkFlagRequired("kubernetes")
 	RootCmd.AddCommand(DashboardCmd)
 }

--- a/cmd/dashboard.go
+++ b/cmd/dashboard.go
@@ -33,7 +33,6 @@ const (
 	remotePort = 8080
 )
 
-var dashboardNamespace string
 var localPort int
 
 var DashboardCmd = &cobra.Command{
@@ -60,7 +59,7 @@ var DashboardCmd = &cobra.Command{
 		// search for dashboard service namespace in order:
 		// dapr-system, default
 		foundNamespace := ""
-		namespaces := []string{"dapr-system", "default"}
+		namespaces := []string{defaultNamespace, "default"}
 		for _, namespace := range namespaces {
 			ok := kubernetes.CheckPodExists(client, namespace, nil, dashboardSvc)
 			if ok {

--- a/docs/reference/dapr-dashboard.md
+++ b/docs/reference/dapr-dashboard.md
@@ -1,0 +1,31 @@
+# dapr dashboard
+
+## Description
+
+Start Dapr dashboard.
+
+## Usage
+
+### Prerequisites
+
+Dapr dashboard should be deployed in the Kubernetes cluster.
+
+You can deploy the dashboard in the Kubernetes cluster as follows:
+
+```bash
+kubectl apply -f https://raw.githubusercontent.com/dapr/dashboard/master/deploy/dashboard.yaml
+```
+
+And then run:
+
+```bash
+dapr dashboard [flags]
+```
+
+## Flags
+
+| Name | Environment Variable | Default | Description
+| --- | --- | --- | --- |
+| `--help`, `-h` | | | Help for dashboard |
+| `--kubernetes`, `-k` | | `false` | Start Dapr dashboard in local browser |
+| `--port`, `-p` | | `8080` | The local port on which to serve dashboard |

--- a/docs/reference/dapr-dashboard.md
+++ b/docs/reference/dapr-dashboard.md
@@ -6,17 +6,7 @@ Start Dapr dashboard.
 
 ## Usage
 
-### Prerequisites
-
-Dapr dashboard should be deployed in the Kubernetes cluster.
-
-You can deploy the dashboard in the Kubernetes cluster as follows:
-
-```bash
-kubectl apply -f https://raw.githubusercontent.com/dapr/dashboard/master/deploy/dashboard.yaml
-```
-
-And then run:
+Run:
 
 ```bash
 dapr dashboard [flags]

--- a/docs/reference/dapr-dashboard.md
+++ b/docs/reference/dapr-dashboard.md
@@ -19,4 +19,3 @@ dapr dashboard [flags]
 | `--help`, `-h` | | | Help for dashboard |
 | `--kubernetes`, `-k` | | `false` | Start Dapr dashboard in local browser |
 | `--port`, `-p` | | `8080` | The local port on which to serve dashboard |
-| `--namespace`, `-n` | | `dapr-system` | The namespace where Dapr dashboard is running |

--- a/docs/reference/dapr-dashboard.md
+++ b/docs/reference/dapr-dashboard.md
@@ -19,3 +19,4 @@ dapr dashboard [flags]
 | `--help`, `-h` | | | Help for dashboard |
 | `--kubernetes`, `-k` | | `false` | Start Dapr dashboard in local browser |
 | `--port`, `-p` | | `8080` | The local port on which to serve dashboard |
+| `--namespace`, `-n` | | `dapr-system` | The namespace where Dapr dashboard is running |

--- a/docs/reference/dapr-dashboard.md
+++ b/docs/reference/dapr-dashboard.md
@@ -2,7 +2,7 @@
 
 ## Description
 
-Start Dapr dashboard.
+Start Dapr dashboard!!!.
 
 ## Usage
 

--- a/docs/reference/dapr-dashboard.md
+++ b/docs/reference/dapr-dashboard.md
@@ -2,7 +2,7 @@
 
 ## Description
 
-Start Dapr dashboard!!!.
+Start Dapr dashboard.
 
 ## Usage
 
@@ -19,3 +19,4 @@ dapr dashboard [flags]
 | `--help`, `-h` | | | Help for dashboard |
 | `--kubernetes`, `-k` | | `false` | Start Dapr dashboard in local browser |
 | `--port`, `-p` | | `8080` | The local port on which to serve dashboard |
+| `--namespace`, `-n` | | `dapr-system` | The namespace where Dapr dashboard is running |

--- a/pkg/kubernetes/client.go
+++ b/pkg/kubernetes/client.go
@@ -51,9 +51,17 @@ func getConfig() (*rest.Config, error) {
 	return config, nil
 }
 
-// GetKubeConfig returns kubeconfig
-func GetKubeConfig() (*rest.Config, error) {
-	return getConfig()
+// GetKubeConfigClient returns the kubeconfig and the client created from the kubeconfig
+func GetKubeConfigClient() (*rest.Config, *k8s.Clientset, error) {
+	config, err := getConfig()
+	if err != nil {
+		return nil, nil, err
+	}
+	client, err := k8s.NewForConfig(config)
+	if err != nil {
+		return config, nil, err
+	}
+	return config, client, nil
 }
 
 // Client returns a new Kubernetes client.

--- a/pkg/kubernetes/pods.go
+++ b/pkg/kubernetes/pods.go
@@ -14,11 +14,12 @@ func ListPods(client *k8s.Clientset, namespace string, labelSelector map[string]
 	if labelSelector != nil {
 		opts.LabelSelector = labels.FormatLabels(labelSelector)
 	}
-	return client.CoreV1().Pods(core_v1.NamespaceAll).List(opts)
+	return client.CoreV1().Pods(v1.NamespaceAll).List(opts)
 }
 
-// CheckPodExists returns the namespace that the given pod resides in, or empty if not present in the given namespace
-func CheckPodExists(client *k8s.Clientset, namespace string, labelSelector map[string]string, deployName string) bool {
+// CheckPodExists returns a boolean representing the pod's existence and the namespace that the given pod resides in,
+// or empty if not present in the given namespace
+func CheckPodExists(client *k8s.Clientset, namespace string, labelSelector map[string]string, deployName string) (bool, string) {
 	opts := v1.ListOptions{}
 	if labelSelector != nil {
 		opts.LabelSelector = labels.FormatLabels(labelSelector)
@@ -26,15 +27,15 @@ func CheckPodExists(client *k8s.Clientset, namespace string, labelSelector map[s
 
 	podList, err := client.CoreV1().Pods(namespace).List(opts)
 	if err != nil {
-		return false
+		return false, ""
 	}
 
 	for _, pod := range podList.Items {
 		if pod.Status.Phase == core_v1.PodRunning {
 			if strings.HasPrefix(pod.Name, deployName) {
-				return true
+				return true, pod.Namespace
 			}
 		}
 	}
-	return false
+	return false, ""
 }

--- a/pkg/kubernetes/pods.go
+++ b/pkg/kubernetes/pods.go
@@ -1,6 +1,8 @@
 package kubernetes
 
 import (
+	"strings"
+
 	core_v1 "k8s.io/api/core/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
@@ -13,4 +15,28 @@ func ListPods(client *k8s.Clientset, namespace string, labelSelector map[string]
 		opts.LabelSelector = labels.FormatLabels(labelSelector)
 	}
 	return client.CoreV1().Pods(v1.NamespaceAll).List(opts)
+}
+
+// PodLocation returns the namespace that the given pod resides in, or empty if not in the given possibilities list
+func PodLocation(client *k8s.Clientset, labelSelector map[string]string, deployName string, namespacesToSearch []string) string {
+	opts := v1.ListOptions{}
+	if labelSelector != nil {
+		opts.LabelSelector = labels.FormatLabels(labelSelector)
+	}
+
+	for _, nspace := range namespacesToSearch {
+		podList, err := client.CoreV1().Pods(nspace).List(opts)
+		if err != nil {
+			return nspace
+		}
+
+		for _, pod := range podList.Items {
+			if pod.Status.Phase == core_v1.PodRunning {
+				if strings.HasPrefix(pod.Name, deployName) {
+					return nspace
+				}
+			}
+		}
+	}
+	return ""
 }


### PR DESCRIPTION
# Description

* Removed user requirement to apply dashboard to their cluster, rely on 'dapr init -k' or helm install
* Added search for dashboard namespace: searches namespaces dapr-system and default for dashboard pod
* Added method to check if pod exists in namespace
* Added -n flag for dapr dashboard command to allow the user to supply a namespace
* Updated documentation for dashboard command

## Issue reference

closes #389 

References: https://github.com/dapr/dapr/pull/1752

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [ ] Created/updated tests
* [x] Extended the documentation
