### PR TITLE
fix mac e2e

### DIFF
--- a/.github/workflows/self_hosted_e2e.yaml
+++ b/.github/workflows/self_hosted_e2e.yaml
@@ -46,7 +46,8 @@ jobs:
           brew install --cask docker
           xattr -d -r com.apple.quarantine /Applications/Docker.app
           sudo /bin/cp /Applications/Docker.app/Contents/Library/LaunchServices/com.docker.vmnetd /Library/PrivilegedHelperTools
-          sudo /bin/cp /Applications/Docker.app/Contents/Resources/com.docker.vmnetd.plist /Library/LaunchDaemons/
+          # On one of the updates to Docker, the file is not available in the path anymore, but still available in the target path.
+          # sudo /bin/cp /Applications/Docker.app/Contents/Resources/com.docker.vmnetd.plist /Library/LaunchDaemons/
           sudo /bin/chmod 544 /Library/PrivilegedHelperTools/com.docker.vmnetd
           sudo /bin/chmod 644 /Library/LaunchDaemons/com.docker.vmnetd.plist
           sudo /bin/launchctl load /Library/LaunchDaemons/com.docker.vmnetd.plist


### PR DESCRIPTION
# Description

On the latest Docker app updates, the file `Applications/Docker.app/Contents/Resources/com.docker.vmnetd.plist` does not exist any longer, it is only available in the target path `/Library/LaunchDaemons/`. Commenting out the copy command for now. 

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #_[issue number]_

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [ ] Extended the documentation
