### PR TITLE
support assign specified dashboard version for init

### DIFF
--- a/cmd/dashboard.go
+++ b/cmd/dashboard.go
@@ -38,9 +38,9 @@ const (
 )
 
 var (
-	dashboardNamespace string
-	dashboardLocalPort int
-	dashboardVersion   bool
+	dashboardNamespace  string
+	dashboardLocalPort  int
+	dashboardVersionCmd bool
 )
 
 var DashboardCmd = &cobra.Command{
@@ -60,7 +60,7 @@ dapr dashboard -k
 dapr dashboard -k -p 9999
 `,
 	Run: func(cmd *cobra.Command, args []string) {
-		if dashboardVersion {
+		if dashboardVersionCmd {
 			fmt.Println(standalone.GetDashboardVersion())
 			os.Exit(0)
 		}
@@ -166,7 +166,7 @@ dapr dashboard -k -p 9999
 
 func init() {
 	DashboardCmd.Flags().BoolVarP(&kubernetesMode, "kubernetes", "k", false, "Opens Dapr dashboard in local browser via local proxy to Kubernetes cluster")
-	DashboardCmd.Flags().BoolVarP(&dashboardVersion, "version", "v", false, "Print the version for Dapr dashboard")
+	DashboardCmd.Flags().BoolVarP(&dashboardVersionCmd, "version", "v", false, "Print the version for Dapr dashboard")
 	DashboardCmd.Flags().IntVarP(&dashboardLocalPort, "port", "p", defaultLocalPort, "The local port on which to serve Dapr dashboard")
 	DashboardCmd.Flags().StringVarP(&dashboardNamespace, "namespace", "n", daprSystemNamespace, "The namespace where Dapr dashboard is running")
 	DashboardCmd.Flags().BoolP("help", "h", false, "Print this help message")

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -17,13 +17,14 @@ import (
 )
 
 var (
-	kubernetesMode bool
-	slimMode       bool
-	runtimeVersion string
-	initNamespace  string
-	enableMTLS     bool
-	enableHA       bool
-	values         []string
+	kubernetesMode   bool
+	slimMode         bool
+	runtimeVersion   string
+	dashboardVersion string
+	initNamespace    string
+	enableMTLS       bool
+	enableHA         bool
+	values           []string
 )
 
 var InitCmd = &cobra.Command{
@@ -74,7 +75,7 @@ dapr init -s
 			if !slimMode {
 				dockerNetwork = viper.GetString("network")
 			}
-			err := standalone.Init(runtimeVersion, dockerNetwork, slimMode)
+			err := standalone.Init(runtimeVersion, dashboardVersion, dockerNetwork, slimMode)
 			if err != nil {
 				print.FailureStatusEvent(os.Stdout, err.Error())
 				return
@@ -88,6 +89,7 @@ func init() {
 	InitCmd.Flags().BoolVarP(&kubernetesMode, "kubernetes", "k", false, "Deploy Dapr to a Kubernetes cluster")
 	InitCmd.Flags().BoolVarP(&slimMode, "slim", "s", false, "Exclude placement service, Redis and Zipkin containers from self-hosted installation")
 	InitCmd.Flags().StringVarP(&runtimeVersion, "runtime-version", "", "latest", "The version of the Dapr runtime to install, for example: 1.0.0")
+	InitCmd.Flags().StringVarP(&dashboardVersion, "dashboard-version", "", "latest", "The version of the Dapr dashboard to install, for example: 1.0.0")
 	InitCmd.Flags().StringVarP(&initNamespace, "namespace", "n", "dapr-system", "The Kubernetes namespace to install Dapr in")
 	InitCmd.Flags().BoolVarP(&enableMTLS, "enable-mtls", "", true, "Enable mTLS in your cluster")
 	InitCmd.Flags().BoolVarP(&enableHA, "enable-ha", "", false, "Enable high availability (HA) mode")

--- a/pkg/kubernetes/kubernetes.go
+++ b/pkg/kubernetes/kubernetes.go
@@ -27,9 +27,9 @@ import (
 )
 
 const (
-	daprReleaseName   = "dapr"
-	daprHelmRepo      = "https://dapr.github.io/helm-charts"
-	daprLatestVersion = "latest"
+	daprReleaseName = "dapr"
+	daprHelmRepo    = "https://dapr.github.io/helm-charts"
+	latestVersion   = "latest"
 )
 
 type InitConfiguration struct {
@@ -116,7 +116,7 @@ func daprChart(version string, config *helm.Configuration) (*chart.Chart, error)
 	pull.RepoURL = daprHelmRepo
 	pull.Settings = &cli.EnvSettings{}
 
-	if version != daprLatestVersion {
+	if version != latestVersion {
 		pull.Version = chartVersion(version)
 	}
 


### PR DESCRIPTION
Signed-off-by: luhualin <luhualin@bilibili.com>

# Description

Support assign specified dashboard version for `dapr init`, such as `dapr init --runtime-version=1.0.0-rc.1 --dashboard-version=0.4.0`, so that uses can skip replace `version: latest` which may lead `403 rate limit exceeded` while calling `api.github.com`

## Issue reference

Fix https://github.com/dapr/cli/issues/415

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Created/updated tests
* [ ] Extended the documentation
