### PR TITLE
Add dapr upgrade command

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,6 +211,18 @@ To remove Dapr from your Kubernetes cluster, use the `uninstall` command with `-
 $ dapr uninstall -k
 ```
 
+### Upgrade Dapr on Kubernetes
+
+To perform a zero downtime upgrade of the Dapr control plane:
+
+```
+$ dapr upgrade -k --runtime-version=1.0.0-rc.2  
+```
+
+The example above shows how to upgrade from your current version to version `1.0.0-rc.2`.
+
+*Note: do not use the `dapr upgrade` command if you're upgrading from 0.x versions of Dapr*
+
 ### Launch Dapr and your app
 
 The Dapr CLI lets you debug easily by launching both Dapr and your app.

--- a/README.md
+++ b/README.md
@@ -173,7 +173,7 @@ $ dapr uninstall --network dapr-network
 
 The init command will install Dapr to a Kubernetes cluster. For more advanced use cases, use our [Helm Chart](https://github.com/dapr/dapr/tree/master/charts/dapr).
 
-*Note: The default namespace is dapr-system*
+*Note: The default namespace is dapr-system. The installation will appear under the name `dapr` for Helm*
 
 ```
 $ dapr init -k

--- a/cmd/upgrade.go
+++ b/cmd/upgrade.go
@@ -39,5 +39,8 @@ func init() {
 	UpgradeCmd.Flags().StringVarP(&runtimeVersion, "runtime-version", "", "latest", "The version of the Dapr runtime to upgrade to, for example: 1.0.0")
 	UpgradeCmd.Flags().BoolP("help", "h", false, "Print this help message")
 
+	UpgradeCmd.MarkFlagRequired("runtime-version")
+	UpgradeCmd.MarkFlagRequired("kubernetes")
+
 	RootCmd.AddCommand(UpgradeCmd)
 }

--- a/cmd/upgrade.go
+++ b/cmd/upgrade.go
@@ -36,7 +36,7 @@ dapr upgrade -k
 
 func init() {
 	UpgradeCmd.Flags().BoolVarP(&kubernetesMode, "kubernetes", "k", false, "Upgrade Dapr in a Kubernetes cluster")
-	UpgradeCmd.Flags().StringVarP(&runtimeVersion, "runtime-version", "", "latest", "The version of the Dapr runtime to upgrade to, for example: 1.0.0")
+	UpgradeCmd.Flags().StringVarP(&runtimeVersion, "runtime-version", "", "", "The version of the Dapr runtime to upgrade to, for example: 1.0.0")
 	UpgradeCmd.Flags().BoolP("help", "h", false, "Print this help message")
 
 	UpgradeCmd.MarkFlagRequired("runtime-version")

--- a/cmd/upgrade.go
+++ b/cmd/upgrade.go
@@ -1,0 +1,43 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+// ------------------------------------------------------------
+
+package cmd
+
+import (
+	"os"
+
+	"github.com/dapr/cli/pkg/kubernetes"
+	"github.com/dapr/cli/pkg/print"
+	"github.com/spf13/cobra"
+)
+
+var UpgradeCmd = &cobra.Command{
+	Use:   "upgrade",
+	Short: "Upgrades a Dapr control plane installation in a cluster. Supported platforms: Kubernetes",
+	Example: `
+# Upgrade Dapr in Kubernetes
+dapr upgrade -k
+
+# See more at: https://docs.dapr.io/getting-started/
+`,
+	Run: func(cmd *cobra.Command, args []string) {
+		err := kubernetes.Upgrade(kubernetes.UpgradeConfig{
+			RuntimeVersion: runtimeVersion,
+		})
+		if err != nil {
+			print.FailureStatusEvent(os.Stdout, "Failed to upgrade Dapr: %s", err)
+			return
+		}
+		print.SuccessStatusEvent(os.Stdout, "Dapr control plane successfully upgraded to version %s. Make sure your deployments are restarted to pick up the latest sidecar version.", runtimeVersion)
+	},
+}
+
+func init() {
+	UpgradeCmd.Flags().BoolVarP(&kubernetesMode, "kubernetes", "k", false, "Upgrade Dapr in a Kubernetes cluster")
+	UpgradeCmd.Flags().StringVarP(&runtimeVersion, "runtime-version", "", "latest", "The version of the Dapr runtime to upgrade to, for example: 1.0.0")
+	UpgradeCmd.Flags().BoolP("help", "h", false, "Print this help message")
+
+	RootCmd.AddCommand(UpgradeCmd)
+}

--- a/go.mod
+++ b/go.mod
@@ -26,6 +26,7 @@ require (
 	gopkg.in/yaml.v2 v2.3.0
 	helm.sh/helm/v3 v3.4.0
 	k8s.io/api v0.20.0
+	k8s.io/apiextensions-apiserver v0.20.0
 	k8s.io/apimachinery v0.20.0
 	k8s.io/cli-runtime v0.20.0
 	k8s.io/client-go v0.20.0

--- a/pkg/kubernetes/upgrade.go
+++ b/pkg/kubernetes/upgrade.go
@@ -48,7 +48,7 @@ func Upgrade(conf UpgradeConfig) error {
 	}
 
 	if len(status) == 0 {
-		return errors.New("Dapr is not installed in your cluster")
+		return errors.New("dapr is not installed in your cluster")
 	}
 
 	print.InfoStatusEvent(os.Stdout, "Dapr control plane version %s detected", status[0].Version)
@@ -69,9 +69,9 @@ func Upgrade(conf UpgradeConfig) error {
 	var vals map[string]interface{}
 
 	if mtls {
-		secret, err := getTrustChainSecret()
-		if err != nil {
-			return err
+		secret, sErr := getTrustChainSecret()
+		if sErr != nil {
+			return sErr
 		}
 
 		ca := secret.Data["ca.crt"]

--- a/pkg/kubernetes/upgrade.go
+++ b/pkg/kubernetes/upgrade.go
@@ -27,16 +27,6 @@ type UpgradeConfig struct {
 }
 
 func Upgrade(conf UpgradeConfig) error {
-	helmConf, err := helmConfig("dapr-system")
-	if err != nil {
-		return err
-	}
-
-	daprChart, err := daprChart(conf.RuntimeVersion, helmConf)
-	if err != nil {
-		return err
-	}
-
 	sc, err := NewStatusClient()
 	if err != nil {
 		return err
@@ -52,6 +42,16 @@ func Upgrade(conf UpgradeConfig) error {
 	}
 
 	print.InfoStatusEvent(os.Stdout, "Dapr control plane version %s detected", status[0].Version)
+
+	helmConf, err := helmConfig(status[0].Namespace)
+	if err != nil {
+		return err
+	}
+
+	daprChart, err := daprChart(conf.RuntimeVersion, helmConf)
+	if err != nil {
+		return err
+	}
 
 	upgradeClient := helm.NewUpgrade(helmConf)
 	upgradeClient.ResetValues = true

--- a/pkg/kubernetes/upgrade.go
+++ b/pkg/kubernetes/upgrade.go
@@ -1,0 +1,123 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+// ------------------------------------------------------------
+
+package kubernetes
+
+import (
+	"errors"
+	"fmt"
+	"os"
+
+	"github.com/dapr/cli/pkg/print"
+	"github.com/dapr/cli/utils"
+	helm "helm.sh/helm/v3/pkg/action"
+	"k8s.io/helm/pkg/strvals"
+)
+
+var crds = []string{
+	"components",
+	"configuration",
+	"subscription",
+}
+
+type UpgradeConfig struct {
+	RuntimeVersion string
+}
+
+func Upgrade(conf UpgradeConfig) error {
+	helmConf, err := helmConfig("dapr-system")
+	if err != nil {
+		return err
+	}
+
+	daprChart, err := daprChart(conf.RuntimeVersion, helmConf)
+	if err != nil {
+		return err
+	}
+
+	sc, err := NewStatusClient()
+	if err != nil {
+		return err
+	}
+
+	status, err := sc.Status()
+	if err != nil {
+		return err
+	}
+
+	if len(status) == 0 {
+		return errors.New("Dapr is not installed in your cluster")
+	}
+
+	print.InfoStatusEvent(os.Stdout, "Dapr control plane version %s detected", status[0].Version)
+
+	upgradeClient := helm.NewUpgrade(helmConf)
+	upgradeClient.ResetValues = true
+	upgradeClient.Namespace = status[0].Namespace
+	upgradeClient.CleanupOnFail = true
+	upgradeClient.Wait = true
+
+	print.InfoStatusEvent(os.Stdout, "Starting upgrade...")
+
+	mtls, err := IsMTLSEnabled()
+	if err != nil {
+		return err
+	}
+
+	var vals map[string]interface{}
+
+	if mtls {
+		secret, err := getTrustChainSecret()
+		if err != nil {
+			return err
+		}
+
+		ca := secret.Data["ca.crt"]
+		issuerCert := secret.Data["issuer.crt"]
+		issuerKey := secret.Data["issuer.key"]
+
+		vals, err = mtlsChartValues(string(ca), string(issuerCert), string(issuerKey))
+		if err != nil {
+			return err
+		}
+	}
+
+	err = applyCRDs(fmt.Sprintf("v%s", conf.RuntimeVersion))
+	if err != nil {
+		return err
+	}
+
+	if _, err = upgradeClient.Run("dapr", daprChart, vals); err != nil {
+		return err
+	}
+	return nil
+}
+
+func applyCRDs(version string) error {
+	for _, crd := range crds {
+		url := fmt.Sprintf("https://raw.githubusercontent.com/dapr/dapr/%s/charts/dapr/crds/%s.yaml", version, crd)
+		_, err := utils.RunCmdAndWait("kubectl", "apply", "-f", url)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func mtlsChartValues(ca, issuerCert, issuerKey string) (map[string]interface{}, error) {
+	chartVals := map[string]interface{}{}
+	globalVals := []string{
+		fmt.Sprintf("dapr_sentry.tls.root.certPEM=%s", ca),
+		fmt.Sprintf("dapr_sentry.tls.issuer.certPEM=%s", issuerCert),
+		fmt.Sprintf("dapr_sentry.tls.issuer.keyPEM=%s", issuerKey),
+	}
+
+	for _, v := range globalVals {
+		if err := strvals.ParseInto(v, chartVals); err != nil {
+			return nil, err
+		}
+	}
+	return chartVals, nil
+}

--- a/pkg/kubernetes/upgrade_test.go
+++ b/pkg/kubernetes/upgrade_test.go
@@ -1,0 +1,42 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+// ------------------------------------------------------------
+
+package kubernetes
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestHAMode(t *testing.T) {
+	t.Run("ha mode", func(t *testing.T) {
+		s := []StatusOutput{
+			{
+				Replicas: 3,
+			},
+		}
+
+		r := highAvailabilityEnabled(s)
+		assert.True(t, r)
+	})
+
+	t.Run("non-ha mode", func(t *testing.T) {
+		s := []StatusOutput{
+			{
+				Replicas: 1,
+			},
+		}
+
+		r := highAvailabilityEnabled(s)
+		assert.False(t, r)
+	})
+}
+
+func TestMTLSChartValues(t *testing.T) {
+	val, err := mtlsChartValues("1", "2", "3", true)
+	assert.NoError(t, err)
+	assert.Len(t, val, 2)
+}

--- a/pkg/kubernetes/upgrade_test.go
+++ b/pkg/kubernetes/upgrade_test.go
@@ -36,7 +36,7 @@ func TestHAMode(t *testing.T) {
 }
 
 func TestMTLSChartValues(t *testing.T) {
-	val, err := mtlsChartValues("1", "2", "3", true)
+	val, err := upgradeChartValues("1", "2", "3", true)
 	assert.NoError(t, err)
 	assert.Len(t, val, 2)
 }


### PR DESCRIPTION
This PR adds a `dapr upgrade -k` command that greatly simplifies the Dapr upgrade experience.

This PR handles CRD updates and certificate exports for zero downtime upgrades.

Closes https://github.com/dapr/cli/issues/560
