### PR TITLE
Fixing duplicate dapr init user message on linux

### DIFF
--- a/pkg/standalone/standalone.go
+++ b/pkg/standalone/standalone.go
@@ -755,7 +755,7 @@ func moveFileToPath(filepath string, installLocation string) (string, error) {
 		return fmt.Sprintf("%s\\daprd.exe", destDir), nil
 	}
 
-	if !strings.HasPrefix(fileName, placementServiceFilePrefix) && installLocation != "" {
+	if strings.HasPrefix(fileName, daprRuntimeFilePrefix) && installLocation != "" {
 		color.Set(color.FgYellow)
 		fmt.Printf("\nDapr runtime installed to %s, you may run the following to add it to your path if you want to run daprd directly:\n", destDir)
 		fmt.Printf("    export PATH=$PATH:%s\n", destDir)


### PR DESCRIPTION
# Description

* Fixed bug where `dapr init` tells the user to export their paths twice

## Issue reference

None

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [ ] Created/updated tests
* [ ] Extended the documentation
