### PR TITLE
Run command: fix bool args passed to daprd

### DIFF
--- a/pkg/standalone/run.go
+++ b/pkg/standalone/run.go
@@ -136,12 +136,12 @@ func getDaprCommand(appID string, daprHTTPPort int, daprGRPCPort int, appPort in
 
 		args = append(
 			args,
-			"--enable-profiling", "true",
+			"--enable-profiling",
 			"--profile-port", strconv.Itoa(profilePort))
 	}
 
 	if appSSL {
-		args = append(args, "--app-ssl", "true")
+		args = append(args, "--app-ssl")
 	}
 
 	cmd := exec.Command(daprCMD, args...)

--- a/pkg/standalone/run_test.go
+++ b/pkg/standalone/run_test.go
@@ -106,7 +106,7 @@ func TestRun(t *testing.T) {
 		assertArgumentEqual(t, "app-protocol", "http", output.DaprCMD.Args)
 		assertArgumentEqual(t, "app-port", "3000", output.DaprCMD.Args)
 		assertArgumentEqual(t, "components-path", DefaultComponentsDirPath(), output.DaprCMD.Args)
-		assertArgumentEqual(t, "app-ssl", "true", output.DaprCMD.Args)
+		assertArgumentEqual(t, "app-ssl", "", output.DaprCMD.Args)
 		assertArgumentEqual(t, "metrics-port", "9001", output.DaprCMD.Args)
 		if runtime.GOOS == "windows" {
 			assertArgumentEqual(t, "placement-host-address", "localhost:6050", output.DaprCMD.Args)


### PR DESCRIPTION
# Description

`cli` incorrectly passes boolean arguments to `daprd`.

## Issue reference

`cli` currently uses package `flag` to parse arguments. Boolean arguments are passed as

```sh
daprd --enable-profiling true # other args follow...
```

See related code: https://github.com/dapr/cli/blob/master/pkg/standalone/run.go#L139

Actually it's not a correct way to pass boolean ones.  [Command line flag syntax](https://pkg.go.dev/flag#hdr-Command_line_flag_syntax) states that:

```text
The following forms are permitted:

-flag
-flag=x
-flag x  // non-boolean flags only

One or two minus signs may be used; they are equivalent. The last form is not permitted for boolean flags because the meaning of the command 
```

This results in a situation where our child processes inaccurately parse arguments. Please see the demo below

```go
// app.go
// This app simply prints arguments passed

package main

import (
    "flag"
    "fmt"
)

func main() {

    wordPtr := flag.String("word", "foo", "a string")
    numbPtr := flag.Int("numb", 42, "an int")
    boolPtr := flag.Bool("bool", false, "a boolean")

    flag.Parse()

    fmt.Println("word:", *wordPtr)
    fmt.Println("numb:", *numbPtr)
    fmt.Println("bool:", *boolPtr)
}
```
Here what we have when invoking the app

```sh
$  go run app.go --bool true --numb 68 --word andy
word: foo
numb: 42
bool: true
```

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Created/updated tests
* [ ] Extended the documentation
