### PR TITLE
Support path that contains spaces

### DIFF
--- a/install/install.ps1
+++ b/install/install.ps1
@@ -8,23 +8,27 @@ param (
 
 $ErrorActionPreference = 'stop'
 
+#Escape space of DapRoot path
+$DaprRoot = $DaprRoot -replace ' ', '` '
+
 # Constants
 $DaprCliFileName = "dapr.exe"
 $DaprCliFilePath = "${DaprRoot}\${DaprCliFileName}"
 
 # GitHub Org and repo hosting Dapr CLI
-$GitHubOrg="dapr"
-$GitHubRepo="cli"
+$GitHubOrg = "dapr"
+$GitHubRepo = "cli"
 
 # Set Github request authentication for basic authentication.
 if ($Env:GITHUB_USER) {
     $basicAuth = [System.Convert]::ToBase64String([System.Text.Encoding]::ASCII.GetBytes($Env:GITHUB_USER + ":" + $Env:GITHUB_TOKEN));
-    $githubHeader = @{"Authorization"="Basic $basicAuth"}
-} else {
+    $githubHeader = @{"Authorization" = "Basic $basicAuth" }
+}
+else {
     $githubHeader = @{}
 }
 
-if((Get-ExecutionPolicy) -gt 'RemoteSigned' -or (Get-ExecutionPolicy) -eq 'ByPass') {
+if ((Get-ExecutionPolicy) -gt 'RemoteSigned' -or (Get-ExecutionPolicy) -eq 'ByPass') {
     Write-Output "PowerShell requires an execution policy of 'RemoteSigned'."
     Write-Output "To make this change please run:"
     Write-Output "'Set-ExecutionPolicy RemoteSigned -scope CurrentUser'"
@@ -39,7 +43,8 @@ if (Test-Path $DaprCliFilePath -PathType Leaf) {
     Write-Warning "Dapr is detected - $DaprCliFilePath"
     Invoke-Expression "$DaprCliFilePath --version"
     Write-Output "Reinstalling Dapr..."
-} else {
+}
+else {
     Write-Output "Installing Dapr..."
 }
 
@@ -57,7 +62,7 @@ if ($releases.Count -eq 0) {
 }
 
 # Filter windows binary and download archive
-$windowsAsset = $releases | Where-Object { $_.tag_name -notlike "*rc*"} | Select-Object -First 1 | Select-Object -ExpandProperty assets | Where-Object { $_.name -Like "*windows_amd64.zip" }
+$windowsAsset = $releases | Where-Object { $_.tag_name -notlike "*rc*" } | Select-Object -First 1 | Select-Object -ExpandProperty assets | Where-Object { $_.name -Like "*windows_amd64.zip" }
 if (!$windowsAsset) {
     throw "Cannot find the windows Dapr CLI binary"
 }
@@ -88,9 +93,10 @@ Remove-Item $zipFilePath -Force
 # Add DaprRoot directory to User Path environment variable
 Write-Output "Try to add $DaprRoot to User Path Environment variable..."
 $UserPathEnvionmentVar = [Environment]::GetEnvironmentVariable("PATH", "User")
-if($UserPathEnvionmentVar -like '*dapr*') {
+if ($UserPathEnvionmentVar -like '*dapr*') {
     Write-Output "Skipping to add $DaprRoot to User Path - $UserPathEnvionmentVar"
-} else {
+}
+else {
     [System.Environment]::SetEnvironmentVariable("PATH", $UserPathEnvionmentVar + ";$DaprRoot", "User")
     $UserPathEnvionmentVar = [Environment]::GetEnvironmentVariable("PATH", "User")
     Write-Output "Added $DaprRoot to User Path - $UserPathEnvionmentVar"


### PR DESCRIPTION
# Description

Executing Install.ps1 will fail if DaprRoot contains spaces

eg:
```powershell
./Install.ps1 -DaprRoot ` C:\Program Files\dapr\`
```
## Issue reference

#513 

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Created/updated tests
* [ ] Extended the documentation
