### PR TITLE
Add support for M1 macs with amd64 compatibility layer (#570)

### DIFF
--- a/install/install.sh
+++ b/install/install.sh
@@ -50,6 +50,14 @@ verifySupported() {
         fi
     done
 
+    if [ "$current_osarch" == "darwin-arm64" ]; then
+        echo "The darwin_arm64 arch has no native binary, however you can use the amd64 version so long as you have rosetta installed"
+        echo "Use 'softwareupdate --install-rosetta' to install rosetta if you don't already have it"
+        ARCH="amd64"
+        return
+    fi
+
+
     echo "No prebuilt binary for ${current_osarch}"
     exit 1
 }


### PR DESCRIPTION
# Description

Until we have a darwin-arm64 build available, users can still run dapr cli on M1 macs using the amd64 compatibility layer. This PR allows our install script to go ahead and install the darwin-amd64 binaries on darwin-arm64.

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #570

## Tested on an M1 mac:

```bash
 % curl -fsSL https://raw.githubusercontent.com/wcs1only/cli/mac_os_arm64/install/install.sh | /bin/bash -s 1.0.0-rc.3
The darwin_arm64 arch has no native binary, however you can use the amd64 version so long as you have rosetta installed
Use 'softwareupdate --install-rosetta' to install rosetta if you don't already have it

Dapr CLI is detected:
CLI version: 1.0.0-rc.3 
Runtime version: 1.0.0-rc.2
Reinstalling Dapr CLI - /usr/local/bin/dapr...

Installing v1.0.0-rc.3 Dapr CLI...
Downloading https://github.com/dapr/cli/releases/download/v1.0.0-rc.3/dapr_darwin_amd64.tar.gz ...
dapr installed into /usr/local/bin successfully.
CLI version: 1.0.0-rc.3 
Runtime version: 1.0.0-rc.2

To get started with Dapr, please visit https://docs.dapr.io/getting-started/
```

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [ ] Extended the documentation
