### PR TITLE
Added version to component spec

### DIFF
--- a/pkg/standalone/standalone.go
+++ b/pkg/standalone/standalone.go
@@ -814,7 +814,7 @@ func createRedisStateStore(redisHost string, componentsPath string) error {
 
 	redisStore.Metadata.Name = "statestore"
 	redisStore.Spec.Type = "state.redis"
-	redisStore.Spec.Version = "v1.0"
+	redisStore.Spec.Version = "v1"
 	redisStore.Spec.Metadata = []componentMetadataItem{
 		{
 			Name:  "redisHost",
@@ -849,7 +849,7 @@ func createRedisPubSub(redisHost string, componentsPath string) error {
 
 	redisPubSub.Metadata.Name = "pubsub"
 	redisPubSub.Spec.Type = "pubsub.redis"
-	redisPubSub.Spec.Version = "v1.0"
+	redisPubSub.Spec.Version = "v1"
 	redisPubSub.Spec.Metadata = []componentMetadataItem{
 		{
 			Name:  "redisHost",

--- a/pkg/standalone/standalone.go
+++ b/pkg/standalone/standalone.go
@@ -74,6 +74,7 @@ type component struct {
 	} `yaml:"metadata"`
 	Spec struct {
 		Type     string                  `yaml:"type"`
+		Version  string                  `yaml:"version"`
 		Metadata []componentMetadataItem `yaml:"metadata"`
 	} `yaml:"spec"`
 }
@@ -813,6 +814,7 @@ func createRedisStateStore(redisHost string, componentsPath string) error {
 
 	redisStore.Metadata.Name = "statestore"
 	redisStore.Spec.Type = "state.redis"
+	redisStore.Spec.Version = "v1.0"
 	redisStore.Spec.Metadata = []componentMetadataItem{
 		{
 			Name:  "redisHost",
@@ -847,6 +849,7 @@ func createRedisPubSub(redisHost string, componentsPath string) error {
 
 	redisPubSub.Metadata.Name = "pubsub"
 	redisPubSub.Spec.Type = "pubsub.redis"
+	redisPubSub.Spec.Version = "v1.0"
 	redisPubSub.Spec.Metadata = []componentMetadataItem{
 		{
 			Name:  "redisHost",

--- a/pkg/standalone/standalone_test.go
+++ b/pkg/standalone/standalone_test.go
@@ -8,6 +8,7 @@ package standalone
 import (
 	"io/ioutil"
 	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -51,4 +52,50 @@ spec: {}
 	})
 
 	os.Remove(testFile)
+}
+
+func TestRedisPubSubConfig(t *testing.T) {
+	expectedPubSubConfig := `apiVersion: dapr.io/v1alpha1
+kind: Component
+metadata:
+  name: pubsub
+spec:
+  type: pubsub.redis
+  version: v1.0
+  metadata:
+  - name: redisHost
+    value: localhost:6379
+  - name: redisPassword
+    value: ""`
+	tempDir := t.TempDir()
+	createRedisPubSub("localhost", tempDir)
+	pubsubFilePath := filepath.Join(tempDir, pubSubYamlFileName)
+	assert.FileExists(t, pubsubFilePath)
+	content, err := ioutil.ReadFile(pubsubFilePath)
+	assert.NoError(t, err)
+	assert.YAMLEq(t, expectedPubSubConfig, string(content))
+}
+
+func TestRedisStateStoreConfig(t *testing.T) {
+	expectedStateStoreConfig := `apiVersion: dapr.io/v1alpha1
+kind: Component
+metadata:
+  name: statestore
+spec:
+  type: state.redis
+  version: v1.0
+  metadata:
+  - name: redisHost
+    value: localhost:6379
+  - name: redisPassword
+    value: ""
+  - name: actorStateStore
+    value: "true"`
+	tempDir := t.TempDir()
+	createRedisStateStore("localhost", tempDir)
+	stateStoreFilePath := filepath.Join(tempDir, stateStoreYamlFileName)
+	assert.FileExists(t, stateStoreFilePath)
+	content, err := ioutil.ReadFile(stateStoreFilePath)
+	assert.NoError(t, err)
+	assert.YAMLEq(t, expectedStateStoreConfig, string(content))
 }

--- a/pkg/standalone/standalone_test.go
+++ b/pkg/standalone/standalone_test.go
@@ -8,7 +8,6 @@ package standalone
 import (
 	"io/ioutil"
 	"os"
-	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -52,50 +51,4 @@ spec: {}
 	})
 
 	os.Remove(testFile)
-}
-
-func TestRedisPubSubConfig(t *testing.T) {
-	expectedPubSubConfig := `apiVersion: dapr.io/v1alpha1
-kind: Component
-metadata:
-  name: pubsub
-spec:
-  type: pubsub.redis
-  version: v1.0
-  metadata:
-  - name: redisHost
-    value: localhost:6379
-  - name: redisPassword
-    value: ""`
-	tempDir := t.TempDir()
-	createRedisPubSub("localhost", tempDir)
-	pubsubFilePath := filepath.Join(tempDir, pubSubYamlFileName)
-	assert.FileExists(t, pubsubFilePath)
-	content, err := ioutil.ReadFile(pubsubFilePath)
-	assert.NoError(t, err)
-	assert.YAMLEq(t, expectedPubSubConfig, string(content))
-}
-
-func TestRedisStateStoreConfig(t *testing.T) {
-	expectedStateStoreConfig := `apiVersion: dapr.io/v1alpha1
-kind: Component
-metadata:
-  name: statestore
-spec:
-  type: state.redis
-  version: v1.0
-  metadata:
-  - name: redisHost
-    value: localhost:6379
-  - name: redisPassword
-    value: ""
-  - name: actorStateStore
-    value: "true"`
-	tempDir := t.TempDir()
-	createRedisStateStore("localhost", tempDir)
-	stateStoreFilePath := filepath.Join(tempDir, stateStoreYamlFileName)
-	assert.FileExists(t, stateStoreFilePath)
-	content, err := ioutil.ReadFile(stateStoreFilePath)
-	assert.NoError(t, err)
-	assert.YAMLEq(t, expectedStateStoreConfig, string(content))
 }

--- a/tests/e2e/standalone/standalone_test.go
+++ b/tests/e2e/standalone/standalone_test.go
@@ -206,7 +206,8 @@ func testInstall(t *testing.T) {
 				"name": "statestore",
 			},
 			"spec": map[interface{}]interface{}{
-				"type": "state.redis",
+				"type":    "state.redis",
+				"version": "v1.0",
 				"metadata": []interface{}{
 					map[interface{}]interface{}{
 						"name":  "redisHost",
@@ -230,7 +231,8 @@ func testInstall(t *testing.T) {
 				"name": "pubsub",
 			},
 			"spec": map[interface{}]interface{}{
-				"type": "pubsub.redis",
+				"type":    "pubsub.redis",
+				"version": "v1.0",
 				"metadata": []interface{}{
 					map[interface{}]interface{}{
 						"name":  "redisHost",

--- a/tests/e2e/standalone/standalone_test.go
+++ b/tests/e2e/standalone/standalone_test.go
@@ -207,7 +207,7 @@ func testInstall(t *testing.T) {
 			},
 			"spec": map[interface{}]interface{}{
 				"type":    "state.redis",
-				"version": "v1.0",
+				"version": "v1",
 				"metadata": []interface{}{
 					map[interface{}]interface{}{
 						"name":  "redisHost",
@@ -232,7 +232,7 @@ func testInstall(t *testing.T) {
 			},
 			"spec": map[interface{}]interface{}{
 				"type":    "pubsub.redis",
-				"version": "v1.0",
+				"version": "v1",
 				"metadata": []interface{}{
 					map[interface{}]interface{}{
 						"name":  "redisHost",


### PR DESCRIPTION
Added version field to pubsub.yaml and statestore.yaml

# Description

`dapr init` was not adding version to component specs generated, which is now required.

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: https://github.com/dapr/dapr/issues/2964
closes #644 

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Created/updated tests
* [ ] Extended the documentation
