### PR TITLE
Remove set-env usage

### DIFF
--- a/.github/workflows/dapr_cli.yaml
+++ b/.github/workflows/dapr_cli.yaml
@@ -101,7 +101,7 @@ jobs:
         run: |
           REL_VERSION_FILE="${{ env.ARTIFACT_DIR }}/release_version.txt"
           REL_VER=`cat ${REL_VERSION_FILE}`
-          echo "##[set-env name=REL_VERSION;]${REL_VER}"
+          echo "REL_VERSION=${REL_VER}" >> $GITHUB_ENV
           rm -f ${REL_VERSION_FILE}
       - name: publish binaries to github
         if: startswith(github.ref, 'refs/tags/v')


### PR DESCRIPTION
https://nvd.nist.gov/vuln/detail/CVE-2020-15228 advises that `setenv` and `add-path` are not secure, so they will be disabled very shortly on workflows. This changes `set-env` to the recommended upgrade.

# Description

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #NA

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [ ] Extended the documentation
