### PR TITLE
Add certificate export command

### DIFF
--- a/README.md
+++ b/README.md
@@ -333,6 +333,24 @@ To check if Mutual TLS is enabled in your Kubernetes cluster:
 $ dapr mtls --kubernetes
 ```
 
+### Export TLS certificates
+
+To export the root cert, issuer cert and issuer key created by Dapr from a Kubernetes cluster to a local path:
+
+```
+$ dapr mtls export
+```
+
+This will save the certs to the working directory.
+
+To specify a custom directory:
+
+```
+$ dapr mtls export -o certs
+```
+
+This can be used when upgrading to a newer version of Dapr, as it's recommended to carry over the existing certs for a zero downtime upgrade.
+
 ### List Components
 
 To list all Dapr components on Kubernetes:

--- a/cmd/mtls.go
+++ b/cmd/mtls.go
@@ -7,10 +7,15 @@ package cmd
 
 import (
 	"fmt"
+	"os"
+	"path/filepath"
 
 	"github.com/dapr/cli/pkg/kubernetes"
+	"github.com/dapr/cli/pkg/print"
 	"github.com/spf13/cobra"
 )
+
+var exportPath string
 
 var MTLSCmd = &cobra.Command{
 	Use:   "mtls",
@@ -18,7 +23,7 @@ var MTLSCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		enabled, err := kubernetes.IsMTLSEnabled()
 		if err != nil {
-			fmt.Printf("error checking mTLS: %s \n", err)
+			print.FailureStatusEvent(os.Stdout, fmt.Sprintf("error checking mTLS: %s", err))
 			return
 		}
 
@@ -30,8 +35,25 @@ var MTLSCmd = &cobra.Command{
 	},
 }
 
+var ExportCMD = &cobra.Command{
+	Use:   "export",
+	Short: "Export the root CA, issuer cert and key from Kubernetes to local files",
+	Run: func(cmd *cobra.Command, args []string) {
+		err := kubernetes.ExportTrustChain(exportPath)
+		if err != nil {
+			print.FailureStatusEvent(os.Stdout, fmt.Sprintf("error exporting trust chain certs: %s", err))
+			return
+		}
+
+		dir, _ := filepath.Abs(exportPath)
+		print.SuccessStatusEvent(os.Stdout, fmt.Sprintf("Trust certs successfully exported to %s", dir))
+	},
+}
+
 func init() {
 	MTLSCmd.Flags().BoolVarP(&kubernetesMode, "kubernetes", "k", false, "Check if mTLS is enabled in a Kubernetes cluster")
+	ExportCMD.Flags().StringVarP(&exportPath, "out", "o", ".", "Output directory path to save the certs")
 	MTLSCmd.MarkFlagRequired("kubernetes")
+	MTLSCmd.AddCommand(ExportCMD)
 	RootCmd.AddCommand(MTLSCmd)
 }

--- a/pkg/kubernetes/client.go
+++ b/pkg/kubernetes/client.go
@@ -23,16 +23,18 @@ import (
 
 const kubeConfigDelimiter = ":"
 
-func getConfig() (*rest.Config, error) {
-	var kubeconfig *string
+var kubeconfig *string
 
+func init() {
 	if home := homeDir(); home != "" {
 		kubeconfig = flag.String("kubeconfig", filepath.Join(home, ".kube", "config"), "(optional) absolute path to the kubeconfig file")
 	} else {
 		kubeconfig = flag.String("kubeconfig", "", "absolute path to the kubeconfig file")
 	}
 	flag.Parse()
+}
 
+func getConfig() (*rest.Config, error) {
 	kubeConfigEnv := os.Getenv("KUBECONFIG")
 	delimiterBelongsToPath := strings.Count(*kubeconfig, kubeConfigDelimiter) == 1 && strings.EqualFold(*kubeconfig, kubeConfigEnv)
 

--- a/pkg/kubernetes/mtls.go
+++ b/pkg/kubernetes/mtls.go
@@ -1,28 +1,92 @@
 package kubernetes
 
 import (
+	"errors"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+
+	"github.com/dapr/dapr/pkg/apis/configuration/v1alpha1"
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 const (
-	defaultConfigName = "default"
+	systemConfigName      = "daprsystem"
+	trustBundleSecretName = "dapr-trust-bundle"
 )
 
 func IsMTLSEnabled() (bool, error) {
-	client, err := DaprClient()
+	c, err := getSystemConfig()
 	if err != nil {
 		return false, err
+	}
+	return c.Spec.MTLSSpec.Enabled, nil
+}
+
+func getSystemConfig() (*v1alpha1.Configuration, error) {
+	client, err := DaprClient()
+	if err != nil {
+		return nil, err
 	}
 
 	configs, err := client.ConfigurationV1alpha1().Configurations(meta_v1.NamespaceAll).List(meta_v1.ListOptions{})
 	if err != nil {
-		return false, err
+		return nil, err
 	}
 
 	for _, c := range configs.Items {
-		if c.GetName() == defaultConfigName {
-			return c.Spec.MTLSSpec.Enabled, nil
+		if c.GetName() == systemConfigName {
+			return &c, nil
 		}
 	}
-	return false, nil
+	return nil, errors.New("system configuration not found")
+}
+
+func ExportTrustChain(outputDir string) error {
+	_, err := os.Stat(outputDir)
+
+	if os.IsNotExist(err) {
+		errDir := os.MkdirAll(outputDir, 0755)
+		if errDir != nil {
+			return err
+		}
+	}
+
+	_, client, err := GetKubeConfigClient()
+	if err != nil {
+		return err
+	}
+
+	c, err := getSystemConfig()
+	if err != nil {
+		return err
+	}
+	res, err := client.CoreV1().Secrets(c.GetNamespace()).List(meta_v1.ListOptions{})
+	if err != nil {
+		return err
+	}
+
+	for _, i := range res.Items {
+		if i.GetName() == trustBundleSecretName {
+			ca := i.Data["ca.crt"]
+			issuerCert := i.Data["issuer.crt"]
+			issuerKey := i.Data["issuer.key"]
+
+			err := ioutil.WriteFile(filepath.Join(outputDir, "ca.crt"), ca, 0700)
+			if err != nil {
+				return err
+			}
+
+			err = ioutil.WriteFile(filepath.Join(outputDir, "issuer.crt"), issuerCert, 0700)
+			if err != nil {
+				return err
+			}
+
+			err = ioutil.WriteFile(filepath.Join(outputDir, "issuer.key"), issuerKey, 0700)
+			if err != nil {
+				return err
+			}
+		}
+	}
+	return nil
 }

--- a/pkg/kubernetes/mtls.go
+++ b/pkg/kubernetes/mtls.go
@@ -42,6 +42,7 @@ func getSystemConfig() (*v1alpha1.Configuration, error) {
 	return nil, errors.New("system configuration not found")
 }
 
+// ExportTrustChain takes the root cert, issuer cert and issuer key from a k8s cluster and saves them in a given directory
 func ExportTrustChain(outputDir string) error {
 	_, err := os.Stat(outputDir)
 

--- a/pkg/kubernetes/mtls.go
+++ b/pkg/kubernetes/mtls.go
@@ -12,7 +12,7 @@ import (
 
 const (
 	systemConfigName      = "daprsystem"
-	trustBundleSecretName = "dapr-trust-bundle"
+	trustBundleSecretName = "dapr-trust-bundle" // nolint:gosec
 )
 
 func IsMTLSEnabled() (bool, error) {
@@ -72,17 +72,17 @@ func ExportTrustChain(outputDir string) error {
 			issuerCert := i.Data["issuer.crt"]
 			issuerKey := i.Data["issuer.key"]
 
-			err := ioutil.WriteFile(filepath.Join(outputDir, "ca.crt"), ca, 0700)
+			err := ioutil.WriteFile(filepath.Join(outputDir, "ca.crt"), ca, 0600)
 			if err != nil {
 				return err
 			}
 
-			err = ioutil.WriteFile(filepath.Join(outputDir, "issuer.crt"), issuerCert, 0700)
+			err = ioutil.WriteFile(filepath.Join(outputDir, "issuer.crt"), issuerCert, 0600)
 			if err != nil {
 				return err
 			}
 
-			err = ioutil.WriteFile(filepath.Join(outputDir, "issuer.key"), issuerKey, 0700)
+			err = ioutil.WriteFile(filepath.Join(outputDir, "issuer.key"), issuerKey, 0600)
 			if err != nil {
 				return err
 			}

--- a/pkg/kubernetes/mtls.go
+++ b/pkg/kubernetes/mtls.go
@@ -86,6 +86,7 @@ func ExportTrustChain(outputDir string) error {
 			if err != nil {
 				return err
 			}
+			break
 		}
 	}
 	return nil


### PR DESCRIPTION
This PR does the following:

1. Adds a command that helps users export their TLS certificates from a kubernetes cluster
2. Fixes race condition bugs for the k8s/dapr clients

Closes #419 