### PR TITLE
Tune CodeCov to not fail PRs

### DIFF
--- a/.codecov.yaml
+++ b/.codecov.yaml
@@ -1,2 +1,14 @@
+coverage:
+  # Commit status https://docs.codecov.io/docs/commit-status are used
+  # to block PR based on coverage threshold.
+  status:
+    project:
+      default:
+        informational: true
+    patch:
+      # Disable the coverage threshold of the patch, so that PRs are
+      # only failing because of overall project coverage threshold.
+      # See https://docs.codecov.io/docs/commit-status#disabling-a-status.
+      default: false
 ignore:
   - "**/zz_generated*.go" # Ignore generated files.


### PR DESCRIPTION
# Description

Currently, the CodeCov/patch is too strict and would fail PRs if not meeting a certain threshold (for example https://github.com/dapr/cli/pull/447). This PR tunes that down until we bring coverage to that point before making a threshold requirement.

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [ ] Created/updated tests
* [ ] Extended the documentation
