### PR TITLE
Fix Apple Silicon (M1) install.

### DIFF
--- a/install/install.sh
+++ b/install/install.sh
@@ -34,7 +34,7 @@ getSystemInfo() {
     OS=$(echo `uname`|tr '[:upper:]' '[:lower:]')
 
     # Most linux distro needs root permission to copy the file to /usr/local/bin
-    if [ "$OS" == "linux" ] && [ "$DAPR_INSTALL_DIR" == "/usr/local/bin" ]; then
+    if [[ "$OS" == "linux" || "$OS" == "darwin" ]] && [ "$DAPR_INSTALL_DIR" == "/usr/local/bin" ]; then
         USE_SUDO="true"
     fi
 }


### PR DESCRIPTION
# Description

On the MacBook Pro with Apple Silicon (M1), `uname` returns `darwin`. However, the script (line 37) only looked for `linux`, resulting in the install not running with `sudo`. The fix includes checking for `darwin` so the script will have the proper permission to write in `/usr/local/bin`.

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #634

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Created/updated tests
* [x] Extended the documentation
