### PR TITLE
Add --wait amd --timeout flags for dapr init -k which are passed to Helm

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,6 +211,12 @@ $ dapr init -k --enable-ha=true
 $ dapr init -k --enable-mtls=false
 ```
 
+#### Waiting for the Helm install to complete
+
+```
+$ dapr init -k --wait
+```
+
 #### Uninstall Dapr on Kubernetes
 
 To remove Dapr from your Kubernetes cluster, use the `uninstall` command with `--kubernetes` flag or the `-k` shorthand.

--- a/README.md
+++ b/README.md
@@ -211,10 +211,10 @@ $ dapr init -k --enable-ha=true
 $ dapr init -k --enable-mtls=false
 ```
 
-#### Waiting for the Helm install to complete
+#### Waiting for the Helm install to complete (default timeout is 300s/5m)
 
 ```
-$ dapr init -k --wait
+$ dapr init -k --wait --timeout 600
 ```
 
 #### Uninstall Dapr on Kubernetes
@@ -223,6 +223,12 @@ To remove Dapr from your Kubernetes cluster, use the `uninstall` command with `-
 
 ```
 $ dapr uninstall -k
+```
+
+The default timeout is 300s/5m and can be overridden using the `--timeout` flag.
+
+```
+$ dapr uninstall -k --timeout 600
 ```
 
 ### Upgrade Dapr on Kubernetes

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -42,7 +42,7 @@ dapr init
 # Initialize Dapr in Kubernetes
 dapr init -k
 
-# Initialize Dapr in Kubernetes and wait for the installation to complete up to 5 minutes
+# Initialize Dapr in Kubernetes and wait for the installation to complete (default timeout is 300s/5m)
 dapr init -k --wait --timeout 300
 
 # Initialize particular Dapr runtime in self-hosted mode
@@ -95,7 +95,7 @@ dapr init -s
 func init() {
 	InitCmd.Flags().BoolVarP(&kubernetesMode, "kubernetes", "k", false, "Deploy Dapr to a Kubernetes cluster")
 	InitCmd.Flags().BoolVarP(&wait, "wait", "", false, "Wait for Kubernetes initialization to complete")
-	InitCmd.Flags().UintVarP(&timeout, "timeout", "", 300, "The timeout for the Kubernetes installation")
+	InitCmd.Flags().UintVarP(&timeout, "timeout", "", 300, "The wait timeout for the Kubernetes installation")
 	InitCmd.Flags().BoolVarP(&slimMode, "slim", "s", false, "Exclude placement service, Redis and Zipkin containers from self-hosted installation")
 	InitCmd.Flags().StringVarP(&runtimeVersion, "runtime-version", "", "latest", "The version of the Dapr runtime to install, for example: 1.0.0")
 	InitCmd.Flags().StringVarP(&dashboardVersion, "dashboard-version", "", "latest", "The version of the Dapr dashboard to install, for example: 1.0.0")

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -43,7 +43,7 @@ dapr init
 dapr init -k
 
 # Initialize Dapr in Kubernetes and wait for the installation to complete (default timeout is 300s/5m)
-dapr init -k --wait --timeout 300
+dapr init -k --wait --timeout 600
 
 # Initialize particular Dapr runtime in self-hosted mode
 dapr init --runtime-version 0.10.0

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -18,6 +18,7 @@ import (
 
 var (
 	kubernetesMode   bool
+	wait             bool
 	slimMode         bool
 	runtimeVersion   string
 	dashboardVersion string
@@ -39,6 +40,9 @@ dapr init
 
 # Initialize Dapr in Kubernetes
 dapr init -k
+
+# Initialize Dapr in Kubernetes and wait for the installation to complete
+dapr init -k --wait
 
 # Initialize particular Dapr runtime in self-hosted mode
 dapr init --runtime-version 0.10.0
@@ -63,6 +67,7 @@ dapr init -s
 				EnableMTLS: enableMTLS,
 				EnableHA:   enableHA,
 				Args:       values,
+				Wait:       wait,
 			}
 			err := kubernetes.Init(config)
 			if err != nil {
@@ -87,6 +92,7 @@ dapr init -s
 
 func init() {
 	InitCmd.Flags().BoolVarP(&kubernetesMode, "kubernetes", "k", false, "Deploy Dapr to a Kubernetes cluster")
+	InitCmd.Flags().BoolVarP(&wait, "wait", "", false, "Wait for Kubernetes initialization to complete")
 	InitCmd.Flags().BoolVarP(&slimMode, "slim", "s", false, "Exclude placement service, Redis and Zipkin containers from self-hosted installation")
 	InitCmd.Flags().StringVarP(&runtimeVersion, "runtime-version", "", "latest", "The version of the Dapr runtime to install, for example: 1.0.0")
 	InitCmd.Flags().StringVarP(&dashboardVersion, "dashboard-version", "", "latest", "The version of the Dapr dashboard to install, for example: 1.0.0")

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -19,6 +19,7 @@ import (
 var (
 	kubernetesMode   bool
 	wait             bool
+	timeout          uint
 	slimMode         bool
 	runtimeVersion   string
 	dashboardVersion string
@@ -41,8 +42,8 @@ dapr init
 # Initialize Dapr in Kubernetes
 dapr init -k
 
-# Initialize Dapr in Kubernetes and wait for the installation to complete
-dapr init -k --wait
+# Initialize Dapr in Kubernetes and wait for the installation to complete up to 5 minutes
+dapr init -k --wait --timeout 300
 
 # Initialize particular Dapr runtime in self-hosted mode
 dapr init --runtime-version 0.10.0
@@ -68,6 +69,7 @@ dapr init -s
 				EnableHA:   enableHA,
 				Args:       values,
 				Wait:       wait,
+				Timeout:    timeout,
 			}
 			err := kubernetes.Init(config)
 			if err != nil {
@@ -93,6 +95,7 @@ dapr init -s
 func init() {
 	InitCmd.Flags().BoolVarP(&kubernetesMode, "kubernetes", "k", false, "Deploy Dapr to a Kubernetes cluster")
 	InitCmd.Flags().BoolVarP(&wait, "wait", "", false, "Wait for Kubernetes initialization to complete")
+	InitCmd.Flags().UintVarP(&timeout, "timeout", "", 300, "The timeout for the Kubernetes installation")
 	InitCmd.Flags().BoolVarP(&slimMode, "slim", "s", false, "Exclude placement service, Redis and Zipkin containers from self-hosted installation")
 	InitCmd.Flags().StringVarP(&runtimeVersion, "runtime-version", "", "latest", "The version of the Dapr runtime to install, for example: 1.0.0")
 	InitCmd.Flags().StringVarP(&dashboardVersion, "dashboard-version", "", "latest", "The version of the Dapr dashboard to install, for example: 1.0.0")

--- a/cmd/uninstall.go
+++ b/cmd/uninstall.go
@@ -45,7 +45,7 @@ dapr uninstall -k
 
 		if uninstallKubernetes {
 			print.InfoStatusEvent(os.Stdout, "Removing Dapr from your cluster...")
-			err = kubernetes.Uninstall(uninstallNamespace)
+			err = kubernetes.Uninstall(uninstallNamespace, timeout)
 		} else {
 			print.InfoStatusEvent(os.Stdout, "Removing Dapr from your machine...")
 			dockerNetwork := viper.GetString("network")
@@ -62,6 +62,7 @@ dapr uninstall -k
 
 func init() {
 	UninstallCmd.Flags().BoolVarP(&uninstallKubernetes, "kubernetes", "k", false, "Uninstall Dapr from a Kubernetes cluster")
+	UninstallCmd.Flags().UintVarP(&timeout, "timeout", "", 300, "The timeout for the Kubernetes uninstall")
 	UninstallCmd.Flags().BoolVar(&uninstallAll, "all", false, "Remove .dapr directory, Redis, Placement and Zipkin containers")
 	UninstallCmd.Flags().String("network", "", "The Docker network from which to remove the Dapr runtime")
 	UninstallCmd.Flags().StringVarP(&uninstallNamespace, "namespace", "n", "dapr-system", "The Kubernetes namespace to uninstall Dapr from")

--- a/cmd/upgrade.go
+++ b/cmd/upgrade.go
@@ -28,6 +28,7 @@ dapr upgrade -k
 		err := kubernetes.Upgrade(kubernetes.UpgradeConfig{
 			RuntimeVersion: upgradeRuntimeVersion,
 			Args:           values,
+			Timeout:        timeout,
 		})
 		if err != nil {
 			print.FailureStatusEvent(os.Stdout, "Failed to upgrade Dapr: %s", err)
@@ -39,6 +40,7 @@ dapr upgrade -k
 
 func init() {
 	UpgradeCmd.Flags().BoolVarP(&kubernetesMode, "kubernetes", "k", false, "Upgrade Dapr in a Kubernetes cluster")
+	UpgradeCmd.Flags().UintVarP(&timeout, "timeout", "", 300, "The timeout for the Kubernetes upgrade")
 	UpgradeCmd.Flags().StringVarP(&upgradeRuntimeVersion, "runtime-version", "", "", "The version of the Dapr runtime to upgrade to, for example: 1.0.0")
 	UpgradeCmd.Flags().BoolP("help", "h", false, "Print this help message")
 	UpgradeCmd.Flags().StringArrayVar(&values, "set", []string{}, "set values on the command line (can specify multiple or separate values with commas: key1=val1,key2=val2)")

--- a/pkg/kubernetes/kubernetes.go
+++ b/pkg/kubernetes/kubernetes.go
@@ -39,6 +39,7 @@ type InitConfiguration struct {
 	EnableHA   bool
 	Args       []string
 	Wait       bool
+	Timeout    uint
 }
 
 // Init deploys the Dapr operator using the supplied runtime version.
@@ -177,6 +178,7 @@ func install(config InitConfiguration) error {
 	installClient.ReleaseName = daprReleaseName
 	installClient.Namespace = config.Namespace
 	installClient.Wait = config.Wait
+	installClient.Timeout = time.Duration(config.Timeout) * time.Second
 
 	values, err := chartValues(config)
 	if err != nil {

--- a/pkg/kubernetes/kubernetes.go
+++ b/pkg/kubernetes/kubernetes.go
@@ -38,6 +38,7 @@ type InitConfiguration struct {
 	EnableMTLS bool
 	EnableHA   bool
 	Args       []string
+	Wait       bool
 }
 
 // Init deploys the Dapr operator using the supplied runtime version.
@@ -175,6 +176,10 @@ func install(config InitConfiguration) error {
 	installClient := helm.NewInstall(helmConf)
 	installClient.ReleaseName = daprReleaseName
 	installClient.Namespace = config.Namespace
+	if config.Wait {
+		installClient.Wait = true
+		installClient.Timeout = 5 * time.Minute
+	}
 
 	values, err := chartValues(config)
 	if err != nil {

--- a/pkg/kubernetes/kubernetes.go
+++ b/pkg/kubernetes/kubernetes.go
@@ -11,6 +11,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"time"
 
 	"github.com/dapr/cli/pkg/print"
 	helm "helm.sh/helm/v3/pkg/action"

--- a/pkg/kubernetes/kubernetes.go
+++ b/pkg/kubernetes/kubernetes.go
@@ -176,10 +176,7 @@ func install(config InitConfiguration) error {
 	installClient := helm.NewInstall(helmConf)
 	installClient.ReleaseName = daprReleaseName
 	installClient.Namespace = config.Namespace
-	if config.Wait {
-		installClient.Wait = true
-		installClient.Timeout = 5 * time.Minute
-	}
+	installClient.Wait = config.Wait
 
 	values, err := chartValues(config)
 	if err != nil {

--- a/pkg/kubernetes/uninstall.go
+++ b/pkg/kubernetes/uninstall.go
@@ -6,17 +6,20 @@
 package kubernetes
 
 import (
+	"time"
+
 	helm "helm.sh/helm/v3/pkg/action"
 )
 
 // Uninstall removes Dapr from a Kubernetes cluster.
-func Uninstall(namespace string) error {
+func Uninstall(namespace string, timeout uint) error {
 	config, err := helmConfig(namespace)
 	if err != nil {
 		return err
 	}
 
 	uninstallClient := helm.NewUninstall(config)
+	uninstallClient.Timeout = time.Duration(timeout) * time.Second
 	_, err = uninstallClient.Run(daprReleaseName)
 	return err
 }

--- a/pkg/kubernetes/upgrade.go
+++ b/pkg/kubernetes/upgrade.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"os"
 	"strings"
+	"time"
 
 	"github.com/dapr/cli/pkg/print"
 	"github.com/dapr/cli/utils"
@@ -28,6 +29,7 @@ var crds = []string{
 type UpgradeConfig struct {
 	RuntimeVersion string
 	Args           []string
+	Timeout        uint
 }
 
 func Upgrade(conf UpgradeConfig) error {
@@ -68,6 +70,7 @@ func Upgrade(conf UpgradeConfig) error {
 	upgradeClient.Namespace = status[0].Namespace
 	upgradeClient.CleanupOnFail = true
 	upgradeClient.Wait = true
+	upgradeClient.Timeout = time.Duration(conf.Timeout) * time.Second
 
 	print.InfoStatusEvent(os.Stdout, "Starting upgrade...")
 


### PR DESCRIPTION
# Description

This PR adds:

* The `--wait` and `--timeout` flags to `dapr init`
* The `--timeout` flag to `dapr upgrade` and `dapr uninstall` (These two commands already wait so the desired behavior described in the issue #597 is already implemented).

This will be tested in an upcoming PR that will add e2e tests per #412.

## Issue reference

Resolves #597

## Checklist

* [x] Code compiles correctly
* [ ] Created/updated tests
* [x] Extended the documentation
