### PR TITLE
Preserve daprd log output

### DIFF
--- a/cmd/run.go
+++ b/cmd/run.go
@@ -102,31 +102,8 @@ var RunCmd = &cobra.Command{
 					output.DaprHTTPPort,
 					output.DaprGRPCPort))
 
-			stdErrPipe, pipeErr := output.DaprCMD.StderrPipe()
-			if pipeErr != nil {
-				print.FailureStatusEvent(os.Stdout, fmt.Sprintf("Error creating stderr for Dapr: %s", err.Error()))
-				os.Exit(1)
-			}
-
-			stdOutPipe, pipeErr := output.DaprCMD.StdoutPipe()
-			if pipeErr != nil {
-				print.FailureStatusEvent(os.Stdout, fmt.Sprintf("Error creating stdout for Dapr: %s", err.Error()))
-				os.Exit(1)
-			}
-
-			errScanner := bufio.NewScanner(stdErrPipe)
-			outScanner := bufio.NewScanner(stdOutPipe)
-			go func() {
-				for errScanner.Scan() {
-					fmt.Println(print.Yellow(fmt.Sprintf("== DAPR == %s\n", errScanner.Text())))
-				}
-			}()
-
-			go func() {
-				for outScanner.Scan() {
-					fmt.Println(print.Yellow(fmt.Sprintf("== DAPR == %s\n", outScanner.Text())))
-				}
-			}()
+			output.DaprCMD.Stdout = os.Stdout
+			output.DaprCMD.Stderr = os.Stderr
 
 			err = output.DaprCMD.Start()
 			if err != nil {


### PR DESCRIPTION
Fixes https://github.com/dapr/cli/issues/484

This PR preserves the output format from the `daprd` process. After this change, logs now look like this:

<a href="https://ibb.co/80xnK5m"><img src="https://i.ibb.co/g3WbjTr/Screen-Shot-2020-12-15-at-10-37-56-AM.png" alt="Screen-Shot-2020-12-15-at-10-37-56-AM" border="0"></a>