### PR TITLE
ci: add stale bot

### DIFF
--- a/.github/workflows/dapr-bot-schedule.yml
+++ b/.github/workflows/dapr-bot-schedule.yml
@@ -1,7 +1,15 @@
-# ------------------------------------------------------------
-# Copyright (c) Microsoft Corporation and Dapr Contributors.
-# Licensed under the MIT License.
-# ------------------------------------------------------------
+#
+# Copyright 2021 The Dapr Authors
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 
 name: dapr-bot-schedule
 

--- a/.github/workflows/dapr-bot-schedule.yml
+++ b/.github/workflows/dapr-bot-schedule.yml
@@ -1,0 +1,47 @@
+# ------------------------------------------------------------
+# Copyright (c) Microsoft Corporation and Dapr Contributors.
+# Licensed under the MIT License.
+# ------------------------------------------------------------
+
+name: dapr-bot-schedule
+
+on:
+  schedule:
+    - cron: '*/10 * * * *'
+  workflow_dispatch:
+jobs:
+  prune_stale:
+    name: Prune Stale
+    runs-on: ubuntu-latest
+    steps:
+    - name: Prune Stale
+      uses: actions/stale@v3.0.14
+      with:
+        repo-token: ${{ secrets.DAPR_BOT_TOKEN }}
+        # Different amounts of days for issues/PRs are not currently supported but there is a PR
+        # open for it: https://github.com/actions/stale/issues/214
+        days-before-stale: 30
+        days-before-close: 7
+        stale-issue-message: >
+          This issue has been automatically marked as stale because it has not had activity in the
+          last 30 days. It will be closed in the next 7 days unless it is tagged (pinned, good first issue, help wanted or triaged/resolved) or other activity
+          occurs. Thank you for your contributions.
+        close-issue-message: >
+          This issue has been automatically closed because it has not had activity in the
+          last 37 days. If this issue is still valid, please ping a maintainer and ask them to label it as pinned, good first issue, help wanted or triaged/resolved.
+          Thank you for your contributions.
+        stale-pr-message: >
+          This pull request has been automatically marked as stale because it has not had
+          activity in the last 30 days. It will be closed in 7 days if no further activity occurs. Please
+          feel free to give a status update now, ping for review, or re-open when it's ready.
+          Thank you for your contributions!
+        close-pr-message: >
+          This pull request has been automatically closed because it has not had
+          activity in the last 37 days. Please feel free to give a status update now, ping for review, or re-open when it's ready.
+          Thank you for your contributions!
+        stale-issue-label: 'stale'
+        exempt-issue-labels: 'pinned,good first issue,help wanted,triaged/resolved'
+        stale-pr-label: 'stale'
+        exempt-pr-labels: 'pinned'
+        operations-per-run: 500
+        ascending: true


### PR DESCRIPTION
Signed-off-by: Long Dai <long0dai@foxmail.com>

# Description

Add stale bot to control issue/pr lifecycle.

It is safe to merge before label, since it would mark those as stale and wait for 37 days to close.

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #_[issue number]_

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [ ] Extended the documentation
