### PR TITLE
Add root cert expiry check command

### DIFF
--- a/README.md
+++ b/README.md
@@ -358,6 +358,12 @@ To specify a custom directory:
 $ dapr mtls export -o certs
 ```
 
+### Check root certificate expiry
+
+```
+$ dapr mtls expiry
+```
+
 This can be used when upgrading to a newer version of Dapr, as it's recommended to carry over the existing certs for a zero downtime upgrade.
 
 ### List Components

--- a/pkg/kubernetes/kubernetes.go
+++ b/pkg/kubernetes/kubernetes.go
@@ -28,7 +28,7 @@ import (
 
 const (
 	daprReleaseName   = "dapr"
-	daprHelmRepo      = "https://dapr.github.io/dapr-helm-charts.io"
+	daprHelmRepo      = "https://daprio.azurecr.io/helm/v1/repo"
 	daprLatestVersion = "latest"
 )
 

--- a/pkg/kubernetes/mtls.go
+++ b/pkg/kubernetes/mtls.go
@@ -1,12 +1,17 @@
 package kubernetes
 
 import (
+	"crypto/x509"
+	"encoding/pem"
 	"errors"
+	"fmt"
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"time"
 
 	"github.com/dapr/dapr/pkg/apis/configuration/v1alpha1"
+	corev1 "k8s.io/api/core/v1"
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -53,42 +58,67 @@ func ExportTrustChain(outputDir string) error {
 		}
 	}
 
-	_, client, err := GetKubeConfigClient()
+	secret, err := getTrustChainSecret()
 	if err != nil {
 		return err
+	}
+
+	ca := secret.Data["ca.crt"]
+	issuerCert := secret.Data["issuer.crt"]
+	issuerKey := secret.Data["issuer.key"]
+
+	err = ioutil.WriteFile(filepath.Join(outputDir, "ca.crt"), ca, 0600)
+	if err != nil {
+		return err
+	}
+
+	err = ioutil.WriteFile(filepath.Join(outputDir, "issuer.crt"), issuerCert, 0600)
+	if err != nil {
+		return err
+	}
+
+	err = ioutil.WriteFile(filepath.Join(outputDir, "issuer.key"), issuerKey, 0600)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func getTrustChainSecret() (*corev1.Secret, error) {
+	_, client, err := GetKubeConfigClient()
+	if err != nil {
+		return nil, err
 	}
 
 	c, err := getSystemConfig()
 	if err != nil {
-		return err
+		return nil, err
 	}
 	res, err := client.CoreV1().Secrets(c.GetNamespace()).List(meta_v1.ListOptions{})
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	for _, i := range res.Items {
 		if i.GetName() == trustBundleSecretName {
-			ca := i.Data["ca.crt"]
-			issuerCert := i.Data["issuer.crt"]
-			issuerKey := i.Data["issuer.key"]
-
-			err := ioutil.WriteFile(filepath.Join(outputDir, "ca.crt"), ca, 0600)
-			if err != nil {
-				return err
-			}
-
-			err = ioutil.WriteFile(filepath.Join(outputDir, "issuer.crt"), issuerCert, 0600)
-			if err != nil {
-				return err
-			}
-
-			err = ioutil.WriteFile(filepath.Join(outputDir, "issuer.key"), issuerKey, 0600)
-			if err != nil {
-				return err
-			}
-			break
+			return &i, nil
 		}
 	}
-	return nil
+	return nil, fmt.Errorf("could not find trust chain secret named %s in namespace %s", trustBundleSecretName, c.GetNamespace())
+}
+
+// Expiry returns the expiry time for the root cert
+func Expiry() (*time.Time, error) {
+	secret, err := getTrustChainSecret()
+	if err != nil {
+		return nil, err
+	}
+
+	caCrt := secret.Data["ca.crt"]
+	block, _ := pem.Decode(caCrt)
+	cert, err := x509.ParseCertificate(block.Bytes)
+	if err != nil {
+		return nil, err
+	}
+	return &cert.NotAfter, nil
 }


### PR DESCRIPTION
This PR allows an operator or developer to check when their Root Certificate expires.

On the way, @youngbupark and I realized there's a bug with the `https://dapr.github.io/dapr-helm-charts.io` chart repo and reverted back to the correct one with this PR.

Once the issue is fixed we can change back.

Usage:

```bash
$ dapr mtls expiry

Root certificate expires in 8759 hours. Expiry date: 2021-08-13 23:55:36 +0000 UTC
```