### PR TITLE
Removing `\n` because a newline is printed by Println

### DIFF
--- a/cmd/run.go
+++ b/cmd/run.go
@@ -177,13 +177,13 @@ var RunCmd = &cobra.Command{
 			outScanner := bufio.NewScanner(stdOutPipe)
 			go func() {
 				for errScanner.Scan() {
-					fmt.Println(print.Blue(fmt.Sprintf("== APP == %s\n", errScanner.Text())))
+					fmt.Println(print.Blue(fmt.Sprintf("== APP == %s", errScanner.Text())))
 				}
 			}()
 
 			go func() {
 				for outScanner.Scan() {
-					fmt.Println(print.Blue(fmt.Sprintf("== APP == %s\n", outScanner.Text())))
+					fmt.Println(print.Blue(fmt.Sprintf("== APP == %s", outScanner.Text())))
 				}
 			}()
 


### PR DESCRIPTION
# Description

Removes the extra `\n` being printed for the application output (stdout & stderr).

## Issue reference

Resolves #616

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [ ] Created/updated tests
* [ ] Extended the documentation
