### PR TITLE
Add a more instructive error message for failure to get latest version

### DIFF
--- a/pkg/standalone/standalone.go
+++ b/pkg/standalone/standalone.go
@@ -470,6 +470,12 @@ func installBinary(wg *sync.WaitGroup, errorChan chan<- error, dir, version, bin
 
 	v, err := overrideLastestVersion(version, githubRepo)
 	if err != nil {
+		if githubRepo == cli_ver.DaprGitHubRepo {
+			err = fmt.Errorf("%s. Try specifying --runtime-version=<desired_version>", err)
+		} else if githubRepo == cli_ver.DashboardGitHubRepo {
+			err = fmt.Errorf("%s. Try specifying --dashboard-version=<desired_version>", err)
+		}
+
 		errorChan <- err
 		return
 	}


### PR DESCRIPTION
# Description

If the github API is blocking requests from a user due to ratelimiting, or an outage, or whatever, the user should be able to work around that by manually specifying a version. We can add a more descriptive error message so that the user can apply the workaround themselves.

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Makes #677 marginally better.

## Example output

```
 % for req in `seq 1 60`; do curl -s https://api.github.com/repos/dapr/dapr/releases > /dev/null& done

% ./dist/darwin_amd64/release/dapr init
⌛  Making the jump to hyperspace...
❌  Downloading binaries and setting up components...
❌  cannot get the latest release version: https://api.github.com/repos/dapr/dapr/releases - 403 Forbidden. Try specifying --runtime-version=<desired_version>
% ./dist/darwin_amd64/release/dapr init --runtime-version=1.2.2
⌛  Making the jump to hyperspace...
❌  Downloading binaries and setting up components...
❌  cannot get the latest release version: https://api.github.com/repos/dapr/dashboard/releases - 403 Forbidden. Try specifying --dashboard-version=<desired_version>
 % ./dist/darwin_amd64/release/dapr init --runtime-version=1.2.2 --dashboard-version=0.6.0
⌛  Making the jump to hyperspace...
↙  Downloading binaries and setting up components... 
Dapr runtime installed to /Users/willardstanley/.dapr/bin, you may run the following to add it to your path if you want to run daprd directly:
    export PATH=$PATH:/Users/willardstanley/.dapr/bin
✅  Downloading binaries and setting up components...
✅  Downloaded binaries and completed components set up.
ℹ️  daprd binary has been installed to /Users/willardstanley/.dapr/bin.
ℹ️  dapr_placement container is running.
ℹ️  dapr_redis container is running.
ℹ️  dapr_zipkin container is running.
ℹ️  Use `docker ps` to check running containers.
✅  Success! Dapr is up and running. To get started, go here: https://aka.ms/dapr-getting-started
```

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [ ] Extended the documentation
