### PR TITLE
Add config file with --slim (#556)

### DIFF
--- a/pkg/standalone/standalone_test.go
+++ b/pkg/standalone/standalone_test.go
@@ -1,0 +1,54 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+// ------------------------------------------------------------
+
+package standalone
+
+import (
+	"io/ioutil"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestStandaloneConfig(t *testing.T) {
+	testFile := "./test.yaml"
+
+	t.Run("Standalone config", func(t *testing.T) {
+		expectConfigZipkin := `apiVersion: dapr.io/v1alpha1
+kind: Configuration
+metadata:
+  name: daprConfig
+spec:
+  tracing:
+    samplingRate: "1"
+    zipkin:
+      endpointAddress: http://test_zipkin_host:9411/api/v2/spans
+`
+		os.Remove(testFile)
+		createDefaultConfiguration("test_zipkin_host", testFile)
+		assert.FileExists(t, testFile)
+		content, err := ioutil.ReadFile(testFile)
+		assert.NoError(t, err)
+		assert.Equal(t, expectConfigZipkin, string(content))
+	})
+
+	t.Run("Standalone config slim", func(t *testing.T) {
+		expectConfigSlim := `apiVersion: dapr.io/v1alpha1
+kind: Configuration
+metadata:
+  name: daprConfig
+spec: {}
+`
+		os.Remove(testFile)
+		createDefaultConfiguration("", testFile)
+		assert.FileExists(t, testFile)
+		content, err := ioutil.ReadFile(testFile)
+		assert.NoError(t, err)
+		assert.Equal(t, expectConfigSlim, string(content))
+	})
+
+	os.Remove(testFile)
+}


### PR DESCRIPTION
# Description

The --slim argument will now create $HOME/.dapr/config.yaml

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #556

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Created/updated tests
* [x] Extended the documentation

## Manual Testing

```bash
willardstanley@Willards-MacBook-Pro cli % ./dist/darwin_amd64/release/dapr init --slim --runtime-version=1.0.0-rc.2         
⌛  Making the jump to hyperspace...
↓  Downloading binaries and setting up components... 
Dapr runtime installed to /Users/willardstanley/.dapr/bin, you may run the following to add it to your path if you want to run daprd directly:
    export PATH=$PATH:/Users/willardstanley/.dapr/bin
✅  Downloaded binaries and completed components set up.
ℹ️  daprd binary has been installed to /Users/willardstanley/.dapr/bin.
ℹ️  placement binary has been installed to /Users/willardstanley/.dapr/bin.
✅  Success! Dapr is up and running. To get started, go here: https://aka.ms/dapr-getting-started
willardstanley@Willards-MacBook-Pro cli % cat ~/.dapr/config.yaml 
apiVersion: dapr.io/v1alpha1
kind: Configuration
metadata:
  name: daprConfig
spec: {}
```
