### PR TITLE
Remove --fix in make lint

### DIFF
--- a/.github/workflows/dapr_cli.yaml
+++ b/.github/workflows/dapr_cli.yaml
@@ -49,13 +49,13 @@ jobs:
         with:
           go-version: ${{ env.GOVER }}
       - name: Install golangci-lint
-        if: matrix.target_arch != 'arm'
+        if: matrix.target_arch != 'arm' && matrix.target_os != 'windows'
         run: |
           curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b "${{ env.GOROOT }}/bin" v${{ env.GOLANGCILINT_VER }}
       - name: Check out code into the Go module directory
         uses: actions/checkout@v2
       - name: Run linter
-        if: matrix.target_arch != 'arm'
+        if: matrix.target_arch != 'arm' && matrix.target_os != 'windows'
         run: make lint
       - name: Parse release version and set REL_VERSION
         run: python ./.github/scripts/get_release_version.py

--- a/Makefile
+++ b/Makefile
@@ -92,10 +92,9 @@ $(CLI_BINARY):
 ################################################################################
 # Target: lint                                                                 #
 ################################################################################
-# Due to https://github.com/golangci/golangci-lint/issues/580, we need to add --fix for windows
 .PHONY: lint
 lint:
-	$(GOLANGCI_LINT) run --fix --timeout=20m
+	$(GOLANGCI_LINT) run --timeout=20m
 
 ################################################################################
 # Target: archive                                                              #


### PR DESCRIPTION
# Description

Remove `--fix` from linter 

`--fix` does autofix of code and changes code for linting. Should be removed as it has been done for dapr/dapr and dapr/components-contrib.

Similarly for the 2 repos, lint is not run in windows or arm nodes, making the change here as well. 

First part in upgrading to 1.30.0.

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #447 

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [ ] Created/updated tests
* [ ] Extended the documentation
