### PR TITLE
Add downgrade language to the upgrade CLI command

### DIFF
--- a/cmd/upgrade.go
+++ b/cmd/upgrade.go
@@ -17,7 +17,7 @@ var upgradeRuntimeVersion string
 
 var UpgradeCmd = &cobra.Command{
 	Use:   "upgrade",
-	Short: "Upgrades a Dapr control plane installation in a cluster. Supported platforms: Kubernetes",
+	Short: "Upgrades or downgrades a Dapr control plane installation in a cluster. Supported platforms: Kubernetes",
 	Example: `
 # Upgrade Dapr in Kubernetes
 dapr upgrade -k
@@ -39,9 +39,9 @@ dapr upgrade -k
 }
 
 func init() {
-	UpgradeCmd.Flags().BoolVarP(&kubernetesMode, "kubernetes", "k", false, "Upgrade Dapr in a Kubernetes cluster")
+	UpgradeCmd.Flags().BoolVarP(&kubernetesMode, "kubernetes", "k", false, "Upgrade or downgrade Dapr in a Kubernetes cluster")
 	UpgradeCmd.Flags().UintVarP(&timeout, "timeout", "", 300, "The timeout for the Kubernetes upgrade")
-	UpgradeCmd.Flags().StringVarP(&upgradeRuntimeVersion, "runtime-version", "", "", "The version of the Dapr runtime to upgrade to, for example: 1.0.0")
+	UpgradeCmd.Flags().StringVarP(&upgradeRuntimeVersion, "runtime-version", "", "", "The version of the Dapr runtime to upgrade or downgrade to, for example: 1.0.0")
 	UpgradeCmd.Flags().BoolP("help", "h", false, "Print this help message")
 	UpgradeCmd.Flags().StringArrayVar(&values, "set", []string{}, "set values on the command line (can specify multiple or separate values with commas: key1=val1,key2=val2)")
 


### PR DESCRIPTION
# Description

Added "downgrade" language to "upgrade" in CLI command descriptions.

## Issue reference

Related docs PR: https://github.com/dapr/docs/pull/1703

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [x] Extended the documentation
