### PR TITLE
Bump e2e runtime to v1.1.1

### DIFF
--- a/tests/e2e/kubernetes/kubernetes_test.go
+++ b/tests/e2e/kubernetes/kubernetes_test.go
@@ -34,7 +34,7 @@ import (
 
 const (
 	daprNamespace        = "dapr-cli-tests"
-	daprRuntimeVersion   = "1.1.0"
+	daprRuntimeVersion   = "1.1.1"
 	daprDashboardVersion = "0.6.0"
 )
 

--- a/tests/e2e/standalone/standalone_test.go
+++ b/tests/e2e/standalone/standalone_test.go
@@ -30,7 +30,7 @@ import (
 
 const (
 	daprNamespace        = "dapr-cli-tests"
-	daprRuntimeVersion   = "1.1.0"
+	daprRuntimeVersion   = "1.1.1"
 	daprDashboardVersion = "0.6.0"
 )
 


### PR DESCRIPTION
# Description

Runtime to v1.1.1 for E2E tests.

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [ ] Extended the documentation
