### PR TITLE
Add k8s ha mode, non-ha mode, status e2e tests

### DIFF
--- a/tests/e2e/kubernetes/kubernetes_test.go
+++ b/tests/e2e/kubernetes/kubernetes_test.go
@@ -53,7 +53,8 @@ func TestKubernetesInstallNonHA(t *testing.T) {
 		{"status check", testStatus(true, false)},
 		//-------------------------------------------------
 		{"uninstall", testUninstall}, // waits for pod deletion
-		{"clusterroles not exist", testClusterRoles(false)},
+		// related to https://github.com/dapr/cli/issues/656
+		{"crds  exist after uninstall", testCRDs(true)},
 		{"clusterroles not exist", testClusterRoles(false)},
 		{"clusterrolebindings not exist", testClusterRoleBindings(false)},
 		{"status check errors out", testStatus(false, false)},
@@ -79,7 +80,8 @@ func TestKubernetesInstallHA(t *testing.T) {
 		{"status check", testStatus(true, true)},
 		//-------------------------------------------------
 		{"uninstall", testUninstall}, // waits for pod deletion
-		{"clusterroles not exist", testClusterRoles(false)},
+		// related to https://github.com/dapr/cli/issues/656
+		{"crds  exist after uninstall", testCRDs(true)},
 		{"clusterroles not exist", testClusterRoles(false)},
 		{"clusterrolebindings not exist", testClusterRoleBindings(false)},
 		{"status check errors out", testStatus(false, true)},

--- a/tests/e2e/kubernetes/kubernetes_test.go
+++ b/tests/e2e/kubernetes/kubernetes_test.go
@@ -38,7 +38,7 @@ const (
 	daprDashboardVersion = "0.6.0"
 )
 
-func TestKubernetesInstall(t *testing.T) {
+func TestKubernetesInstallNonHA(t *testing.T) {
 	// Ensure a clean environment
 	uninstall()
 
@@ -46,10 +46,36 @@ func TestKubernetesInstall(t *testing.T) {
 		name  string
 		phase func(*testing.T)
 	}{
-		{"install", testInstall},
+		{"install", testInstall(false)},
 		{"crds exist", testCRDs(true)},
 		{"clusterroles exist", testClusterRoles(true)},
 		{"clusterrolebindings exist", testClusterRoleBindings(true)},
+		{"status check", testStatus(false)},
+		//-------------------------------------------------
+		{"uninstall", testUninstall},
+		{"clusterroles not exist", testClusterRoles(false)},
+		{"clusterroles not exist", testClusterRoles(false)},
+		{"clusterrolebindings not exist", testClusterRoleBindings(false)},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, tc.phase)
+	}
+}
+
+func TestKubernetesInstallHA(t *testing.T) {
+	// Ensure a clean environment
+	uninstall()
+
+	tests := []struct {
+		name  string
+		phase func(*testing.T)
+	}{
+		{"install", testInstall(true)},
+		{"crds exist", testCRDs(true)},
+		{"clusterroles exist", testClusterRoles(true)},
+		{"clusterrolebindings exist", testClusterRoleBindings(true)},
+		{"status check", testStatus(true)},
 		//-------------------------------------------------
 		{"uninstall", testUninstall},
 		{"clusterroles not exist", testClusterRoles(false)},
@@ -83,74 +109,122 @@ func testUninstall(t *testing.T) {
 	require.NoError(t, err, "uninstall failed")
 }
 
-func testInstall(t *testing.T) {
-	daprPath := getDaprPath()
-	output, err := spawn.Command(daprPath,
-		"init", "-k",
-		"--wait",
-		"-n", daprNamespace,
-		"--runtime-version", daprRuntimeVersion,
-		"--log-as-json")
-	t.Log(output)
-	require.NoError(t, err, "init failed")
+func testInstall(haMode bool) func(t *testing.T) {
+	return func(t *testing.T) {
+		daprPath := getDaprPath()
+		args := []string{
+			"init", "-k",
+			"--wait",
+			"-n", daprNamespace,
+			"--runtime-version", daprRuntimeVersion,
+			"--log-as-json"}
+		if haMode {
+			args = append(args, "--enable-ha")
+		}
+		output, err := spawn.Command(daprPath, args...)
+		t.Log(output)
+		require.NoError(t, err, "init failed")
 
-	ctx := context.Background()
-	ctxt, cancel := context.WithTimeout(ctx, 10*time.Second)
-	defer cancel()
-	k8sClient, err := kubernetes.Client()
-	require.NoError(t, err)
-	list, err := k8sClient.CoreV1().Pods(daprNamespace).List(ctxt, v1.ListOptions{
-		Limit: 100,
-	})
-	require.NoError(t, err)
+		ctx := context.Background()
+		ctxt, cancel := context.WithTimeout(ctx, 10*time.Second)
+		defer cancel()
+		k8sClient, err := kubernetes.Client()
+		require.NoError(t, err)
+		list, err := k8sClient.CoreV1().Pods(daprNamespace).List(ctxt, v1.ListOptions{
+			Limit: 100,
+		})
+		require.NoError(t, err)
 
-	notFound := map[string]string{
-		"sentry":    daprRuntimeVersion,
-		"sidecar":   daprRuntimeVersion,
-		"dashboard": daprDashboardVersion,
-		"placement": daprRuntimeVersion,
-		"operator":  daprRuntimeVersion,
-	}
-	prefixes := map[string]string{
-		"sentry":    "dapr-sentry-",
-		"sidecar":   "dapr-sidecar-injector-",
-		"dashboard": "dapr-dashboard-",
-		"placement": "dapr-placement-server-",
-		"operator":  "dapr-operator-",
-	}
+		notFound := map[string]string{
+			"sentry":    daprRuntimeVersion,
+			"sidecar":   daprRuntimeVersion,
+			"dashboard": daprDashboardVersion,
+			"placement": daprRuntimeVersion,
+			"operator":  daprRuntimeVersion,
+		}
+		prefixes := map[string]string{
+			"sentry":    "dapr-sentry-",
+			"sidecar":   "dapr-sidecar-injector-",
+			"dashboard": "dapr-dashboard-",
+			"placement": "dapr-placement-server-",
+			"operator":  "dapr-operator-",
+		}
 
-	t.Logf("items %d", len(list.Items))
-	for _, pod := range list.Items {
-		t.Log(pod.ObjectMeta.Name)
-		for component, prefix := range prefixes {
-			if pod.Status.Phase != core_v1.PodRunning {
-				continue
-			}
-			if !pod.Status.ContainerStatuses[0].Ready {
-				continue
-			}
-			if strings.HasPrefix(pod.ObjectMeta.Name, prefix) {
-				expectedVersion, ok := notFound[component]
-				if !ok {
+		t.Logf("items %d", len(list.Items))
+		for _, pod := range list.Items {
+			t.Log(pod.ObjectMeta.Name)
+			for component, prefix := range prefixes {
+				if pod.Status.Phase != core_v1.PodRunning {
 					continue
 				}
-				if len(pod.Spec.Containers) == 0 {
+				if !pod.Status.ContainerStatuses[0].Ready {
 					continue
 				}
+				if strings.HasPrefix(pod.ObjectMeta.Name, prefix) {
+					expectedVersion, ok := notFound[component]
+					if !ok {
+						continue
+					}
+					if len(pod.Spec.Containers) == 0 {
+						continue
+					}
 
-				image := pod.Spec.Containers[0].Image
-				versionIndex := strings.LastIndex(image, ":")
-				if versionIndex != -1 {
-					version := image[versionIndex+1:]
-					if version == expectedVersion {
-						delete(notFound, component)
+					image := pod.Spec.Containers[0].Image
+					versionIndex := strings.LastIndex(image, ":")
+					if versionIndex != -1 {
+						version := image[versionIndex+1:]
+						if version == expectedVersion {
+							delete(notFound, component)
+						}
 					}
 				}
 			}
 		}
-	}
 
-	assert.Empty(t, notFound)
+		assert.Empty(t, notFound)
+	}
+}
+
+func testStatus(haMode bool) func(t *testing.T) {
+	return func(t *testing.T) {
+		daprPath := getDaprPath()
+		output, err := spawn.Command(daprPath, "status", "-k")
+		require.NoError(t, err, "status check failed")
+		notFound := map[string][]string{}
+		if !haMode {
+			notFound = map[string][]string{
+				"dapr-sentry":           {daprRuntimeVersion, "1"},
+				"dapr-sidecar-injector": {daprRuntimeVersion, "1"},
+				"dapr-dashboard":        {daprDashboardVersion, "1"},
+				"dapr-placement-server": {daprRuntimeVersion, "1"},
+				"dapr-operator":         {daprRuntimeVersion, "1"},
+			}
+		} else {
+			notFound = map[string][]string{
+				"dapr-sentry":           {daprRuntimeVersion, "3"},
+				"dapr-sidecar-injector": {daprRuntimeVersion, "3"},
+				"dapr-dashboard":        {daprDashboardVersion, "1"},
+				"dapr-placement-server": {daprRuntimeVersion, "3"},
+				"dapr-operator":         {daprRuntimeVersion, "3"},
+			}
+		}
+
+		lines := strings.Split(output, "\n")[1:] // remove header of status
+		for _, line := range lines {
+			cols := strings.Fields(strings.TrimSpace(line))
+			if len(cols) > 6 { // atleast 6 fields are verified from status (Age and created time are not)
+				if toVerify, ok := notFound[cols[0]]; ok { // get by name
+					require.Equal(t, daprNamespace, cols[1], "namespace must match")
+					require.Equal(t, "True", cols[2], "healthly field must be true")
+					require.Equal(t, "Running", cols[3], "pods must be Running")
+					require.Equal(t, toVerify[1], cols[4], "replicas must be equal")
+					require.Equal(t, toVerify[0], cols[5], "versions must match")
+					delete(notFound, cols[0])
+				}
+			}
+		}
+		assert.Empty(t, notFound)
+	}
 }
 
 func testCRDs(wanted bool) func(t *testing.T) {


### PR DESCRIPTION
# Description

Add k8s ha mode, non-ha mode, status e2e tests, checked for pod deletion on uninstall -- used for status check failure testing.

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: https://github.com/dapr/cli/issues/660

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Created/updated tests
* [ ] Extended the documentation
