### PR TITLE
Revert pinning of Go 1.16.6

### DIFF
--- a/.github/workflows/dapr_cli.yaml
+++ b/.github/workflows/dapr_cli.yaml
@@ -21,7 +21,7 @@ jobs:
     name: Build ${{ matrix.target_os }}_${{ matrix.target_arch }} binaries
     runs-on: ${{ matrix.os }}
     env:
-      GOVER: 1.16.6
+      GOVER: 1.16
       GOLANG_CI_LINT_VER: v1.31
       GOOS: ${{ matrix.target_os }}
       GOARCH: ${{ matrix.target_arch }}

--- a/.github/workflows/kind_e2e.yaml
+++ b/.github/workflows/kind_e2e.yaml
@@ -37,7 +37,7 @@ jobs:
     name: E2E tests for K8s (KinD)
     runs-on: ubuntu-latest
     env:
-      GOVER: 1.16.6
+      GOVER: 1.16
     strategy:
       fail-fast: false # Keep running if one leg fails.
       matrix:

--- a/.github/workflows/self_hosted_e2e.yaml
+++ b/.github/workflows/self_hosted_e2e.yaml
@@ -22,7 +22,7 @@ jobs:
     name: Run Self-Hosted E2E tests in ${{ matrix.target_os }}_${{ matrix.target_arch }}
     runs-on: ${{ matrix.os }}
     env:
-      GOVER: 1.16.6
+      GOVER: 1.16
       GOOS: ${{ matrix.target_os }}
       GOARCH: ${{ matrix.target_arch }}
       GOPROXY: https://proxy.golang.org

--- a/.github/workflows/upgrade_e2e.yaml
+++ b/.github/workflows/upgrade_e2e.yaml
@@ -37,7 +37,7 @@ jobs:
     name: Upgrade path tests (KinD)
     runs-on: ubuntu-latest
     env:
-      GOVER: 1.16.6
+      GOVER: 1.16
     strategy:
       fail-fast: false # Keep running if one leg fails.
       matrix:


### PR DESCRIPTION
# Description

Revert pinning of Go 1.16.6 because that is the default as of today.