### PR TITLE
Add UTs for publish and invoke

### DIFF
--- a/cmd/invoke.go
+++ b/cmd/invoke.go
@@ -6,10 +6,8 @@
 package cmd
 
 import (
-	"fmt"
 	"os"
 
-	"github.com/dapr/cli/pkg/invoke"
 	"github.com/dapr/cli/pkg/print"
 	"github.com/spf13/cobra"
 )
@@ -22,16 +20,7 @@ var InvokeCmd = &cobra.Command{
 	Use:   "invoke",
 	Short: "Invokes a Dapr app with an optional payload (deprecated, use invokePost)",
 	Run: func(cmd *cobra.Command, args []string) {
-		response, err := invoke.Post(invokeAppID, invokeAppMethod, invokePayload)
-		if err != nil {
-			print.FailureStatusEvent(os.Stdout, fmt.Sprintf("Error invoking app %s: %s", invokeAppID, err))
-			return
-		}
-
-		if response != "" {
-			fmt.Println(response)
-		}
-
+		invokePost(invokeAppID, invokeAppMethod, invokePayload)
 		print.SuccessStatusEvent(os.Stdout, "App invoked successfully")
 	},
 }

--- a/cmd/invoke.go
+++ b/cmd/invoke.go
@@ -22,7 +22,11 @@ var InvokeCmd = &cobra.Command{
 	Use:   "invoke",
 	Short: "Invokes a Dapr app with an optional payload (deprecated, use invokePost)",
 	Run: func(cmd *cobra.Command, args []string) {
-		invokePost(invokeAppID, invokeAppMethod, invokePayload)
+		err := invokePost(invokeAppID, invokeAppMethod, invokePayload)
+		if err != nil {
+			// exit with error
+			os.Exit(1)
+		}
 		print.SuccessStatusEvent(os.Stdout, "App invoked successfully")
 	},
 }

--- a/cmd/invokeGet.go
+++ b/cmd/invokeGet.go
@@ -14,12 +14,12 @@ var invokeGetCmd = &cobra.Command{
 	Use:   "invokeGet",
 	Short: "Issue HTTP GET to Dapr app",
 	Run: func(cmd *cobra.Command, args []string) {
-		client := standalone.NewStandaloneClient()
-		response, err := client.InvokeGet(invokeAppID, invokeAppMethod)
+		client := standalone.NewClient()
+		response, err := client.Get(invokeAppID, invokeAppMethod)
 		if err != nil {
-			print.FailureStatusEvent(os.Stdout, fmt.Sprintf("Error invoking app %s: %s", invokeAppID, err))
-
-			return
+			print.FailureStatusEvent(os.Stdout, fmt.Sprintf("error invoking app %s: %s", invokeAppID, err))
+			// exit with error
+			os.Exit(1)
 		}
 
 		if response != "" {

--- a/cmd/invokeGet.go
+++ b/cmd/invokeGet.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/dapr/cli/pkg/invoke"
 	"github.com/dapr/cli/pkg/print"
+	"github.com/dapr/cli/pkg/standalone"
 	"github.com/spf13/cobra"
 )
 
@@ -14,7 +14,8 @@ var invokeGetCmd = &cobra.Command{
 	Use:   "invokeGet",
 	Short: "Issue HTTP GET to Dapr app",
 	Run: func(cmd *cobra.Command, args []string) {
-		response, err := invoke.Get(invokeAppID, invokeAppMethod)
+		client := standalone.NewStandaloneClient()
+		response, err := client.InvokeGet(invokeAppID, invokeAppMethod)
 		if err != nil {
 			print.FailureStatusEvent(os.Stdout, fmt.Sprintf("Error invoking app %s: %s", invokeAppID, err))
 

--- a/cmd/invokeGet.go
+++ b/cmd/invokeGet.go
@@ -15,7 +15,7 @@ var invokeGetCmd = &cobra.Command{
 	Short: "Issue HTTP GET to Dapr app",
 	Run: func(cmd *cobra.Command, args []string) {
 		client := standalone.NewClient()
-		response, err := client.Get(invokeAppID, invokeAppMethod)
+		response, err := client.InvokeGet(invokeAppID, invokeAppMethod)
 		if err != nil {
 			print.FailureStatusEvent(os.Stdout, fmt.Sprintf("error invoking app %s: %s", invokeAppID, err))
 			// exit with error

--- a/cmd/invokePost.go
+++ b/cmd/invokePost.go
@@ -9,8 +9,8 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/dapr/cli/pkg/invoke"
 	"github.com/dapr/cli/pkg/print"
+	"github.com/dapr/cli/pkg/standalone"
 	"github.com/spf13/cobra"
 )
 
@@ -19,23 +19,26 @@ var (
 		Use:   "invokePost",
 		Short: "Issue HTTP POST to Dapr app with an optional payload",
 		Run: func(cmd *cobra.Command, args []string) {
-
-			response, err := invoke.Post(invokeAppID, invokeAppMethod, invokePayload)
-			if err != nil {
-				print.FailureStatusEvent(os.Stdout, fmt.Sprintf("Error invoking app %s: %s", invokeAppID, err))
-
-				return
-			}
-
-			if response != "" {
-				fmt.Println(response)
-			}
+			invokePost(invokeAppID, invokeAppMethod, invokePayload)
 
 			print.SuccessStatusEvent(os.Stdout, fmt.Sprintf("HTTP Post to method %s invoked successfully", invokeAppMethod))
-
 		},
 	}
 )
+
+func invokePost(invokeAppID, invokeAppMethod, invokePayload string) {
+	client := standalone.NewStandaloneClient()
+	response, err := client.InvokePost(invokeAppID, invokeAppMethod, invokePayload)
+	if err != nil {
+		print.FailureStatusEvent(os.Stdout, fmt.Sprintf("Error invoking app %s: %s", invokeAppID, err))
+
+		return
+	}
+
+	if response != "" {
+		fmt.Println(response)
+	}
+}
 
 func init() {
 	invokePostCmd.Flags().StringVarP(&invokeAppID, "app-id", "a", "", "the app id to invoke")

--- a/cmd/invokePost.go
+++ b/cmd/invokePost.go
@@ -29,7 +29,7 @@ var invokePostCmd = &cobra.Command{
 
 func invokePost(invokeAppID, invokeAppMethod, invokePayload string) error {
 	client := standalone.NewClient()
-	response, err := client.Post(invokeAppID, invokeAppMethod, invokePayload)
+	response, err := client.InvokePost(invokeAppID, invokeAppMethod, invokePayload)
 	if err != nil {
 		er := fmt.Errorf("error invoking app %s: %s", invokeAppID, err)
 		print.FailureStatusEvent(os.Stdout, er.Error())

--- a/cmd/invokePost.go
+++ b/cmd/invokePost.go
@@ -18,24 +18,28 @@ var invokePostCmd = &cobra.Command{
 	Use:   "invokePost",
 	Short: "Issue HTTP POST to Dapr app with an optional payload",
 	Run: func(cmd *cobra.Command, args []string) {
-		invokePost(invokeAppID, invokeAppMethod, invokePayload)
-
+		err := invokePost(invokeAppID, invokeAppMethod, invokePayload)
+		if err != nil {
+			// exit with error
+			os.Exit(1)
+		}
 		print.SuccessStatusEvent(os.Stdout, fmt.Sprintf("HTTP Post to method %s invoked successfully", invokeAppMethod))
 	},
 }
 
-func invokePost(invokeAppID, invokeAppMethod, invokePayload string) {
-	client := standalone.NewStandaloneClient()
-	response, err := client.InvokePost(invokeAppID, invokeAppMethod, invokePayload)
+func invokePost(invokeAppID, invokeAppMethod, invokePayload string) error {
+	client := standalone.NewClient()
+	response, err := client.Post(invokeAppID, invokeAppMethod, invokePayload)
 	if err != nil {
-		print.FailureStatusEvent(os.Stdout, fmt.Sprintf("Error invoking app %s: %s", invokeAppID, err))
-
-		return
+		er := fmt.Errorf("error invoking app %s: %s", invokeAppID, err)
+		print.FailureStatusEvent(os.Stdout, er.Error())
+		return er
 	}
 
 	if response != "" {
 		fmt.Println(response)
 	}
+	return nil
 }
 
 func init() {

--- a/cmd/publish.go
+++ b/cmd/publish.go
@@ -24,11 +24,11 @@ var PublishCmd = &cobra.Command{
 	Use:   "publish",
 	Short: "Publish an event to multiple consumers",
 	Run: func(cmd *cobra.Command, args []string) {
-		client := standalone.NewStandaloneClient()
+		client := standalone.NewClient()
 		err := client.Publish(publishTopic, publishPayload, pubsubName)
 		if err != nil {
 			print.FailureStatusEvent(os.Stdout, fmt.Sprintf("Error publishing topic %s: %s", publishTopic, err))
-			return
+			os.Exit(1)
 		}
 
 		print.SuccessStatusEvent(os.Stdout, "Event published successfully")

--- a/cmd/publish.go
+++ b/cmd/publish.go
@@ -10,7 +10,7 @@ import (
 	"os"
 
 	"github.com/dapr/cli/pkg/print"
-	"github.com/dapr/cli/pkg/publish"
+	"github.com/dapr/cli/pkg/standalone"
 	"github.com/spf13/cobra"
 )
 
@@ -22,7 +22,8 @@ var PublishCmd = &cobra.Command{
 	Use:   "publish",
 	Short: "Publish an event to multiple consumers",
 	Run: func(cmd *cobra.Command, args []string) {
-		err := publish.SendPayloadToTopic(publishTopic, publishPayload, pubsubName)
+		client := standalone.NewStandaloneClient()
+		err := client.Publish(publishTopic, publishPayload, pubsubName)
 		if err != nil {
 			print.FailureStatusEvent(os.Stdout, fmt.Sprintf("Error publishing topic %s: %s", publishTopic, err))
 			return

--- a/pkg/metadata/metadata_test.go
+++ b/pkg/metadata/metadata_test.go
@@ -1,0 +1,19 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+// ------------------------------------------------------------
+
+package metadata
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/dapr/cli/pkg/api"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMakeMetadataGetEndpoint(t *testing.T) {
+	actual := makeMetadataGetEndpoint(9999)
+	assert.Equal(t, fmt.Sprintf("http://127.0.0.1:9999/v%s/metadata", api.RuntimeAPIVersion), actual, "expected strings to match")
+}

--- a/pkg/standalone/client.go
+++ b/pkg/standalone/client.go
@@ -13,7 +13,6 @@ type daprProcess struct {
 }
 
 type Client interface {
-	DaprProcess
 	InvokeGet(appID, method string) (string, error)
 	InvokePost(appID, method, payload string) (string, error)
 	Publish(topic, payload, pubsubName string) error
@@ -25,8 +24,4 @@ type Standalone struct {
 
 func NewStandaloneClient() Client {
 	return &Standalone{process: &daprProcess{}}
-}
-
-func (s *Standalone) List() ([]ListOutput, error) {
-	return s.process.List()
 }

--- a/pkg/standalone/client.go
+++ b/pkg/standalone/client.go
@@ -12,9 +12,13 @@ type DaprProcess interface {
 type daprProcess struct {
 }
 
+// Client is the interface the wraps all the methods exposed by the Dapr CLI.
 type Client interface {
-	InvokeGet(appID, method string) (string, error)
-	InvokePost(appID, method, payload string) (string, error)
+	// Get is used to invoke a method on a Dapr application with GET verb.
+	Get(appID, method string) (string, error)
+	// Post is used to invoke a method on a Dapr application with POST verb.
+	Post(appID, method, payload string) (string, error)
+	// Publish is used to publish event to a topic in a pubsub.
 	Publish(topic, payload, pubsubName string) error
 }
 
@@ -22,6 +26,6 @@ type Standalone struct {
 	process DaprProcess
 }
 
-func NewStandaloneClient() Client {
+func NewClient() Client {
 	return &Standalone{process: &daprProcess{}}
 }

--- a/pkg/standalone/client.go
+++ b/pkg/standalone/client.go
@@ -1,0 +1,32 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+// ------------------------------------------------------------
+
+package standalone
+
+type DaprProcess interface {
+	List() ([]ListOutput, error)
+}
+
+type daprProcess struct {
+}
+
+type Client interface {
+	DaprProcess
+	InvokeGet(appID, method string) (string, error)
+	InvokePost(appID, method, payload string) (string, error)
+	Publish(topic, payload, pubsubName string) error
+}
+
+type Standalone struct {
+	process DaprProcess
+}
+
+func NewStandaloneClient() Client {
+	return &Standalone{process: &daprProcess{}}
+}
+
+func (s *Standalone) List() ([]ListOutput, error) {
+	return s.process.List()
+}

--- a/pkg/standalone/client.go
+++ b/pkg/standalone/client.go
@@ -14,10 +14,10 @@ type daprProcess struct {
 
 // Client is the interface the wraps all the methods exposed by the Dapr CLI.
 type Client interface {
-	// Get is used to invoke a method on a Dapr application with GET verb.
-	Get(appID, method string) (string, error)
-	// Post is used to invoke a method on a Dapr application with POST verb.
-	Post(appID, method, payload string) (string, error)
+	// InvokeGet is used to invoke a method on a Dapr application with GET verb.
+	InvokeGet(appID, method string) (string, error)
+	// InvokePost is used to invoke a method on a Dapr application with POST verb.
+	InvokePost(appID, method, payload string) (string, error)
 	// Publish is used to publish event to a topic in a pubsub.
 	Publish(topic, payload, pubsubName string) error
 }

--- a/pkg/standalone/invoke.go
+++ b/pkg/standalone/invoke.go
@@ -3,7 +3,7 @@
 // Licensed under the MIT License.
 // ------------------------------------------------------------
 
-package invoke
+package standalone
 
 import (
 	"bytes"
@@ -12,12 +12,11 @@ import (
 	"net/http"
 
 	"github.com/dapr/cli/pkg/api"
-	"github.com/dapr/cli/pkg/standalone"
 )
 
-// Get invokes the application via HTTP GET.
-func Get(appID, method string) (string, error) {
-	list, err := standalone.List()
+// InvokeGet invokes the application via HTTP GET.
+func (s *Standalone) InvokeGet(appID, method string) (string, error) {
+	list, err := s.List()
 	if err != nil {
 		return "", err
 	}
@@ -39,8 +38,8 @@ func Get(appID, method string) (string, error) {
 }
 
 // Post invokes the application via HTTP POST.
-func Post(appID, method, payload string) (string, error) {
-	list, err := standalone.List()
+func (s *Standalone) InvokePost(appID, method, payload string) (string, error) {
+	list, err := s.List()
 	if err != nil {
 		return "", err
 	}
@@ -62,7 +61,7 @@ func Post(appID, method, payload string) (string, error) {
 	return "", fmt.Errorf("app ID %s not found", appID)
 }
 
-func makeEndpoint(lo standalone.ListOutput, method string) string {
+func makeEndpoint(lo ListOutput, method string) string {
 	return fmt.Sprintf("http://127.0.0.1:%s/v%s/invoke/%s/method/%s", fmt.Sprintf("%v", lo.HTTPPort), api.RuntimeAPIVersion, lo.AppID, method)
 }
 

--- a/pkg/standalone/invoke.go
+++ b/pkg/standalone/invoke.go
@@ -15,7 +15,7 @@ import (
 )
 
 // InvokeGet invokes the application via HTTP GET.
-func (s *Standalone) Get(appID, method string) (string, error) {
+func (s *Standalone) InvokeGet(appID, method string) (string, error) {
 	list, err := s.process.List()
 	if err != nil {
 		return "", err
@@ -37,8 +37,8 @@ func (s *Standalone) Get(appID, method string) (string, error) {
 	return "", fmt.Errorf("app ID %s not found", appID)
 }
 
-// Post invokes the application via HTTP POST.
-func (s *Standalone) Post(appID, method, payload string) (string, error) {
+// InvokePost invokes the application via HTTP POST.
+func (s *Standalone) InvokePost(appID, method, payload string) (string, error) {
 	list, err := s.process.List()
 	if err != nil {
 		return "", err

--- a/pkg/standalone/invoke.go
+++ b/pkg/standalone/invoke.go
@@ -15,7 +15,7 @@ import (
 )
 
 // InvokeGet invokes the application via HTTP GET.
-func (s *Standalone) InvokeGet(appID, method string) (string, error) {
+func (s *Standalone) Get(appID, method string) (string, error) {
 	list, err := s.process.List()
 	if err != nil {
 		return "", err
@@ -38,7 +38,7 @@ func (s *Standalone) InvokeGet(appID, method string) (string, error) {
 }
 
 // Post invokes the application via HTTP POST.
-func (s *Standalone) InvokePost(appID, method, payload string) (string, error) {
+func (s *Standalone) Post(appID, method, payload string) (string, error) {
 	list, err := s.process.List()
 	if err != nil {
 		return "", err

--- a/pkg/standalone/invoke.go
+++ b/pkg/standalone/invoke.go
@@ -16,7 +16,7 @@ import (
 
 // InvokeGet invokes the application via HTTP GET.
 func (s *Standalone) InvokeGet(appID, method string) (string, error) {
-	list, err := s.List()
+	list, err := s.process.List()
 	if err != nil {
 		return "", err
 	}
@@ -39,7 +39,7 @@ func (s *Standalone) InvokeGet(appID, method string) (string, error) {
 
 // Post invokes the application via HTTP POST.
 func (s *Standalone) InvokePost(appID, method, payload string) (string, error) {
-	list, err := s.List()
+	list, err := s.process.List()
 	if err != nil {
 		return "", err
 	}

--- a/pkg/standalone/invoke_test.go
+++ b/pkg/standalone/invoke_test.go
@@ -1,0 +1,108 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+// ------------------------------------------------------------
+
+package standalone
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestInvoke(t *testing.T) {
+	testCases := []struct {
+		name          string
+		errorExpected bool
+		errString     string
+		appID         string
+		method        string
+		lo            ListOutput
+		listErr       error
+		expectedPath  string
+		postResponse  string
+		resp          string
+	}{
+		{
+			name:          "list apps error",
+			errorExpected: true,
+			errString:     assert.AnError.Error(),
+			listErr:       assert.AnError,
+		},
+		{
+			name:          "appID not found",
+			errorExpected: true,
+			appID:         "invalid",
+			errString:     "app ID invalid not found",
+			lo: ListOutput{
+				AppID: "testapp",
+			},
+		},
+		{
+			name:   "appID found successful invoke empty response",
+			appID:  "testapp",
+			method: "test",
+			lo: ListOutput{
+				AppID: "testapp",
+			},
+		},
+		{
+			name:   "appID found successful invoke",
+			appID:  "testapp",
+			method: "test",
+			lo: ListOutput{
+				AppID: "testapp",
+			},
+			expectedPath: "/v1.0/invoke/testapp/method/test",
+			postResponse: "test payload",
+			resp:         "successful invoke",
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.name+" get", func(t *testing.T) {
+			ts, port := getTestServer(tc.expectedPath, tc.resp)
+			ts.Start()
+			defer ts.Close()
+			tc.lo.HTTPPort = port
+			client := &Standalone{
+				process: &mockDaprProcess{
+					Lo: []ListOutput{
+						tc.lo,
+					},
+					Err: tc.listErr,
+				},
+			}
+			res, err := client.InvokeGet(tc.appID, tc.method)
+			if tc.errorExpected {
+				assert.Error(t, err, "expected an error")
+				assert.Equal(t, tc.errString, err.Error(), "expected error strings to match")
+			} else {
+				assert.NoError(t, err, "expected no error")
+				assert.Equal(t, tc.resp, res, "expected response to match")
+			}
+		})
+		t.Run(tc.name+" post", func(t *testing.T) {
+			ts, port := getTestServer(tc.expectedPath, tc.resp)
+			ts.Start()
+			defer ts.Close()
+			tc.lo.HTTPPort = port
+			client := &Standalone{
+				process: &mockDaprProcess{
+					Lo:  []ListOutput{tc.lo},
+					Err: tc.listErr,
+				},
+			}
+			res, err := client.InvokePost(tc.appID, tc.method, "test payload")
+			if tc.errorExpected {
+				assert.Error(t, err, "expected an error")
+				assert.Equal(t, tc.errString, err.Error(), "expected error strings to match")
+			} else {
+				assert.NoError(t, err, "expected no error")
+				assert.Equal(t, tc.postResponse, res, "expected response to match")
+			}
+		})
+	}
+}

--- a/pkg/standalone/invoke_test.go
+++ b/pkg/standalone/invoke_test.go
@@ -74,7 +74,7 @@ func TestInvoke(t *testing.T) {
 					Err: tc.listErr,
 				},
 			}
-			res, err := client.Get(tc.appID, tc.method)
+			res, err := client.InvokeGet(tc.appID, tc.method)
 			if tc.errorExpected {
 				assert.Error(t, err, "expected an error")
 				assert.Equal(t, tc.errString, err.Error(), "expected error strings to match")
@@ -94,7 +94,7 @@ func TestInvoke(t *testing.T) {
 					Err: tc.listErr,
 				},
 			}
-			res, err := client.Post(tc.appID, tc.method, "test payload")
+			res, err := client.InvokePost(tc.appID, tc.method, "test payload")
 			if tc.errorExpected {
 				assert.Error(t, err, "expected an error")
 				assert.Equal(t, tc.errString, err.Error(), "expected error strings to match")

--- a/pkg/standalone/invoke_test.go
+++ b/pkg/standalone/invoke_test.go
@@ -61,7 +61,6 @@ func TestInvoke(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.name+" get", func(t *testing.T) {
 			ts, port := getTestServer(tc.expectedPath, tc.resp)
 			ts.Start()
@@ -75,7 +74,7 @@ func TestInvoke(t *testing.T) {
 					Err: tc.listErr,
 				},
 			}
-			res, err := client.InvokeGet(tc.appID, tc.method)
+			res, err := client.Get(tc.appID, tc.method)
 			if tc.errorExpected {
 				assert.Error(t, err, "expected an error")
 				assert.Equal(t, tc.errString, err.Error(), "expected error strings to match")
@@ -95,7 +94,7 @@ func TestInvoke(t *testing.T) {
 					Err: tc.listErr,
 				},
 			}
-			res, err := client.InvokePost(tc.appID, tc.method, "test payload")
+			res, err := client.Post(tc.appID, tc.method, "test payload")
 			if tc.errorExpected {
 				assert.Error(t, err, "expected an error")
 				assert.Equal(t, tc.errString, err.Error(), "expected error strings to match")

--- a/pkg/standalone/list.go
+++ b/pkg/standalone/list.go
@@ -41,6 +41,10 @@ type runData struct {
 	appCmd     string
 }
 
+func (d *daprProcess) List() ([]ListOutput, error) {
+	return List()
+}
+
 // List outputs all the applications.
 func List() ([]ListOutput, error) {
 	list := []ListOutput{}

--- a/pkg/standalone/publish.go
+++ b/pkg/standalone/publish.go
@@ -23,7 +23,7 @@ func (s *Standalone) Publish(topic, payload, pubsubName string) error {
 		return errors.New("pubsubName is missing")
 	}
 
-	l, err := s.List()
+	l, err := s.process.List()
 	if err != nil {
 		return err
 	}

--- a/pkg/standalone/publish.go
+++ b/pkg/standalone/publish.go
@@ -45,13 +45,9 @@ func (s *Standalone) Publish(topic, payload, pubsubName string) error {
 	if err != nil {
 		return err
 	}
-
+	defer r.Body.Close()
 	if r.StatusCode != http.StatusOK {
 		return fmt.Errorf("unexpected status code %d on publishing to %s in %s", r.StatusCode, topic, pubsubName)
-	}
-
-	if r != nil {
-		defer r.Body.Close()
 	}
 
 	return nil

--- a/pkg/standalone/publish_test.go
+++ b/pkg/standalone/publish_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestPubLish(t *testing.T) {
+func TestPublish(t *testing.T) {
 	testCases := []struct {
 		name          string
 		pubsubName    string
@@ -73,7 +73,6 @@ func TestPubLish(t *testing.T) {
 		},
 	}
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			ts, port := getTestServer(tc.expectedPath, tc.resp)
 			ts.Start()

--- a/pkg/standalone/publish_test.go
+++ b/pkg/standalone/publish_test.go
@@ -1,0 +1,97 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+// ------------------------------------------------------------
+
+package standalone
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPubLish(t *testing.T) {
+	testCases := []struct {
+		name          string
+		pubsubName    string
+		payload       string
+		topic         string
+		lo            ListOutput
+		listErr       error
+		expectedPath  string
+		postResponse  string
+		resp          string
+		errorExpected bool
+		errString     string
+	}{
+		{
+			name:          "test empty topic",
+			payload:       "test",
+			pubsubName:    "test",
+			errString:     "topic is missing",
+			errorExpected: true,
+		},
+		{
+			name:          "test empty pubsubName",
+			payload:       "test",
+			topic:         "test",
+			errString:     "pubsubName is missing",
+			errorExpected: true,
+		},
+		{
+			name:          "test list error",
+			payload:       "test",
+			topic:         "test",
+			pubsubName:    "test",
+			listErr:       assert.AnError,
+			errString:     assert.AnError.Error(),
+			errorExpected: true,
+		},
+		{
+			name:       "test empty appID in list output",
+			payload:    "test",
+			topic:      "test",
+			pubsubName: "test",
+			lo: ListOutput{
+				// empty appID
+				Command: "test",
+			},
+			errString:     "couldn't find a running Dapr instance",
+			errorExpected: true,
+		},
+		{
+			name:         "successful call",
+			pubsubName:   "testPubsubName",
+			topic:        "testTopic",
+			payload:      "test payload",
+			expectedPath: "/v1.0/publish/testPubsubName/testTopic",
+			postResponse: "test payload",
+			lo: ListOutput{
+				AppID: "notempty",
+			},
+		},
+	}
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			ts, port := getTestServer(tc.expectedPath, tc.resp)
+			ts.Start()
+			defer ts.Close()
+			tc.lo.HTTPPort = port
+			client := &Standalone{
+				process: &mockDaprProcess{
+					Lo:  []ListOutput{tc.lo},
+					Err: tc.listErr,
+				},
+			}
+			err := client.Publish(tc.topic, tc.payload, tc.pubsubName)
+			if tc.errorExpected {
+				assert.Error(t, err, "expected an error")
+				assert.Equal(t, tc.errString, err.Error(), "expected error strings to match")
+			} else {
+				assert.NoError(t, err, "expected no error")
+			}
+		})
+	}
+}

--- a/pkg/standalone/testutils.go
+++ b/pkg/standalone/testutils.go
@@ -1,0 +1,42 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+// ------------------------------------------------------------
+
+package standalone
+
+import (
+	"bytes"
+	"net"
+	"net/http"
+	"net/http/httptest"
+)
+
+type mockDaprProcess struct {
+	Lo  []ListOutput
+	Err error
+}
+
+func (m *mockDaprProcess) List() ([]ListOutput, error) {
+	return m.Lo, m.Err
+}
+
+func getTestServer(expectedPath, resp string) (*httptest.Server, int) {
+	ts := httptest.NewUnstartedServer(http.HandlerFunc(func(
+		w http.ResponseWriter, r *http.Request) {
+		if r.RequestURI != expectedPath {
+			w.WriteHeader(http.StatusInternalServerError)
+
+			return
+		}
+		if r.Method == http.MethodPost {
+			buf := new(bytes.Buffer)
+			buf.ReadFrom(r.Body)
+			w.Write(buf.Bytes())
+		} else if r.Method == http.MethodGet {
+			w.Write([]byte(resp))
+		}
+	}))
+
+	return ts, ts.Listener.Addr().(*net.TCPAddr).Port
+}


### PR DESCRIPTION
# Description

Make the publish, invoke testable. 

Make List implement a receiver. 

Add unit tests for publish and invoke. 

Add testutils package, defining utilities for testing. 


Output: 
Using quickstarts pub-sub 

```
./dist/darwin_amd64/release/dapr publish --topic A --pubsub pubsub --data '{ "message": "This is a test edge ver 2" }'
✅  Event published successfully

Output: 
== APP == A:  {

== APP ==   id: 'e0792cec-2e93-46b7-999c-2f0ff3dd8130',

== APP ==   source: 'node-subscriber',

== APP ==   type: 'com.dapr.event.sent',

== APP ==   specversion: '1.0',

== APP ==   datacontenttype: 'application/json',

== APP ==   data: { message: 'This is a test edge ver 2' },

== APP ==   subject: '00-747e47361df80a76cab6bb5ae16c3a4b-b767ff08348189ec-01',

== APP ==   topic: 'A',

== APP ==   pubsubname: 'pubsub'

== APP == }

```

Using hello-world quickstart

```
$ ./dist/darwin_amd64/release/dapr invoke --app-id nodeapp --method neworder --payload "{\"data\": { \"orderId\": \"42\" } }"
✅  App invoked successfully
$ ./dist/darwin_amd64/release/dapr invokeGet --app-id nodeapp --method order
{"orderId":"42"}
✅  HTTP Get to method order invoked successfully

$ ./dist/darwin_amd64/release/dapr invokePost --app-id nodeapp --method neworder --payload "{\"data\": { \"orderId\": \"43\" } }"
✅  HTTP Post to method neworder invoked successfully
$ ./dist/darwin_amd64/release/dapr invokeGet --app-id nodeapp --method order
{"orderId":"43"}
✅  HTTP Get to method order invoked successfully
```


## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

a part of the implementation for #485 

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Created/updated tests
* [ ] Extended the documentation
