### PR TITLE
Revert the changes for exit code on stop error

### DIFF
--- a/cmd/stop.go
+++ b/cmd/stop.go
@@ -30,7 +30,6 @@ dapr stop --app-id <ID>
 			err := standalone.Stop(appID)
 			if err != nil {
 				print.FailureStatusEvent(os.Stdout, "failed to stop app id %s: %s", appID, err)
-				os.Exit(1)
 			} else {
 				print.SuccessStatusEvent(os.Stdout, "app stopped successfully: %s", appID)
 			}

--- a/tests/e2e/standalone/standalone_test.go
+++ b/tests/e2e/standalone/standalone_test.go
@@ -78,12 +78,6 @@ func TestNegativeScenarios(t *testing.T) {
 		require.Equal(t, "No Dapr instances found.\n", output)
 	})
 
-	t.Run("stop without install", func(t *testing.T) {
-		output, err := spawn.Command(daprPath, "stop", "-a", "test")
-		require.Error(t, err, "expected error status on list without install")
-		require.Contains(t, output, "failed to stop app id test: couldn't find app id test", "expected output to match")
-	})
-
 	t.Run("stop unkonwn flag", func(t *testing.T) {
 		output, err := spawn.Command(daprPath, "stop", "-p", "test")
 		require.Error(t, err, "expected error on stop with unknown flag")
@@ -476,7 +470,6 @@ func testPublish(t *testing.T) {
 			assert.Contains(t, output, "Only one of --data and --data-file allowed in the same publish command")
 
 		})
-
 
 		output, err := spawn.Command(getDaprPath(), "stop", "--app-id", "pub_e2e")
 		t.Log(output)

--- a/tests/e2e/standalone/standalone_test.go
+++ b/tests/e2e/standalone/standalone_test.go
@@ -78,6 +78,12 @@ func TestNegativeScenarios(t *testing.T) {
 		require.Equal(t, "No Dapr instances found.\n", output)
 	})
 
+	t.Run("stop without install", func(t *testing.T) {
+		output, err := spawn.Command(daprPath, "stop", "-a", "test")
+		require.NoError(t, err, "expected no error on stop without install")
+		require.Contains(t, output, "failed to stop app id test: couldn't find app id test", "expected output to match")
+	})
+
 	t.Run("stop unkonwn flag", func(t *testing.T) {
 		output, err := spawn.Command(daprPath, "stop", "-p", "test")
 		require.Error(t, err, "expected error on stop with unknown flag")


### PR DESCRIPTION
# Description

This changes the stop error code change done in https://github.com/dapr/cli/pull/683

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #_[issue number]_

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [ ] Extended the documentation
