### PR TITLE
fix(kubernetes/status): pod not ready state will cause panic

### DIFF
--- a/pkg/kubernetes/status.go
+++ b/pkg/kubernetes/status.go
@@ -95,13 +95,16 @@ func (s *StatusClient) Status() ([]StatusOutput, error) {
 			running := true
 
 			for _, p := range p.Items {
-				if p.Status.ContainerStatuses[0].State.Waiting != nil {
+				if len(p.Status.ContainerStatuses) == 0 {
+					status = p.Status.Phase
+				} else if p.Status.ContainerStatuses[0].State.Waiting != nil {
 					status = fmt.Sprintf("Waiting (%s)", p.Status.ContainerStatuses[0].State.Waiting.Reason)
 				} else if pod.Status.ContainerStatuses[0].State.Terminated != nil {
 					status = "Terminated"
 				}
 
-				if p.Status.ContainerStatuses[0].State.Running == nil {
+				if len(p.Status.ContainerStatuses) == 0 ||
+					p.Status.ContainerStatuses[0].State.Running == nil {
 					running = false
 
 					break

--- a/pkg/kubernetes/status.go
+++ b/pkg/kubernetes/status.go
@@ -96,7 +96,7 @@ func (s *StatusClient) Status() ([]StatusOutput, error) {
 
 			for _, p := range p.Items {
 				if len(p.Status.ContainerStatuses) == 0 {
-					status = p.Status.Phase
+					status = string(p.Status.Phase)
 				} else if p.Status.ContainerStatuses[0].State.Waiting != nil {
 					status = fmt.Sprintf("Waiting (%s)", p.Status.ContainerStatuses[0].State.Waiting.Reason)
 				} else if pod.Status.ContainerStatuses[0].State.Terminated != nil {


### PR DESCRIPTION
dapr init -k --enable-ha=true  ## use high avaliable method to install dapr

![image](https://user-images.githubusercontent.com/20457624/110579159-25deac80-81a1-11eb-92a0-edd7ffdde3a6.png)


![image](https://user-images.githubusercontent.com/20457624/110579288-735b1980-81a1-11eb-884a-3d77b93f07b8.png)

```shell
# delete pvc
kubectl delete pvc raft-log-dapr-placement-server-0 -n dapr-system
kubectl delete pvc raft-log-dapr-placement-server-1 -n dapr-system
kubectl delete pvc raft-log-dapr-placement-server-2 -n dapr-system

apiVersion: v1
kind: PersistentVolumeClaim
metadata:
  name: raft-log-dapr-placement-server-0
  annotations:
    volume.beta.kubernetes.io/storage-provisioner: cloud.tencent.com/xxx
  finalizers:
  - kubernetes.io/pvc-protection
  labels:
    app: dapr-placement-server
spec:
  accessModes:
  - ReadWriteOnce
  resources:
    requests:
      storage: 10Gi
  storageClassName: cbs
  volumeMode: Filesystem
-----------------------------------------------------------------
apiVersion: v1
kind: PersistentVolumeClaim
metadata:
  name: raft-log-dapr-placement-server-1
  annotations:
    volume.beta.kubernetes.io/storage-provisioner: cloud.tencent.com/xxx
  finalizers:
  - kubernetes.io/pvc-protection
  labels:
    app: dapr-placement-server
spec:
  accessModes:
  - ReadWriteOnce
  resources:
    requests:
      storage: 10Gi
  storageClassName: cbs
  volumeMode: Filesystem
---------------------------------------------------------------
apiVersion: v1
kind: PersistentVolumeClaim
metadata:
  name: raft-log-dapr-placement-server-2
  annotations:
    volume.beta.kubernetes.io/storage-provisioner: cloud.tencent.com/xxx
  finalizers:
  - kubernetes.io/pvc-protection
  labels:
    app: dapr-placement-server
spec:
  accessModes:
  - ReadWriteOnce
  resources:
    requests:
      storage: 10Gi
  storageClassName: cbs
  volumeMode: Filesystem
```

kubectl apply -f raft-log-dapr-placement-server-0 raft-log-dapr-placement-server-1 raft-log-dapr-placement-server-2 -n dapr-system

![image](https://user-images.githubusercontent.com/20457624/110579531-fc725080-81a1-11eb-8440-1b8c883f3252.png)
