### PR TITLE
Proper removal of "v" from release version

### DIFF
--- a/pkg/kubernetes/kubernetes.go
+++ b/pkg/kubernetes/kubernetes.go
@@ -11,6 +11,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/dapr/cli/pkg/print"
@@ -90,7 +91,7 @@ func getVersion(version string) (string, error) {
 		if err != nil {
 			return "", fmt.Errorf("cannot get the latest release version: %s", err)
 		}
-		version = version[1:]
+		version = strings.TrimPrefix(version, "v")
 	}
 	return version, nil
 }

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -104,7 +104,7 @@ func GetLatestReleaseGithub(githubURL string) (string, error) {
 
 		for _, release := range githubRepoReleases {
 			if !strings.Contains(release.TagName, "-rc") {
-				return release.TagName[1:], nil
+				return strings.TrimPrefix(release.TagName, "v"), nil
 			}
 		}
 


### PR DESCRIPTION
# Description

Quick fix for #761 so that if the version is not prefixed with "v", that the major release is not trimmed.

## Issue reference

Closes #761

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [ ] Created/updated tests
* [ ] Extended the documentation
