### PR TITLE
Add help message for installing without sudo and admin rights

### DIFF
--- a/install/install.ps1
+++ b/install/install.ps1
@@ -56,6 +56,7 @@ else {
 Write-Output "Creating $DaprRoot directory"
 New-Item -ErrorAction Ignore -Path $DaprRoot -ItemType "directory"
 if (!(Test-Path $DaprRoot -PathType Container)) {
+    Write-Warning "Please visit https://docs.dapr.io/getting-started/install-dapr-cli/ for instructions on how to install without admin rights."
     throw "Cannot create $DaprRoot"
 }
 

--- a/install/install.sh
+++ b/install/install.sh
@@ -69,7 +69,10 @@ runAsRoot() {
         CMD="sudo $CMD"
     fi
 
-    $CMD
+    $CMD || {
+        echo "Please visit https://docs.dapr.io/getting-started/install-dapr-cli/ for instructions on how to install without sudo."
+        exit 1
+    }
 }
 
 checkHttpRequestCLI() {


### PR DESCRIPTION
# Description

Adds help message with instructions when Dapr cannot installed due to lack of `sudo` or admin rights.

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #580

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Created/updated tests
* [x] Extended the documentation
