### PR TITLE
Fixed uninstall command to take the version in kubernetes mode to uninstall

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,7 +169,7 @@ You can uninstall a specific version of the Dapr runtime on kubernetes using `da
 
 ```bash
 # Uninstall v0.1.0 runtime
-$ dapr init --runtime-version 0.1.0 --kubernetes
+$ dapr uninstall --runtime-version 0.1.0 --kubernetes
 ```
 
 #### Uninstall Dapr from a specific install path 
@@ -212,6 +212,9 @@ To remove Dapr from your Kubernetes cluster, use the `uninstall` command with `-
 
 ```
 $ dapr uninstall --kubernetes
+
+# Uninstall v0.1.0 runtime
+$ dapr uninstall --runtime-version 0.1.0 --kubernetes
 ```
 
 ### Launch Dapr and your app

--- a/README.md
+++ b/README.md
@@ -163,15 +163,6 @@ The above command can also be run when Dapr has been installed in a non-docker e
 
 **You should always run a `dapr uninstall` before running another `dapr init`.**
 
-#### Uninstall a specific runtime version on kubernetes
-
-You can uninstall a specific version of the Dapr runtime on kubernetes using `dapr uninstall --runtime-version`. You can find the list of versions in [Dapr Release](https://github.com/dapr/dapr/releases).
-
-```bash
-# Uninstall v0.1.0 runtime
-$ dapr uninstall --runtime-version 0.1.0 --kubernetes
-```
-
 #### Uninstall Dapr from a specific install path 
 
 If previously installed to a specific location for eg: `~/dapr_bin`, Dapr can be unsintalled with the `--install-path` argument
@@ -212,9 +203,13 @@ To remove Dapr from your Kubernetes cluster, use the `uninstall` command with `-
 
 ```
 $ dapr uninstall --kubernetes
+```
 
+You can uninstall a specific version of the Dapr runtime on kubernetes using `dapr uninstall --runtime-version`. You can find the list of versions in [Dapr Release](https://github.com/dapr/dapr/releases).
+
+```bash
 # Uninstall v0.1.0 runtime
-$ dapr uninstall --runtime-version 0.1.0 --kubernetes
+$ dapr uninstall --runtime-version=v0.1.0 --kubernetes
 ```
 
 ### Launch Dapr and your app

--- a/README.md
+++ b/README.md
@@ -163,6 +163,15 @@ The above command can also be run when Dapr has been installed in a non-docker e
 
 **You should always run a `dapr uninstall` before running another `dapr init`.**
 
+#### Uninstall a specific runtime version on kubernetes
+
+You can uninstall a specific version of the Dapr runtime on kubernetes using `dapr uninstall --runtime-version`. You can find the list of versions in [Dapr Release](https://github.com/dapr/dapr/releases).
+
+```bash
+# Uninstall v0.1.0 runtime
+$ dapr init --runtime-version 0.1.0 --kubernetes
+```
+
 #### Uninstall Dapr from a specific install path 
 
 If previously installed to a specific location for eg: `~/dapr_bin`, Dapr can be unsintalled with the `--install-path` argument

--- a/cmd/uninstall.go
+++ b/cmd/uninstall.go
@@ -16,6 +16,7 @@ import (
 	"github.com/spf13/viper"
 )
 
+var uninstallVersion string
 var uninstallKubernetes bool
 var uninstallAll bool
 
@@ -33,7 +34,7 @@ var UninstallCmd = &cobra.Command{
 
 		if uninstallKubernetes {
 			print.InfoStatusEvent(os.Stdout, "Removing Dapr from your cluster...")
-			err = kubernetes.Uninstall()
+			err = kubernetes.Uninstall(uninstallVersion)
 		} else {
 			print.InfoStatusEvent(os.Stdout, "Removing Dapr from your machine...")
 			dockerNetwork := viper.GetString("network")
@@ -50,9 +51,10 @@ var UninstallCmd = &cobra.Command{
 }
 
 func init() {
-	UninstallCmd.Flags().BoolVar(&uninstallKubernetes, "kubernetes", false, "Uninstall Dapr from a Kubernetes cluster")
+	UninstallCmd.Flags().BoolVarP(&uninstallKubernetes, "kubernetes", "k", false, "Uninstall Dapr from a Kubernetes cluster")
 	UninstallCmd.Flags().BoolVar(&uninstallAll, "all", false, "Remove Redis container in addition to actor placement container")
 	UninstallCmd.Flags().String("install-path", "", "The optional location to uninstall Daprd binary from.  The default is /usr/local/bin for Linux/Mac and C:\\dapr for Windows")
 	UninstallCmd.Flags().String("network", "", "The Docker network from which to remove the Dapr runtime")
+	UninstallCmd.Flags().StringVarP(&uninstallVersion, "runtime-version", "", "latest", "The version of the Dapr runtime to uninstall. for example: v0.1.0")
 	RootCmd.AddCommand(UninstallCmd)
 }

--- a/cmd/uninstall.go
+++ b/cmd/uninstall.go
@@ -55,6 +55,6 @@ func init() {
 	UninstallCmd.Flags().BoolVar(&uninstallAll, "all", false, "Remove Redis container in addition to actor placement container")
 	UninstallCmd.Flags().String("install-path", "", "The optional location to uninstall Daprd binary from.  The default is /usr/local/bin for Linux/Mac and C:\\dapr for Windows")
 	UninstallCmd.Flags().String("network", "", "The Docker network from which to remove the Dapr runtime")
-	UninstallCmd.Flags().StringVarP(&uninstallVersion, "runtime-version", "", "latest", "The version of the Dapr runtime to uninstall. for example: v0.1.0")
+	UninstallCmd.Flags().StringVarP(&uninstallVersion, "runtime-version", "", "latest", "The version of the Dapr runtime to uninstall. for example: v0.1.0 (Kubernetes mode only)")
 	RootCmd.AddCommand(UninstallCmd)
 }

--- a/docs/reference/dapr-init.md
+++ b/docs/reference/dapr-init.md
@@ -18,7 +18,6 @@ dapr init [flags]
 | `--install-path` | `DAPR_INSTALL_PATH` | `Linux & Mac: /usr/local/bin` `Windows: C:\dapr` | The optional location to install Dapr to.  The default is /usr/local/bin for Linux/Mac and C:\dapr for Windows |
 | `--kubernetes`, `-k` | | `false` | Deploy Dapr to a Kubernetes cluster |
 | `--network` | `DAPR_NETWORK` | | The Docker network on which to deploy the Dapr runtime |
-| `--runtime-version` | | `latest` | The version of the Dapr runtime to install. for example: v0.1.0 (default "latest") |
 | `--runtime-version` | | `latest` | The version of the Dapr runtime to install, for example: `v0.1.0-alpha` |
 | `--redis-host` | `DAPR_REDIS_HOST` | `localhost` | The host on which the Redis service resides |
 | `--install-path` |  | `/usr/local/bin` for Linux/Mac and `C:\dapr` for Windows | The optional location to install Dapr to. |

--- a/docs/reference/dapr-uninstall.md
+++ b/docs/reference/dapr-uninstall.md
@@ -18,4 +18,5 @@ dapr uninstall [flags]
 | `--help`, `-h` | | | Help for uninstall |
 | `--kubernetes`, `-k` | | `false` | Uninstall Dapr from a Kubernetes cluster |
 | `--network` | `DAPR_NETWORK` | | The Docker network from which to remove the Dapr runtime |
+| `--runtime-version` | | `latest` | The version of the Dapr runtime to uninstall, for example: `v0.1.0-alpha` (Kubernetes mode only) |
 | `--install-path` |  | `/usr/local/bin` for Linux/Mac and `C:\dapr` for Windows | The optional location to uninstall Dapr from. Use if provided during `dapr init`|

--- a/docs/reference/dapr-uninstall.md
+++ b/docs/reference/dapr-uninstall.md
@@ -16,6 +16,6 @@ dapr uninstall [flags]
 | --- | --- | --- | --- |
 | `--all` | | `false` | Remove Redis, Zipkin containers in addition to actor placement container. Remove default dapr dir located at `$HOME/.dapr or %USERPROFILE%\.dapr\`. |
 | `--help`, `-h` | | | Help for uninstall |
-| `--kubernetes` | | `false` | Uninstall Dapr from a Kubernetes cluster |
+| `--kubernetes`, `-k` | | `false` | Uninstall Dapr from a Kubernetes cluster |
 | `--network` | `DAPR_NETWORK` | | The Docker network from which to remove the Dapr runtime |
 | `--install-path` |  | `/usr/local/bin` for Linux/Mac and `C:\dapr` for Windows | The optional location to uninstall Dapr from. Use if provided during `dapr init`|

--- a/pkg/kubernetes/uninstall.go
+++ b/pkg/kubernetes/uninstall.go
@@ -14,15 +14,19 @@ import (
 )
 
 // Uninstall removes Dapr
-func Uninstall() error {
-	version, err := cli_ver.GetLatestRelease(cli_ver.DaprGitHubOrg, cli_ver.DaprGitHubRepo)
-	if err != nil {
-		return fmt.Errorf("cannot get the manifest file: %s", err)
+func Uninstall(version string) error {
+	if version == daprLatestVersion {
+		v, err := cli_ver.GetLatestRelease(cli_ver.DaprGitHubOrg, cli_ver.DaprGitHubRepo)
+		if err != nil {
+			return fmt.Errorf("cannot get the manifest file: %s", err)
+		}
+
+		version = v
 	}
 
-	var daprManifestPath string = "https://github.com/dapr/dapr/releases/download/" + version + "/dapr-operator.yaml"
+	var daprManifestPath string = fmt.Sprintf("https://github.com/dapr/dapr/releases/download/%s/dapr-operator.yaml", version)
 
-	_, err = utils.RunCmdAndWait("kubectl", "delete", "-f", daprManifestPath)
+	_, err := utils.RunCmdAndWait("kubectl", "delete", "-f", daprManifestPath)
 	if err != nil {
 		return errors.New("is Dapr running? uninstall does not remove Dapr when installed via Helm")
 	}


### PR DESCRIPTION
# Description

* Fixed uninstall command to take version in kubernetes mode. It is needed when installed through specific version, and it helps testing release candidate builds.
* Added --runtime-version flag to `dapr uninstall`
* Added -k shorthand to `dapr uninstall`

## Issue reference

closes #395 

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [ ] Created/updated tests
* [x] Extended the documentation
