### PR TITLE
fix shutdown hang when enable socket

### DIFF
--- a/pkg/metadata/metadata.go
+++ b/pkg/metadata/metadata.go
@@ -78,6 +78,10 @@ func Put(httpPort int, key, value, appID, socket string) error {
 	}
 
 	defer r.Body.Close()
+	if socket != "" {
+		// Retryablehttp does not close idle socket connections.
+		defer client.HTTPClient.CloseIdleConnections()
+	}
 	return nil
 }
 

--- a/tests/e2e/standalone/standalone_test.go
+++ b/tests/e2e/standalone/standalone_test.go
@@ -382,14 +382,13 @@ func testRun(t *testing.T) {
 		assert.Contains(t, output, "Exited Dapr successfully")
 	})
 
-	// t.Run("API shutdown with socket", func(t *testing.T) {
-	// 	// Test that the CLI exits on a daprd shutdown.
-	// 	output, err := spawn.Command(daprPath, "run", "--app-id", "testapp", "--unix-domain-socket", "/tmp", "--", "bash", "-c", "curl --unix-socket /tmp/dapr-testapp-http.socket -v -X POST http://unix/v1.0/shutdown; sleep 10; exit 1")
-	// 	t.Log(output)
-	// 	require.NoError(t, err, "run failed")
-	// 	assert.Contains(t, output, "Exited App successfully", "App should be shutdown before it has a chance to return non-zero")
-	// 	assert.Contains(t, output, "Exited Dapr successfully")
-	// })
+	t.Run("API shutdown with socket", func(t *testing.T) {
+		// Test that the CLI exits on a daprd shutdown.
+		output, err := spawn.Command(daprPath, "run", "--app-id", "testapp", "--unix-domain-socket", "/tmp", "--", "bash", "-c", "curl --unix-socket /tmp/dapr-testapp-http.socket -v -X POST http://unix/v1.0/shutdown; sleep 10; exit 1")
+		t.Log(output)
+		require.NoError(t, err, "run failed")
+		assert.Contains(t, output, "Exited Dapr successfully")
+	})
 }
 
 func executeAgainstRunningDapr(t *testing.T, f func(), daprArgs ...string) {

--- a/tests/e2e/standalone/standalone_test.go
+++ b/tests/e2e/standalone/standalone_test.go
@@ -37,9 +37,7 @@ const (
 	daprDashboardVersion = "0.9.0"
 )
 
-// Removing unix domain socket tests till shutdown API with unix domain sockets is fixed.
-// https://github.com/dapr/dapr/issues/3894
-var socketCases = []string{""}
+var socketCases = []string{"", "/tmp"}
 
 func TestStandaloneInstall(t *testing.T) {
 	// Ensure a clean environment.


### PR DESCRIPTION
Signed-off-by: Loong <loong.dai@intel.com>

# Description

Go-retryablehttp cannot close idle socket connections, need to call it by hand.

Fix https://github.com/dapr/dapr/issues/3894

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #_[issue number]_

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [ ] Created/updated tests
* [ ] Extended the documentation
