### PR TITLE
Upgrading to Go 1.16 and golangci-lint 1.39

### DIFF
--- a/.github/workflows/dapr_cli.yaml
+++ b/.github/workflows/dapr_cli.yaml
@@ -21,8 +21,8 @@ jobs:
     name: Build ${{ matrix.target_os }}_${{ matrix.target_arch }} binaries
     runs-on: ${{ matrix.os }}
     env:
-      GOVER: 1.15
-      GOLANG_CI_LINT_VER: v1.31
+      GOVER: 1.16
+      GOLANG_CI_LINT_VER: v1.39
       GOOS: ${{ matrix.target_os }}
       GOARCH: ${{ matrix.target_arch }}
       GOPROXY: https://proxy.golang.org

--- a/.github/workflows/self_hosted_e2e.yaml
+++ b/.github/workflows/self_hosted_e2e.yaml
@@ -16,7 +16,7 @@ jobs:
     name: Run Self-Hosted E2E tests in ${{ matrix.target_os }}_${{ matrix.target_arch }}
     runs-on: ${{ matrix.os }}
     env:
-      GOVER: 1.15
+      GOVER: 1.16
       GOOS: ${{ matrix.target_os }}
       GOARCH: ${{ matrix.target_arch }}
       GOPROXY: https://proxy.golang.org

--- a/docs/development/development.md
+++ b/docs/development/development.md
@@ -7,7 +7,7 @@ This document helps you get started developing Dapr CLI. If you find any problem
 
 ### Linux and MacOS
 
-1. The Go language environment `1.15` [(instructions)](https://golang.org/doc/install#tarball).
+1. The Go language environment `1.16` [(instructions)](https://golang.org/doc/install#tarball).
    * Make sure that your GOPATH and PATH are configured correctly
    ```bash
    export GOPATH=~/go

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/dapr/cli
 
-go 1.15
+go 1.16
 
 require (
 	github.com/Pallinder/sillyname-go v0.0.0-20130730142914-97aeae9e6ba1


### PR DESCRIPTION
# Description

Upgrading to Go 1.16 and golangci-lint 1.39 in `go.mod` and GitHub workflow

## Issue reference

Resolves #666 😈 

## Checklist

* [x] Code compiles correctly
* [ ] Created/updated tests
* [ ] Extended the documentation
