### PR TITLE
Add `--output` option to `dapr list`

### DIFF
--- a/README.md
+++ b/README.md
@@ -368,6 +368,13 @@ To list all Dapr instances running in a Kubernetes cluster:
 $ dapr list --kubernetes
 ```
 
+To list all Dapr instances but return output as JSON or YAML (e.g. for consumption by other tools):
+
+```
+$ dapr list --output json
+$ dapr list --output yaml
+```
+
 ### Check system services (control plane) status
 
 Check Dapr's system services (control plane) health status in a Kubernetes cluster:

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -36,7 +36,7 @@ func outputList(list interface{}, length int) {
 			os.Exit(1)
 		}
 
-		// Standalone mode displays a separate message when no instances are found. 
+		// Standalone mode displays a separate message when no instances are found.
 		if !kubernetesMode && length == 0 {
 			fmt.Println("No Dapr instances found.")
 			return

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -50,6 +50,12 @@ dapr list
 # List Dapr instances in Kubernetes mode
 dapr list -k
 `,
+	PreRun: func(cmd *cobra.Command, args []string) {
+		if (outputMode != "" && outputMode != "json" && outputMode != "yaml" && outputMode != "table") {
+			print.FailureStatusEvent(os.Stdout, "An invalid output mode was specified.")
+			os.Exit(1)
+		}
+	},
 	Run: func(cmd *cobra.Command, args []string) {
 		if kubernetesMode {
 			list, err := kubernetes.List()
@@ -78,7 +84,7 @@ dapr list -k
 
 func init() {
 	ListCmd.Flags().BoolVarP(&kubernetesMode, "kubernetes", "k", false, "List all Dapr pods in a Kubernetes cluster")
-	ListCmd.Flags().StringVarP(&outputMode, "output", "o", "", "The format of the list (table or json)")
+	ListCmd.Flags().StringVarP(&outputMode, "output", "o", "", "The format of the list (json, yaml, table (default))")
 	ListCmd.Flags().BoolP("help", "h", false, "Print this help message")
 	RootCmd.AddCommand(ListCmd)
 }

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -18,12 +18,12 @@ import (
 )
 
 var (
-	outputMode string
+	outputFormat string
 )
 
 func outputList(list interface{}) {
-	if (outputMode == "json" || outputMode == "yaml") {
-		err := utils.PrintDetail(os.Stdout, outputMode, list)
+	if (outputFormat == "json" || outputFormat == "yaml") {
+		err := utils.PrintDetail(os.Stdout, outputFormat, list)
 
 		if err != nil {
 			print.FailureStatusEvent(os.Stdout, err.Error())
@@ -51,8 +51,8 @@ dapr list
 dapr list -k
 `,
 	PreRun: func(cmd *cobra.Command, args []string) {
-		if (outputMode != "" && outputMode != "json" && outputMode != "yaml" && outputMode != "table") {
-			print.FailureStatusEvent(os.Stdout, "An invalid output mode was specified.")
+		if (outputFormat != "" && outputFormat != "json" && outputFormat != "yaml" && outputFormat != "table") {
+			print.FailureStatusEvent(os.Stdout, "An invalid output format was specified.")
 			os.Exit(1)
 		}
 	},
@@ -84,7 +84,7 @@ dapr list -k
 
 func init() {
 	ListCmd.Flags().BoolVarP(&kubernetesMode, "kubernetes", "k", false, "List all Dapr pods in a Kubernetes cluster")
-	ListCmd.Flags().StringVarP(&outputMode, "output", "o", "", "The format of the list (json, yaml, table (default))")
+	ListCmd.Flags().StringVarP(&outputFormat, "output", "o", "", "The output format of the list. Valid values are: json, yaml, or table (default)")
 	ListCmd.Flags().BoolP("help", "h", false, "Print this help message")
 	RootCmd.AddCommand(ListCmd)
 }

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -22,20 +22,20 @@ var (
 )
 
 func outputList(list interface{}) {
-	if (outputFormat == "json" || outputFormat == "yaml") {
+	if outputFormat == "json" || outputFormat == "yaml" {
 		err := utils.PrintDetail(os.Stdout, outputFormat, list)
 
 		if err != nil {
 			print.FailureStatusEvent(os.Stdout, err.Error())
 			os.Exit(1)
 		}
-	} else {	
+	} else {
 		table, err := gocsv.MarshalString(list)
 		if err != nil {
 			print.FailureStatusEvent(os.Stdout, err.Error())
 			os.Exit(1)
 		}
-		
+
 		utils.PrintTable(table)
 	}
 }
@@ -51,7 +51,7 @@ dapr list
 dapr list -k
 `,
 	PreRun: func(cmd *cobra.Command, args []string) {
-		if (outputFormat != "" && outputFormat != "json" && outputFormat != "yaml" && outputFormat != "table") {
+		if outputFormat != "" && outputFormat != "json" && outputFormat != "yaml" && outputFormat != "table" {
 			print.FailureStatusEvent(os.Stdout, "An invalid output format was specified.")
 			os.Exit(1)
 		}

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -21,7 +21,7 @@ var (
 	outputFormat string
 )
 
-func outputList(list interface{}) {
+func outputList(list interface{}, length int) {
 	if outputFormat == "json" || outputFormat == "yaml" {
 		err := utils.PrintDetail(os.Stdout, outputFormat, list)
 
@@ -34,6 +34,12 @@ func outputList(list interface{}) {
 		if err != nil {
 			print.FailureStatusEvent(os.Stdout, err.Error())
 			os.Exit(1)
+		}
+
+		// Standalone mode displays a separate message when no instances are found. 
+		if !kubernetesMode && length == 0 {
+			fmt.Println("No Dapr instances found.")
+			return
 		}
 
 		utils.PrintTable(table)
@@ -64,7 +70,7 @@ dapr list -k
 				os.Exit(1)
 			}
 
-			outputList(list)
+			outputList(list, len(list))
 		} else {
 			list, err := standalone.List()
 			if err != nil {
@@ -72,12 +78,7 @@ dapr list -k
 				os.Exit(1)
 			}
 
-			if len(list) == 0 {
-				fmt.Println("No Dapr instances found.")
-				return
-			}
-
-			outputList(list)
+			outputList(list, len(list))
 		}
 	},
 }

--- a/pkg/kubernetes/list.go
+++ b/pkg/kubernetes/list.go
@@ -12,10 +12,10 @@ import (
 
 // ListOutput represents the application ID, application port and creation time.
 type ListOutput struct {
-	AppID   string `csv:"APP ID"`
-	AppPort string `csv:"APP PORT"`
-	Age     string `csv:"AGE"`
-	Created string `csv:"CREATED"`
+	AppID   string `csv:"APP ID"   json:"appId"   yaml:"appId"`
+	AppPort string `csv:"APP PORT" json:"appPort" yaml:"appPort"`
+	Age     string `csv:"AGE"      json:"age"     yaml:"age"`
+	Created string `csv:"CREATED"  json:"created" yaml:"created"`
 }
 
 // List outputs all the applications.

--- a/pkg/standalone/list.go
+++ b/pkg/standalone/list.go
@@ -20,15 +20,15 @@ import (
 
 // ListOutput represents the application ID, application port and creation time.
 type ListOutput struct {
-	AppID          string `csv:"APP ID"`
-	HTTPPort       int    `csv:"HTTP PORT"`
-	GRPCPort       int    `csv:"GRPC PORT"`
-	AppPort        int    `csv:"APP PORT"`
-	MetricsEnabled bool   `csv:"-"` // Not displayed, consumed by dashboard.
-	Command        string `csv:"COMMAND"`
-	Age            string `csv:"AGE"`
-	Created        string `csv:"CREATED"`
-	PID            int
+	AppID          string `csv:"APP ID"    json:"appId"          yaml:"appId"`
+	HTTPPort       int    `csv:"HTTP PORT" json:"httpPort"       yaml:"httpPort"`
+	GRPCPort       int    `csv:"GRPC PORT" json:"grpcPort"       yaml:"grpcPort"`
+	AppPort        int    `csv:"APP PORT"  json:"appPort"        yaml:"appPort"`
+	MetricsEnabled bool   `csv:"-"         json:"metricsEnabled" yaml:"metricsEnabled"` // Not displayed in table, consumed by dashboard.
+	Command        string `csv:"COMMAND"   json:"command"        yaml:"command"`
+	Age            string `csv:"AGE"       json:"age"            yaml:"age"`
+	Created        string `csv:"CREATED"   json:"created"        yaml:"created"`
+	PID            int    `csv:"PID"       json:"pid"            yaml:"pid"`
 }
 
 // runData is a placeholder for collected information linking cli and sidecar.

--- a/tests/e2e/standalone/standalone_test.go
+++ b/tests/e2e/standalone/standalone_test.go
@@ -575,9 +575,9 @@ func listOutputCheck(t *testing.T, output string) {
 }
 
 func listJsonOutputCheck(t *testing.T, output string) {
-	var result map[string]interface{};
+	var result map[string]interface{}
 
-	err := json.Unmarshal([]byte(output), &result);
+	err := json.Unmarshal([]byte(output), &result)
 
 	assert.NoError(t, err, "output was not valid JSON")
 
@@ -588,7 +588,7 @@ func listJsonOutputCheck(t *testing.T, output string) {
 }
 
 func listYamlOutputCheck(t *testing.T, output string) {
-	var result map[string]interface{};
+	var result map[string]interface{}
 
 	err := yaml.Unmarshal([]byte(output), &result)
 

--- a/tests/e2e/standalone/standalone_test.go
+++ b/tests/e2e/standalone/standalone_test.go
@@ -413,6 +413,10 @@ func testList(t *testing.T) {
 		require.NoError(t, err, "dapr list failed")
 		listYamlOutputCheck(t, output)
 
+		output, err = spawn.Command(getDaprPath(), "list", "-o", "invalid")
+		t.Log(output)
+		require.Error(t, err, "dapr list should fail with an invalid output format")
+
 		// We can call stop so as not to wait for the app to time out
 		output, err = spawn.Command(getDaprPath(), "stop", "--app-id", "dapr_e2e_list")
 		t.Log(output)


### PR DESCRIPTION
# Description

Adds an `--output` to `dapr list` that allows the user to specify an alternative output format.  Valid values are `json`, `yaml`, and `table` (the default if omitted). Invalid values result in an error message.

This allows tools and other automation to more easily consume the list of running Dapr applications.

Examples:

```bash
% ./dist/darwin_amd64/release/dapr list -k         
  APP ID   APP PORT  AGE  CREATED              
  nodeapp  3000      18h  2021-05-25 16:22.30  

% ./dist/darwin_amd64/release/dapr list -k -o table
  APP ID   APP PORT  AGE  CREATED              
  nodeapp  3000      18h  2021-05-25 16:22.30  

% ./dist/darwin_amd64/release/dapr list -k -o json 
{
  "appId": "nodeapp",
  "appPort": "3000",
  "age": "18h",
  "created": "2021-05-25 16:22.30"
}%  
                                                                                                                                                                                                    
% ./dist/darwin_amd64/release/dapr list -k -o yaml
appId: nodeapp
appPort: "3000"
age: 18h
created: 2021-05-25 16:22.30

% ./dist/darwin_amd64/release/dapr list            
  APP ID   HTTP PORT  GRPC PORT  APP PORT  COMMAND  AGE  CREATED              PID    
  app-one  55206      55207      0                  41m  2021-05-26 09:55.39  93908  

% ./dist/darwin_amd64/release/dapr list -o table
  APP ID   HTTP PORT  GRPC PORT  APP PORT  COMMAND  AGE  CREATED              PID    
  app-one  55206      55207      0                  41m  2021-05-26 09:55.39  93908  

% ./dist/darwin_amd64/release/dapr list -o json 
{
  "appId": "app-one",
  "httpPort": 55206,
  "grpcPort": 55207,
  "appPort": 0,
  "metricsEnabled": true,
  "command": "",
  "age": "41m",
  "created": "2021-05-26 09:55.39",
  "pid": 93908
}%                
                                                                                                                                                                                      
% ./dist/darwin_amd64/release/dapr list -o yaml
appId: app-one
httpPort: 55206
grpcPort: 55207
appPort: 0
metricsEnabled: true
command: ""
age: 41m
created: 2021-05-26 09:55.39
pid: 93908

 % ./dist/darwin_amd64/release/dapr list -o invalid  
❌  An invalid output format was specified.
```

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #728

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Created/updated tests
* [x] Extended the documentation (drafted PR [dapr/docs#1512](https://github.com/dapr/docs/pull/1512))
