### PR TITLE
Notify dapr/homebrew-tap on new release.

### DIFF
--- a/.github/workflows/release_notification.yaml
+++ b/.github/workflows/release_notification.yaml
@@ -1,0 +1,17 @@
+# ------------------------------------------------------------
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+# ------------------------------------------------------------
+
+name: release_notification
+
+on:
+  release:
+    types: [prereleased,released]
+jobs:
+  notify:
+    name: Notify about Dapr Cli release.
+    runs-on: ubuntu-latest
+    steps:
+      - name: Notify dapr/homebrew-tap repo
+        run: GITHUB_TOKEN="${{ secrets.RELEASE_USER_TOKEN }}" gh api repos/dapr/homebrew-tap/dispatches -X POST -F event_type=update


### PR DESCRIPTION
# Description

Notifies homebrew repo about a new release of Dapr Cli. This avoids busy waiting every 5 min for a new release.

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #328

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [ ] Extended the documentation
