### PR TITLE
Update tests and build for runtime 1.5.0-rc.3

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.16
 require (
 	github.com/Pallinder/sillyname-go v0.0.0-20130730142914-97aeae9e6ba1
 	github.com/briandowns/spinner v1.6.1
-	github.com/dapr/dapr v1.5.0-rc.1
+	github.com/dapr/dapr v1.5.0-rc.3
 	github.com/dapr/go-sdk v1.0.0
 	github.com/docker/docker v17.12.0-ce-rc1.0.20200916142827-bd33bbf0497b+incompatible
 	github.com/emicklei/go-restful v2.10.0+incompatible // indirect

--- a/go.sum
+++ b/go.sum
@@ -308,8 +308,8 @@ github.com/cyphar/filepath-securejoin v0.2.2/go.mod h1:FpkQEhXnPnOthhzymB7CGsFk2
 github.com/dancannon/gorethink v4.0.0+incompatible/go.mod h1:BLvkat9KmZc1efyYwhz3WnybhRZtgF1K929FD8z1avU=
 github.com/danieljoos/wincred v1.0.2/go.mod h1:SnuYRW9lp1oJrZX/dXJqr0cPK5gYXqx3EJbmjhLdK9U=
 github.com/dapr/components-contrib v1.5.0-rc.1/go.mod h1:ixc7KCpP0Ra91hQG+/e2nwSmA9ESlAdLrqjK/zvjyXE=
-github.com/dapr/dapr v1.5.0-rc.1 h1:P7+3BgXqeQnui/arKVWbmxxiyJgW88TpU/0BZmwr4to=
-github.com/dapr/dapr v1.5.0-rc.1/go.mod h1:TLv3aJtm3yLNh8TDMHRz/Rkn8Oyx9l9O80RmXJZ1ZU0=
+github.com/dapr/dapr v1.5.0-rc.3 h1:dgIyhIbKRKQ6afstbV4ah99ueNrcyVHX+31VK8dUcY4=
+github.com/dapr/dapr v1.5.0-rc.3/go.mod h1:TLv3aJtm3yLNh8TDMHRz/Rkn8Oyx9l9O80RmXJZ1ZU0=
 github.com/dapr/go-sdk v1.0.0 h1:3nOmFzsPaHzzgINQQD9AFofVX6LV8QYJtpogaBfwkUg=
 github.com/dapr/go-sdk v1.0.0/go.mod h1:zyhsocIKv4pqQ2VtvWvf2CK1UhP7Z2OAOXgEpVxMgIs=
 github.com/dapr/kit v0.0.2-0.20210614175626-b9074b64d233 h1:M0dWIG8kUxEFU57IqTWeqptNqlBsfosFgsA5Ov7rJ8g=

--- a/tests/e2e/kubernetes/kubernetes_test.go
+++ b/tests/e2e/kubernetes/kubernetes_test.go
@@ -15,8 +15,8 @@ import (
 )
 
 const (
-	currentRuntimeVersion   = "1.5.0-rc.2"
-	currentDashboardVersion = "0.8.0"
+	currentRuntimeVersion   = "1.5.0-rc.3"
+	currentDashboardVersion = "0.9.0-rc.1"
 )
 
 var currentVersionDetails = common.VersionDetails{

--- a/tests/e2e/upgrade/upgrade_test.go
+++ b/tests/e2e/upgrade/upgrade_test.go
@@ -46,8 +46,8 @@ var supportedUpgradePaths = []upgradePath{
 			CustomResourceDefs:  []string{"components.dapr.io", "configurations.dapr.io", "subscriptions.dapr.io"},
 		},
 		next: common.VersionDetails{
-			RuntimeVersion:      "1.5.0-rc.2",
-			DashboardVersion:    "0.8.0",
+			RuntimeVersion:      "1.5.0-rc.3",
+			DashboardVersion:    "0.9.0-rc.1",
 			ClusterRoles:        []string{"dapr-operator-admin", "dashboard-reader"},
 			ClusterRoleBindings: []string{"dapr-operator", "dapr-role-tokenreview-binding", "dashboard-reader-global"},
 			CustomResourceDefs:  []string{"components.dapr.io", "configurations.dapr.io", "subscriptions.dapr.io"},


### PR DESCRIPTION
# Description

Update tests to use Dashboard 0.9.0-rc.1 and Runtime 1.5.0-rc.3

Also updates go.mod to use dapr/dapr 1.5.0-rc.3 (which doesn't actually include runtime code changes compared to 1.5.0-rc.1)