### PR TITLE
Remove redis-host flag, fix configs and uninstall with network flag.

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,12 +139,6 @@ $ dapr init --network dapr-network
 
 > Note: When installed to a specific Docker network, you will need to add the `--placement-host-address` arguments to `dapr run` commands run in any containers within that network.
 
-#### Install with a specific host on which the Redis service resides
-```bash
-# Specify a particular redis host
-$ dapr init --redis-host 10.0.0.1
-```
-
 ### Uninstall Dapr in a standalone mode
 
 Uninstalling will remove daprd binary and the placement container (if installed with Docker or the placement binary if not).
@@ -249,11 +243,11 @@ $ dapr run --app-id nodeapp --app-port 3000 --dapr-grpc-port 50002 node app.js
 Example of launching Dapr within a specific Docker network:
 
 ```bash
-$ dapr init --redis-host dapr_redis --network dapr-network
+$ dapr init --network dapr-network
 $ dapr run --app-id nodeapp --placement-host-address dapr_placement node app.js
 ```
 
-> Note: When in a specific Docker network, the Redis and placement service containers are given specific network aliases, `dapr_redis` and `dapr_placement`, respectively.
+> Note: When in a specific Docker network, the Redis, Zipkin and placement service containers are given specific network aliases, `dapr_redis`, `dapr_zipkin` and `dapr_placement`, respectively. The default configuration files reflect the network alias rather than `localhost` when a docker network is specified.
 
 ### Use gRPC
 

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -30,8 +30,6 @@ var InitCmd = &cobra.Command{
 	Short: "Install Dapr on supported hosting platforms. Supported platforms: Kubernetes and self-hosted",
 	PreRun: func(cmd *cobra.Command, args []string) {
 		viper.BindPFlag("network", cmd.Flags().Lookup("network"))
-		viper.BindPFlag("install-path", cmd.Flags().Lookup("install-path"))
-		viper.BindPFlag("redis-host", cmd.Flags().Lookup("redis-host"))
 	},
 	Example: `
 # Initialize Dapr in self-hosted mode
@@ -68,8 +66,7 @@ dapr init -s
 			if !slimMode {
 				dockerNetwork = viper.GetString("network")
 			}
-			redisHost := viper.GetString("redis-host")
-			err := standalone.Init(runtimeVersion, dockerNetwork, redisHost, slimMode)
+			err := standalone.Init(runtimeVersion, dockerNetwork, slimMode)
 			if err != nil {
 				print.FailureStatusEvent(os.Stdout, err.Error())
 				return
@@ -87,7 +84,6 @@ func init() {
 	InitCmd.Flags().BoolVarP(&enableMTLS, "enable-mtls", "", true, "Enable mTLS in your cluster")
 	InitCmd.Flags().BoolVarP(&enableHA, "enable-ha", "", false, "Enable high availability (HA) mode")
 	InitCmd.Flags().String("network", "", "The Docker network on which to deploy the Dapr runtime")
-	InitCmd.Flags().String("redis-host", "localhost", "The host on which the Redis service resides")
 	InitCmd.Flags().BoolP("help", "h", false, "Print this help message")
 
 	RootCmd.AddCommand(InitCmd)

--- a/pkg/standalone/uninstall.go
+++ b/pkg/standalone/uninstall.go
@@ -37,20 +37,21 @@ func removeContainers(uninstallPlacementContainer, uninstallAll bool, dockerNetw
 }
 
 func removeDockerContainer(containerErrs []error, containerName, network string) []error {
-	exists, _ := confirmContainerIsRunningOrExists(containerName, false)
+	container := utils.CreateContainerName(containerName, network)
+	exists, _ := confirmContainerIsRunningOrExists(container, false)
 	if !exists {
-		print.WarningStatusEvent(os.Stdout, "WARNING: %s container does not exist", containerName)
+		print.WarningStatusEvent(os.Stdout, "WARNING: %s container does not exist", container)
 		return containerErrs
 	}
-	print.InfoStatusEvent(os.Stdout, "Removing container: %s", containerName)
+	print.InfoStatusEvent(os.Stdout, "Removing container: %s", container)
 	_, err := utils.RunCmdAndWait(
 		"docker", "rm",
 		"--force",
-		utils.CreateContainerName(containerName, network))
+		container)
 	if err != nil {
 		containerErrs = append(
 			containerErrs,
-			fmt.Errorf("could not remove %s container: %s", containerName, err))
+			fmt.Errorf("could not remove %s container: %s", container, err))
 	}
 	return containerErrs
 }


### PR DESCRIPTION
# Description

Changes made: 
1. remove redis-host flag and environment var binding. 
2. remove install-path environment binding, since that flag is no longer there. 
3. fix uninstall when network specified, check for the right container name and remove it.
4. print right container name on dapr init when network specified. 
5. write configuration files with network aliases when network specified, localhost otherwise.


```
$  ./dist/darwin_amd64/release/dapr init --network mynet
⌛  Making the jump to hyperspace...
→  Downloading binaries and setting up components...
Dapr runtime installed to ~/.dapr/bin, you may run the following to add it to your path if you want to run daprd directly:
    export PATH=$PATH:~/.dapr/bin
✅  Downloaded binaries and completed components set up.
ℹ️  daprd binary has been installed to ~/.dapr/bin.
ℹ️  dapr_placement_mynet container is running.
ℹ️  dapr_redis_mynet container is running.
ℹ️  dapr_zipkin_mynet container is running.
ℹ️  Use `docker ps` to check running containers.
✅  Success! Dapr is up and running. To get started, go here: https://aka.ms/dapr-getting-started


$ ./dist/darwin_amd64/release/dapr uninstall --all --network mynet
ℹ️  Removing Dapr from your machine...
ℹ️  Removing directory: ~/.dapr/bin
ℹ️  Removing container: dapr_placement_mynet
ℹ️  Removing container: dapr_redis_mynet
ℹ️  Removing container: dapr_zipkin_mynet
ℹ️  Removing directory: ~/.dapr
✅  Dapr has been removed successfully
```


Connecting to the services from another container running in the same docker network.
```
# telnet localhost 9411
Trying 127.0.0.1...
Trying ::1...
telnet: Unable to connect to remote host: Cannot assign requested address
# telnet dapr_zipkin 9411
Trying 172.18.0.2...
Connected to dapr_zipkin.
Escape character is '^]'.
^]
telnet> quit
Connection closed.


# telnet localhost 6379
Trying 127.0.0.1...
Trying ::1...
telnet: Unable to connect to remote host: Cannot assign requested address
# telnet dapr_redis 6379
Trying 172.18.0.3...
Connected to dapr_redis.
Escape character is '^]'.
^]
telnet> quit
Connection closed.
```

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #418 
closes #540 
## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [ ] Created/updated tests
* [x] Extended the documentation Will update https://github.com/dapr/docs/pull/992
