### PR TITLE
Use a named event for dapr stop on Windows (#631)

### DIFF
--- a/cmd/run.go
+++ b/cmd/run.go
@@ -9,10 +9,8 @@ import (
 	"bufio"
 	"fmt"
 	"os"
-	"os/signal"
 	"strconv"
 	"strings"
-	"syscall"
 	"time"
 
 	"github.com/dapr/cli/pkg/metadata"
@@ -90,7 +88,7 @@ var RunCmd = &cobra.Command{
 		}
 
 		sigCh := make(chan os.Signal, 1)
-		signal.Notify(sigCh, syscall.SIGTERM, syscall.SIGINT)
+		setupShutdownNotify(sigCh)
 
 		daprRunning := make(chan bool, 1)
 		appRunning := make(chan bool, 1)

--- a/cmd/shutdown.go
+++ b/cmd/shutdown.go
@@ -1,0 +1,18 @@
+// +build !windows
+
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation and Dapr Contributors.
+// Licensed under the MIT License.
+// ------------------------------------------------------------
+
+package cmd
+
+import (
+	"os"
+	"os/signal"
+	"syscall"
+)
+
+func setupShutdownNotify(sigCh chan os.Signal) {
+	signal.Notify(sigCh, syscall.SIGTERM, syscall.SIGINT)
+}

--- a/cmd/shutdown_windows.go
+++ b/cmd/shutdown_windows.go
@@ -1,0 +1,34 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation and Dapr Contributors.
+// Licensed under the MIT License.
+// ------------------------------------------------------------
+
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"os/signal"
+	"syscall"
+
+	"github.com/dapr/cli/pkg/print"
+	"golang.org/x/sys/windows"
+)
+
+func setupShutdownNotify(sigCh chan os.Signal){
+	//This will catch Ctrl-C
+	signal.Notify(sigCh, syscall.SIGTERM, syscall.SIGINT)
+
+	// Unlike Linux/Mac, you can't just send a SIGTERM from another process
+	// In order for 'dapr stop' to be able to signal gracefully we must use a named event in Windows
+	go func() {
+		eventName, _ := syscall.UTF16FromString(fmt.Sprintf("dapr_cli_%v", os.Getpid()))
+		eventHandle, _ := windows.CreateEvent(nil, 0, 0, &eventName[0])
+		_, err := windows.WaitForSingleObject(eventHandle, windows.INFINITE)
+		if err != nil {
+			print.WarningStatusEvent(os.Stdout, "Unable to wait for shutdown event. 'dapr stop' will not work. Error: %s", err.Error())
+			return
+		}
+		sigCh <- os.Interrupt
+	}()
+}

--- a/go.mod
+++ b/go.mod
@@ -23,6 +23,7 @@ require (
 	github.com/spf13/cobra v1.1.1
 	github.com/spf13/viper v1.7.0
 	github.com/stretchr/testify v1.6.1
+	golang.org/x/sys v0.0.0-20210319071255-635bc2c9138d // indirect
 	gopkg.in/yaml.v2 v2.3.0
 	helm.sh/helm/v3 v3.4.0
 	k8s.io/api v0.20.0


### PR DESCRIPTION
# Description

Windows doesn't have an easy SIGTERM equivalent, so we use a named event to signal Windows to stop Dapr gracefully.

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #631 

## Manual Testing
Without this change (run `dapr stop --app-id` in another terminal):

```bash
You're up and running! Both Dapr and your app logs will appear here.


C:\Users\Charlie\quickstarts\hello-world>echo %ERRORLEVEL%
1
```

With this change (run `dapr stop --app-id` in another terminal):

```bash
You're up and running! Both Dapr and your app logs will appear here.


terminated signal received: shutting down
Exited Dapr successfully
Exited App successfully

C:\Users\Charlie\quickstarts\hello-world>echo %ERRORLEVEL%
0
```
## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [ ] Created/updated tests
* [ ] Extended the documentation
