### PR TITLE
Add --all flag to kubernetes uninstall

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,6 +231,14 @@ The default timeout is 300s/5m and can be overridden using the `--timeout` flag.
 $ dapr uninstall -k --timeout 600
 ```
 
+To remove all Dapr Custom Resource Definitions:
+
+```
+$ dapr uninstall -k --all
+```
+
+*Warning: this will remove any components, subscriptions or configurations that are applied in the cluster at the time of deletion.*
+
 ### Upgrade Dapr on Kubernetes
 
 To perform a zero downtime upgrade of the Dapr control plane:

--- a/cmd/uninstall.go
+++ b/cmd/uninstall.go
@@ -62,7 +62,6 @@ dapr uninstall -k
 
 func init() {
 	UninstallCmd.Flags().BoolVarP(&uninstallKubernetes, "kubernetes", "k", false, "Uninstall Dapr from a Kubernetes cluster")
-	UninstallCmd.Flags().BoolVarP(&uninstallAll, "kubernetes", "k", false, "Uninstall Dapr from a Kubernetes cluster")
 	UninstallCmd.Flags().UintVarP(&timeout, "timeout", "", 300, "The timeout for the Kubernetes uninstall")
 	UninstallCmd.Flags().BoolVar(&uninstallAll, "all", false, "Remove .dapr directory, Redis, Placement and Zipkin containers on local machine, and CRDs on a Kubernetes cluster")
 	UninstallCmd.Flags().String("network", "", "The Docker network from which to remove the Dapr runtime")

--- a/cmd/uninstall.go
+++ b/cmd/uninstall.go
@@ -45,7 +45,7 @@ dapr uninstall -k
 
 		if uninstallKubernetes {
 			print.InfoStatusEvent(os.Stdout, "Removing Dapr from your cluster...")
-			err = kubernetes.Uninstall(uninstallNamespace, timeout)
+			err = kubernetes.Uninstall(uninstallNamespace, uninstallAll, timeout)
 		} else {
 			print.InfoStatusEvent(os.Stdout, "Removing Dapr from your machine...")
 			dockerNetwork := viper.GetString("network")
@@ -62,8 +62,9 @@ dapr uninstall -k
 
 func init() {
 	UninstallCmd.Flags().BoolVarP(&uninstallKubernetes, "kubernetes", "k", false, "Uninstall Dapr from a Kubernetes cluster")
+	UninstallCmd.Flags().BoolVarP(&uninstallAll, "kubernetes", "k", false, "Uninstall Dapr from a Kubernetes cluster")
 	UninstallCmd.Flags().UintVarP(&timeout, "timeout", "", 300, "The timeout for the Kubernetes uninstall")
-	UninstallCmd.Flags().BoolVar(&uninstallAll, "all", false, "Remove .dapr directory, Redis, Placement and Zipkin containers")
+	UninstallCmd.Flags().BoolVar(&uninstallAll, "all", false, "Remove .dapr directory, Redis, Placement and Zipkin containers on local machine, and CRDs on a Kubernetes cluster")
 	UninstallCmd.Flags().String("network", "", "The Docker network from which to remove the Dapr runtime")
 	UninstallCmd.Flags().StringVarP(&uninstallNamespace, "namespace", "n", "dapr-system", "The Kubernetes namespace to uninstall Dapr from")
 	UninstallCmd.Flags().BoolP("help", "h", false, "Print this help message")

--- a/pkg/kubernetes/uninstall.go
+++ b/pkg/kubernetes/uninstall.go
@@ -8,11 +8,12 @@ package kubernetes
 import (
 	"time"
 
+	"github.com/dapr/cli/utils"
 	helm "helm.sh/helm/v3/pkg/action"
 )
 
 // Uninstall removes Dapr from a Kubernetes cluster.
-func Uninstall(namespace string, timeout uint) error {
+func Uninstall(namespace string, uninstallAll bool, timeout uint) error {
 	config, err := helmConfig(namespace)
 	if err != nil {
 		return err
@@ -21,5 +22,18 @@ func Uninstall(namespace string, timeout uint) error {
 	uninstallClient := helm.NewUninstall(config)
 	uninstallClient.Timeout = time.Duration(timeout) * time.Second
 	_, err = uninstallClient.Run(daprReleaseName)
-	return err
+	if err != nil {
+		return err
+	}
+
+	if uninstallAll {
+		for _, crd := range crdsFullResources {
+			_, err := utils.RunCmdAndWait("kubectl", "delete", "crd", crd)
+			if err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
 }

--- a/pkg/kubernetes/upgrade.go
+++ b/pkg/kubernetes/upgrade.go
@@ -26,6 +26,12 @@ var crds = []string{
 	"subscription",
 }
 
+var crdsFullResources = []string{
+	"components.dapr.io",
+	"configurations.dapr.io",
+	"subscription.dapr.io",
+}
+
 type UpgradeConfig struct {
 	RuntimeVersion string
 	Args           []string

--- a/pkg/kubernetes/upgrade.go
+++ b/pkg/kubernetes/upgrade.go
@@ -29,7 +29,7 @@ var crds = []string{
 var crdsFullResources = []string{
 	"components.dapr.io",
 	"configurations.dapr.io",
-	"subscription.dapr.io",
+	"subscriptions.dapr.io",
 }
 
 type UpgradeConfig struct {


### PR DESCRIPTION
This PR adds the `--all` flag to a Kubernetes uninstall command to remove all CRDs.

closes #656 