### PR TITLE
Use absolute path for docker install MacOS

### DIFF
--- a/.github/workflows/self_hosted_e2e.yaml
+++ b/.github/workflows/self_hosted_e2e.yaml
@@ -50,7 +50,7 @@ jobs:
           sudo /bin/chmod 544 /Library/PrivilegedHelperTools/com.docker.vmnetd
           sudo /bin/chmod 644 /Library/LaunchDaemons/com.docker.vmnetd.plist
           sudo /bin/launchctl load /Library/LaunchDaemons/com.docker.vmnetd.plist
-          open -g -a Docker.app
+          open -g -a /Applications/Docker.app
           i=0
           while ! docker system info &>/dev/null; do
             (( i++ == 0 )) && printf %s '-- Waiting for Docker to finish starting up...' || printf '.'


### PR DESCRIPTION
# Description

We're seeing an intermittent issue with the ```open Docker.app``` command on MacOS E2E tests. 
https://github.com/dapr/cli/pull/696/checks?check_run_id=2422461523#step:4:31

Going to use an absolute path here to see if that helps.

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [ ] Extended the documentation
