### PR TITLE
Add invoke --data-file option and e2e tests

### DIFF
--- a/cmd/invoke.go
+++ b/cmd/invoke.go
@@ -7,6 +7,7 @@ package cmd
 
 import (
 	"fmt"
+	"io/ioutil"
 	"net/http"
 	"os"
 
@@ -22,6 +23,7 @@ var (
 	invokeAppMethod string
 	invokeData      string
 	invokeVerb      string
+	invokeDataFile  string
 )
 
 var InvokeCmd = &cobra.Command{
@@ -35,8 +37,19 @@ dapr invoke --app-id target --method sample --data '{"key":"value"}
 dapr invoke --app-id target --method sample --verb GET
 `,
 	Run: func(cmd *cobra.Command, args []string) {
+		bytePayload := []byte{}
+		var err error
+		if invokeDataFile != "" {
+			bytePayload, err = ioutil.ReadFile(invokeDataFile)
+			if err != nil {
+				print.FailureStatusEvent(os.Stdout, "Error reading payload from '%s'. Error: %s", invokeDataFile, err)
+				os.Exit(1)
+			}
+		} else if invokeData != "" {
+			bytePayload = []byte(invokeData)
+		}
 		client := standalone.NewClient()
-		response, err := client.Invoke(invokeAppID, invokeAppMethod, invokeData, invokeVerb)
+		response, err := client.Invoke(invokeAppID, invokeAppMethod, bytePayload, invokeVerb)
 		if err != nil {
 			err = fmt.Errorf("error invoking app %s: %s", invokeAppID, err)
 			print.FailureStatusEvent(os.Stdout, err.Error())
@@ -55,6 +68,7 @@ func init() {
 	InvokeCmd.Flags().StringVarP(&invokeAppMethod, "method", "m", "", "The method to invoke")
 	InvokeCmd.Flags().StringVarP(&invokeData, "data", "d", "", "The JSON serialized data string (optional)")
 	InvokeCmd.Flags().StringVarP(&invokeVerb, "verb", "v", defaultHTTPVerb, "The HTTP verb to use")
+	InvokeCmd.Flags().StringVarP(&invokeDataFile, "data-file", "f", "", "A file containing the JSON serialized data (optional)")
 	InvokeCmd.Flags().BoolP("help", "h", false, "Print this help message")
 	InvokeCmd.MarkFlagRequired("app-id")
 	InvokeCmd.MarkFlagRequired("method")

--- a/pkg/standalone/client.go
+++ b/pkg/standalone/client.go
@@ -15,7 +15,7 @@ type daprProcess struct {
 // Client is the interface the wraps all the methods exposed by the Dapr CLI.
 type Client interface {
 	// Invoke is a command to invoke a remote or local dapr instance
-	Invoke(appID, method, data, verb string) (string, error)
+	Invoke(appID, method string, data []byte, verb string) (string, error)
 	// Publish is used to publish event to a topic in a pubsub for an app ID.
 	Publish(publishAppID, pubsubName, topic string, payload []byte) error
 }

--- a/pkg/standalone/invoke.go
+++ b/pkg/standalone/invoke.go
@@ -8,7 +8,6 @@ package standalone
 import (
 	"bytes"
 	"fmt"
-	"io"
 	"io/ioutil"
 	"net/http"
 
@@ -16,7 +15,7 @@ import (
 )
 
 // Invoke is a command to invoke a remote or local dapr instance.
-func (s *Standalone) Invoke(appID, method, data, verb string) (string, error) {
+func (s *Standalone) Invoke(appID, method string, data []byte, verb string) (string, error) {
 	list, err := s.process.List()
 	if err != nil {
 		return "", err
@@ -25,12 +24,7 @@ func (s *Standalone) Invoke(appID, method, data, verb string) (string, error) {
 	for _, lo := range list {
 		if lo.AppID == appID {
 			url := makeEndpoint(lo, method)
-			var body io.Reader
-
-			if data != "" {
-				body = bytes.NewBuffer([]byte(data))
-			}
-			req, err := http.NewRequest(verb, url, body)
+			req, err := http.NewRequest(verb, url, bytes.NewBuffer(data))
 			if err != nil {
 				return "", err
 			}

--- a/pkg/standalone/invoke_test.go
+++ b/pkg/standalone/invoke_test.go
@@ -74,7 +74,7 @@ func TestInvoke(t *testing.T) {
 					Err: tc.listErr,
 				},
 			}
-			res, err := client.Invoke(tc.appID, tc.method, "", "GET")
+			res, err := client.Invoke(tc.appID, tc.method, []byte{}, "GET")
 			if tc.errorExpected {
 				assert.Error(t, err, "expected an error")
 				assert.Equal(t, tc.errString, err.Error(), "expected error strings to match")
@@ -95,7 +95,7 @@ func TestInvoke(t *testing.T) {
 					Err: tc.listErr,
 				},
 			}
-			res, err := client.Invoke(tc.appID, tc.method, tc.resp, "POST")
+			res, err := client.Invoke(tc.appID, tc.method, []byte(tc.resp), "POST")
 			if tc.errorExpected {
 				assert.Error(t, err, "expected an error")
 				assert.Equal(t, tc.errString, err.Error(), "expected error strings to match")
@@ -116,7 +116,7 @@ func TestInvoke(t *testing.T) {
 					Err: tc.listErr,
 				},
 			}
-			res, err := client.Invoke(tc.appID, tc.method, tc.resp, "DELETE")
+			res, err := client.Invoke(tc.appID, tc.method, []byte(tc.resp), "DELETE")
 			if tc.errorExpected {
 				assert.Error(t, err, "expected an error")
 				assert.Equal(t, tc.errString, err.Error(), "expected error strings to match")
@@ -137,7 +137,7 @@ func TestInvoke(t *testing.T) {
 					Err: tc.listErr,
 				},
 			}
-			res, err := client.Invoke(tc.appID, tc.method, tc.resp, "PUT")
+			res, err := client.Invoke(tc.appID, tc.method, []byte(tc.resp), "PUT")
 			if tc.errorExpected {
 				assert.Error(t, err, "expected an error")
 				assert.Equal(t, tc.errString, err.Error(), "expected error strings to match")


### PR DESCRIPTION
# Description

The `dapr invoke` command now also has a data-file option.

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #668

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [ ] Extended the documentation
