### PR TITLE
Authentication to GitHub API using GITHUB_TOKEN environment variable

### DIFF
--- a/.github/workflows/kind_e2e.yaml
+++ b/.github/workflows/kind_e2e.yaml
@@ -123,6 +123,7 @@ jobs:
       run: |
         export TEST_OUTPUT_FILE=$GITHUB_WORKSPACE/test-e2e-kind.json
         echo "TEST_OUTPUT_FILE=$TEST_OUTPUT_FILE" >> $GITHUB_ENV
+        export GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }}
         make e2e-build-run-k8s
       shell: bash
     - name: Upload test results

--- a/.github/workflows/self_hosted_e2e.yaml
+++ b/.github/workflows/self_hosted_e2e.yaml
@@ -62,6 +62,7 @@ jobs:
         run: |
           export TEST_OUTPUT_FILE=$GITHUB_WORKSPACE/test-e2e-standalone.json
           echo "TEST_OUTPUT_FILE=$TEST_OUTPUT_FILE" >> $GITHUB_ENV
+          export GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }}
           make e2e-build-run-sh
         shell: bash
       - name: Upload test results

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
+	"os"
 	"strings"
 )
 
@@ -33,7 +34,18 @@ type githubRepoReleaseItem struct {
 // GetLatestRelease return the latest release version of dapr.
 func GetLatestRelease(gitHubOrg, gitHubRepo string) (string, error) {
 	releaseURL := fmt.Sprintf("https://api.github.com/repos/%s/%s/releases", gitHubOrg, gitHubRepo)
-	resp, err := http.Get(releaseURL)
+
+	req, err := http.NewRequest("GET", releaseURL, nil)
+	if err != nil {
+		return "", err
+	}
+
+	githubToken := os.Getenv("GITHUB_TOKEN")
+	if githubToken != "" {
+		req.Header.Add("Authorization", "token "+githubToken)
+	}
+
+	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
# Description

Authenticating to the Github API using the `GITHUB_TOKEN` environment variable, if set.

See https://docs.github.com/en/rest/overview/resources-in-the-rest-api#rate-limiting

## Issue reference

Related to #677 - resolves for our Github Actions Workflow pipeline.

## Checklist

* [x] Code compiles correctly
* [ ] Created/updated tests
* [ ] Extended the documentation
