### PR TITLE
Update E2E tests to runtime 1.5.0 and dashboard 0.9.0

### DIFF
--- a/tests/e2e/kubernetes/kubernetes_test.go
+++ b/tests/e2e/kubernetes/kubernetes_test.go
@@ -15,8 +15,8 @@ import (
 )
 
 const (
-	currentRuntimeVersion   = "1.5.0-rc.3"
-	currentDashboardVersion = "0.9.0-rc.1"
+	currentRuntimeVersion   = "1.5.0"
+	currentDashboardVersion = "0.9.0"
 )
 
 var currentVersionDetails = common.VersionDetails{

--- a/tests/e2e/standalone/standalone_test.go
+++ b/tests/e2e/standalone/standalone_test.go
@@ -33,8 +33,8 @@ import (
 )
 
 const (
-	daprRuntimeVersion   = "1.4.0"
-	daprDashboardVersion = "0.8.0"
+	daprRuntimeVersion   = "1.5.0"
+	daprDashboardVersion = "0.9.0"
 )
 
 var socketCases = []string{"", "/tmp"}

--- a/tests/e2e/upgrade/upgrade_test.go
+++ b/tests/e2e/upgrade/upgrade_test.go
@@ -46,8 +46,8 @@ var supportedUpgradePaths = []upgradePath{
 			CustomResourceDefs:  []string{"components.dapr.io", "configurations.dapr.io", "subscriptions.dapr.io"},
 		},
 		next: common.VersionDetails{
-			RuntimeVersion:      "1.5.0-rc.3",
-			DashboardVersion:    "0.9.0-rc.1",
+			RuntimeVersion:      "1.5.0",
+			DashboardVersion:    "0.9.0",
 			ClusterRoles:        []string{"dapr-operator-admin", "dashboard-reader"},
 			ClusterRoleBindings: []string{"dapr-operator", "dapr-role-tokenreview-binding", "dashboard-reader-global"},
 			CustomResourceDefs:  []string{"components.dapr.io", "configurations.dapr.io", "subscriptions.dapr.io"},


### PR DESCRIPTION
# Description

Update E2E tests to runtime 1.5.0 and dashboard 0.9.0