### PR TITLE
Publish events with CloudEvents envelopes

### DIFF
--- a/pkg/standalone/publish.go
+++ b/pkg/standalone/publish.go
@@ -60,12 +60,12 @@ func (s *Standalone) Publish(publishAppID, pubsubName, topic string, payload []b
 	// Detect publishing with CloudEvents envelope.
 	var cloudEvent map[string]interface{}
 	if json.Unmarshal(payload, &cloudEvent); err == nil {
-		_, hasId := cloudEvent["id"]
+		_, hasID := cloudEvent["id"]
 		_, hasSource := cloudEvent["source"]
 		_, hasSpecVersion := cloudEvent["specversion"]
 		_, hasType := cloudEvent["type"]
 		_, hasData := cloudEvent["data"]
-		if hasId && hasSource && hasSpecVersion && hasType && hasData {
+		if hasID && hasSource && hasSpecVersion && hasType && hasData {
 			contentType = "application/cloudevents+json"
 		}
 	}

--- a/pkg/standalone/testutils.go
+++ b/pkg/standalone/testutils.go
@@ -26,9 +26,46 @@ func (m *mockDaprProcess) List() ([]ListOutput, error) {
 	return m.Lo, m.Err
 }
 
+func getTestServerFunc(handler http.Handler) (*httptest.Server, int) {
+	ts := httptest.NewUnstartedServer(handler)
+
+	return ts, ts.Listener.Addr().(*net.TCPAddr).Port
+}
+
 func getTestServer(expectedPath, resp string) (*httptest.Server, int) {
-	ts := httptest.NewUnstartedServer(http.HandlerFunc(func(
-		w http.ResponseWriter, r *http.Request) {
+	ts := httptest.NewUnstartedServer(handlerTestPathResp(expectedPath, resp))
+
+	return ts, ts.Listener.Addr().(*net.TCPAddr).Port
+}
+
+func getTestSocketServerFunc(handler http.Handler, appID, path string) (*http.Server, net.Listener) {
+	s := &http.Server{
+		Handler: handler,
+	}
+
+	socket := utils.GetSocket(path, appID, "http")
+	l, err := net.Listen("unix", socket)
+	if err != nil {
+		panic(fmt.Sprintf("httptest: failed to listen on %v: %v", socket, err))
+	}
+	return s, l
+}
+
+func getTestSocketServer(expectedPath, resp, appID, path string) (*http.Server, net.Listener) {
+	s := &http.Server{
+		Handler: handlerTestPathResp(expectedPath, resp),
+	}
+
+	socket := utils.GetSocket(path, appID, "http")
+	l, err := net.Listen("unix", socket)
+	if err != nil {
+		panic(fmt.Sprintf("httptest: failed to listen on %v: %v", socket, err))
+	}
+	return s, l
+}
+
+func handlerTestPathResp(expectedPath, resp string) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
 		if expectedPath != "" && r.RequestURI != expectedPath {
 			w.WriteHeader(http.StatusInternalServerError)
 
@@ -41,33 +78,5 @@ func getTestServer(expectedPath, resp string) (*httptest.Server, int) {
 			buf.ReadFrom(r.Body)
 			w.Write(buf.Bytes())
 		}
-	}))
-
-	return ts, ts.Listener.Addr().(*net.TCPAddr).Port
-}
-
-func getTestSocketServer(expectedPath, resp, appID, path string) (*http.Server, net.Listener) {
-	s := &http.Server{
-		Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			if expectedPath != "" && r.RequestURI != expectedPath {
-				w.WriteHeader(http.StatusInternalServerError)
-
-				return
-			}
-			if r.Method == http.MethodGet {
-				w.Write([]byte(resp))
-			} else {
-				buf := new(bytes.Buffer)
-				buf.ReadFrom(r.Body)
-				w.Write(buf.Bytes())
-			}
-		}),
 	}
-
-	socket := utils.GetSocket(path, appID, "http")
-	l, err := net.Listen("unix", socket)
-	if err != nil {
-		panic(fmt.Sprintf("httptest: failed to listen on %v: %v", socket, err))
-	}
-	return s, l
 }

--- a/tests/e2e/standalone/standalone_test.go
+++ b/tests/e2e/standalone/standalone_test.go
@@ -489,7 +489,7 @@ func testPublish(t *testing.T) {
 	daprPath := getDaprPath()
 	for _, path := range socketCases {
 		executeAgainstRunningDapr(t, func() {
-			t.Run(fmt.Sprintf("publish from file with socket %s", path), func(t *testing.T) {
+			t.Run(fmt.Sprintf("publish message from file with socket %s", path), func(t *testing.T) {
 				output, err := spawn.Command(daprPath, "publish", "--publish-app-id", "pub_e2e", "--unix-domain-socket", path, "--pubsub", "pubsub", "--topic", "sample", "--data-file", "../testdata/message.json")
 				t.Log(output)
 				assert.NoError(t, err, "unable to publish from --data-file")
@@ -499,7 +499,7 @@ func testPublish(t *testing.T) {
 				assert.Equal(t, map[string]interface{}{"dapr": "is_great"}, event.Data)
 			})
 
-			t.Run(fmt.Sprintf("publish from file with socket %s", path), func(t *testing.T) {
+			t.Run(fmt.Sprintf("publish cloudevent from file with socket %s", path), func(t *testing.T) {
 				output, err := spawn.Command(daprPath, "publish", "--publish-app-id", "pub_e2e", "--unix-domain-socket", path, "--pubsub", "pubsub", "--topic", "sample", "--data-file", "../testdata/cloudevent.json")
 				t.Log(output)
 				assert.NoError(t, err, "unable to publish from --data-file")

--- a/tests/e2e/testdata/cloudevent.json
+++ b/tests/e2e/testdata/cloudevent.json
@@ -1,0 +1,9 @@
+{
+    "id": "3cc97064-edd1-49f4-b911-c959a7370e68",
+    "source": "e2e_test",
+    "specversion": "1.0",
+    "type": "test.v1",
+    "subject": "e2e_subject",
+    "datacontenttype": "application/json",
+    "data": {"dapr": "is_great"}
+}


### PR DESCRIPTION
Publish events with CloudEvent envelope with content type `application/cloudevents+json`

# Description

Added logic to detect CloudEvent envelopes by checking for the required fields `id`, `source`, `spec version`, `type`, and `data`. If all of these attributes are present, the content type is changed from `application/json` to `application/cloudevents+json`.

Most of the change was getting the unit tests to be more flexible with the HTTP test server handler logic.

I will be creating a Docs PR to add this information to https://docs.dapr.io/reference/cli/dapr-publish/

## Issue reference

Closes #838

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Created/updated tests
* [ ] Extended the documentation
