### PR TITLE
Allow specifying of runtime-version via Env Var for `dapr init`

### DIFF
--- a/cmd/init.go
+++ b/cmd/init.go
@@ -59,6 +59,14 @@ dapr init -s
 	Run: func(cmd *cobra.Command, args []string) {
 		print.PendingStatusEvent(os.Stdout, "Making the jump to hyperspace...")
 
+		if runtimeVersion == "latest" {
+			runtimeVersionEnv := viper.GetString("runtime_version")
+			if runtimeVersionEnv != "" {
+				runtimeVersion = runtimeVersionEnv
+			}
+		}
+		print.InfoStatusEvent(os.Stdout, "Dapr runtime version: %s", runtimeVersion)
+
 		if kubernetesMode {
 			print.InfoStatusEvent(os.Stdout, "Note: To install Dapr using Helm, see here: https://docs.dapr.io/getting-started/install-dapr-kubernetes/#install-with-helm-advanced\n")
 
@@ -93,6 +101,7 @@ dapr init -s
 }
 
 func init() {
+	viper.BindEnv("runtime_version")
 	InitCmd.Flags().BoolVarP(&kubernetesMode, "kubernetes", "k", false, "Deploy Dapr to a Kubernetes cluster")
 	InitCmd.Flags().BoolVarP(&wait, "wait", "", false, "Wait for Kubernetes initialization to complete")
 	InitCmd.Flags().UintVarP(&timeout, "timeout", "", 300, "The wait timeout for the Kubernetes installation")

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -59,14 +59,6 @@ dapr init -s
 	Run: func(cmd *cobra.Command, args []string) {
 		print.PendingStatusEvent(os.Stdout, "Making the jump to hyperspace...")
 
-		if runtimeVersion == "latest" {
-			runtimeVersionEnv := viper.GetString("runtime_version")
-			if runtimeVersionEnv != "" {
-				runtimeVersion = runtimeVersionEnv
-			}
-		}
-		print.InfoStatusEvent(os.Stdout, "Dapr runtime version: %s", runtimeVersion)
-
 		if kubernetesMode {
 			print.InfoStatusEvent(os.Stdout, "Note: To install Dapr using Helm, see here: https://docs.dapr.io/getting-started/install-dapr-kubernetes/#install-with-helm-advanced\n")
 
@@ -101,12 +93,17 @@ dapr init -s
 }
 
 func init() {
-	viper.BindEnv("runtime_version")
+	defaultRuntimeVersion := "latest"
+	viper.BindEnv("runtime_version_override", "DAPR_RUNTIME_VERSION")
+	runtimeVersionEnv := viper.GetString("runtime_version_override")
+	if runtimeVersionEnv != "" {
+		defaultRuntimeVersion = runtimeVersionEnv
+	}
 	InitCmd.Flags().BoolVarP(&kubernetesMode, "kubernetes", "k", false, "Deploy Dapr to a Kubernetes cluster")
 	InitCmd.Flags().BoolVarP(&wait, "wait", "", false, "Wait for Kubernetes initialization to complete")
 	InitCmd.Flags().UintVarP(&timeout, "timeout", "", 300, "The wait timeout for the Kubernetes installation")
 	InitCmd.Flags().BoolVarP(&slimMode, "slim", "s", false, "Exclude placement service, Redis and Zipkin containers from self-hosted installation")
-	InitCmd.Flags().StringVarP(&runtimeVersion, "runtime-version", "", "latest", "The version of the Dapr runtime to install, for example: 1.0.0")
+	InitCmd.Flags().StringVarP(&runtimeVersion, "runtime-version", "", defaultRuntimeVersion, "The version of the Dapr runtime to install, for example: 1.0.0")
 	InitCmd.Flags().StringVarP(&dashboardVersion, "dashboard-version", "", "latest", "The version of the Dapr dashboard to install, for example: 1.0.0")
 	InitCmd.Flags().StringVarP(&initNamespace, "namespace", "n", "dapr-system", "The Kubernetes namespace to install Dapr in")
 	InitCmd.Flags().BoolVarP(&enableMTLS, "enable-mtls", "", true, "Enable mTLS in your cluster")


### PR DESCRIPTION
# Description

Allows optionally specifying of the runtime version with an environment variable.

## Justification:

When using `dapr init` / `dapr init -k` in workflows and tests it is handy to specify the runtime version via an environment variables.

This is particularly true where Dapr's Mechanical Markdown is used and the runtime version itself should not appear in the code snippets.
E.g. Quickstart validation, sample validation for Python and Go SDKs

Full example

```bash
export DAPR_RUNTIME_VERSION=1.4.3-rc.1
dapr init
```

Output
```
⌛  Making the jump to hyperspace...
ℹ️  Dapr runtime version: 1.4.3-rc.1
ℹ️  Installing runtime version 1.4.3-rc.1
↓  Downloading binaries and setting up components...
Dapr runtime installed to /Users/bverst/.dapr/bin, you may run the following to add it to your path if you want to run daprd directly:
    export PATH=$PATH:/Users/bverst/.dapr/bin
✅  Downloading binaries and setting up components...
✅  Downloaded binaries and completed components set up.
ℹ️  daprd binary has been installed to /Users/bverst/.dapr/bin.
ℹ️  dapr_placement container is running.
ℹ️  dapr_redis container is running.
ℹ️  dapr_zipkin container is running.
ℹ️  Use `docker ps` to check running containers.
✅  Success! Dapr is up and running. To get started, go here: https://aka.ms/dapr-getting-started
```

* [X] Code compiles correctly
* [ ] Created/updated tests
* [ ] Extended the documentation
