### PR TITLE
Fix crd deletions on upgrades

### DIFF
--- a/pkg/kubernetes/upgrade.go
+++ b/pkg/kubernetes/upgrade.go
@@ -133,19 +133,6 @@ func highAvailabilityEnabled(status []StatusOutput) bool {
 }
 
 func applyCRDs(version string) error {
-	l := []string{
-		"components.dapr.io",
-		"configurations.dapr.io",
-		"subscriptions.dapr.io",
-	}
-
-	for _, c := range l {
-		_, err := utils.RunCmdAndWait("kubectl", "delete", "crd", c)
-		if err != nil {
-			return err
-		}
-	}
-
 	for _, crd := range crds {
 		url := fmt.Sprintf("https://raw.githubusercontent.com/dapr/dapr/%s/charts/dapr/crds/%s.yaml", version, crd)
 		_, err := utils.RunCmdAndWait("kubectl", "apply", "-f", url)


### PR DESCRIPTION
Fixes https://github.com/dapr/cli/issues/622

I've tested this works for the following scenarios:

1. CLI init --> CLI upgrade
2. Helm install --> CLI upgrade
3. CLI init --> Helm upgrade (and manual CRD change, as Helm doesn't update CRDs)

This PR removes the deletion of the CRDs which make the owner references kick in and delete all the associated instances.

In addition, I've verified that the upgrade path described in [this](https://github.com/dapr/cli/issues/601) issue also works.

My hypothesis is that the failure described in #601 happened because of CRDs pre 1.0.0-rc.x being registered in the system, as installing rc-1.0.0-rc.3 wouldn't have updated the CRDs at that time.