### PR TITLE
Ignore go.work for Go 1.18 Workspaces

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,6 @@ cli
 **/components
 
 test_output.json
+
+# Go Workspaces (introduced in Go 1.18+)
+go.work


### PR DESCRIPTION
Go 1.18 introduces Go workspaces. These can be used to pin specific go versions or maybe locally built library versions / dependencies.
See `https://github.com/golang/go/issues/45713`

This avoids the need to constantly update go.mod for local development. For example I commonly use replace to refer to components-contrib and dapr on my local file system instead of the remote.