### PR TITLE
Apply CRDs on init -k

### DIFF
--- a/pkg/kubernetes/kubernetes.go
+++ b/pkg/kubernetes/kubernetes.go
@@ -159,6 +159,11 @@ func install(config InitConfiguration) error {
 		return err
 	}
 
+	err = applyCRDs(fmt.Sprintf("v%s", config.Version))
+	if err != nil {
+		return err
+	}
+
 	installClient := helm.NewInstall(helmConf)
 	installClient.ReleaseName = daprReleaseName
 	installClient.Namespace = config.Namespace


### PR DESCRIPTION
This PR applies the Dapr CRDs during the `init` process, the same as `upgrade`.