### PR TITLE
Skip CRD application during downgrade

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/gocarina/gocsv v0.0.0-20190426105157-2fc85fcf0c07
 	github.com/google/go-cmp v0.5.5 // indirect
 	github.com/hashicorp/go-retryablehttp v0.5.3
-	github.com/hashicorp/go-version v1.3.0 // indirect
+	github.com/hashicorp/go-version v1.3.0
 	github.com/mattn/go-runewidth v0.0.8 // indirect
 	github.com/mitchellh/go-ps v0.0.0-20190716172923-621e5597135b
 	github.com/nightlyone/lockfile v0.0.0-20180618180623-0ad87eef1443

--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/gocarina/gocsv v0.0.0-20190426105157-2fc85fcf0c07
 	github.com/google/go-cmp v0.5.5 // indirect
 	github.com/hashicorp/go-retryablehttp v0.5.3
+	github.com/hashicorp/go-version v1.3.0 // indirect
 	github.com/mattn/go-runewidth v0.0.8 // indirect
 	github.com/mitchellh/go-ps v0.0.0-20190716172923-621e5597135b
 	github.com/nightlyone/lockfile v0.0.0-20180618180623-0ad87eef1443

--- a/go.sum
+++ b/go.sum
@@ -626,6 +626,8 @@ github.com/hashicorp/go-syslog v1.0.0/go.mod h1:qPfqrKkXGihmCqbJM2mZgkZGvKG1dFdv
 github.com/hashicorp/go-uuid v1.0.0/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=
 github.com/hashicorp/go-uuid v1.0.1/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=
 github.com/hashicorp/go-version v1.2.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
+github.com/hashicorp/go-version v1.3.0 h1:McDWVJIU/y+u1BRV06dPaLfLCaT7fUTJLp5r04x7iNw=
+github.com/hashicorp/go-version v1.3.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
 github.com/hashicorp/go.net v0.0.1/go.mod h1:hjKkEWcCURg++eb33jQU7oqQcI9XDCnUzHA0oac0k90=
 github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=

--- a/pkg/kubernetes/upgrade_test.go
+++ b/pkg/kubernetes/upgrade_test.go
@@ -46,3 +46,10 @@ func TestArgsChartValues(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Len(t, val, 4)
 }
+
+func TestIsDowngrade(t *testing.T) {
+	assert.True(t, isDowngrade("1.3.0", "1.4.0-rc.5"))
+	assert.True(t, isDowngrade("1.3.0", "1.4.0"))
+	assert.False(t, isDowngrade("1.4.0-rc.5", "1.3.0"))
+	assert.False(t, isDowngrade("1.4.0", "1.3.0"))
+}


### PR DESCRIPTION
# Description
With the addition of the v2alpha1 subscription CRD, rolling back to
a previous version does not work seamlessly. This is due to k8s not
allowing a new CRD without the v2alpha1 version.

As CRDs are additive skipping their removal when downgrading should
not impact anything. Handling this with an implicit flag allows for
users to have an easy experience without touching the CRDs.

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: Endgame

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [ ] Extended the documentation
