### PR TITLE
Add flag to pass resiliency specifier to daprd

### DIFF
--- a/cmd/run.go
+++ b/cmd/run.go
@@ -47,6 +47,7 @@ var (
 	metricsPort        int
 	maxRequestBodySize int
 	unixDomainSocket   string
+	resiliencyFile     string
 )
 
 const (
@@ -108,6 +109,7 @@ var RunCmd = &cobra.Command{
 			MetricsPort:        metricsPort,
 			MaxRequestBodySize: maxRequestBodySize,
 			UnixDomainSocket:   unixDomainSocket,
+			ResiliencyFile:     resiliencyFile,
 		})
 		if err != nil {
 			print.FailureStatusEvent(os.Stderr, err.Error())
@@ -340,6 +342,7 @@ func init() {
 	RunCmd.Flags().BoolP("help", "h", false, "Print this help message")
 	RunCmd.Flags().IntVarP(&maxRequestBodySize, "dapr-http-max-request-size", "", -1, "Max size of request body in MB")
 	RunCmd.Flags().StringVarP(&unixDomainSocket, "unix-domain-socket", "u", "", "Path to a unix domain socket dir. If specified, Dapr API servers will use Unix Domain Sockets")
+	RunCmd.Flags().StringVarP(&resiliencyFile, "resiliency", "", standalone.DefaultResiliencyConfigFilePath(), "Dapr resiliency configuration file")
 
 	RootCmd.AddCommand(RunCmd)
 }

--- a/pkg/standalone/common.go
+++ b/pkg/standalone/common.go
@@ -20,10 +20,11 @@ import (
 )
 
 const (
-	defaultDaprDirName       = ".dapr"
-	defaultDaprBinDirName    = "bin"
-	defaultComponentsDirName = "components"
-	defaultConfigFileName    = "config.yaml"
+	defaultDaprDirName        = ".dapr"
+	defaultDaprBinDirName     = "bin"
+	defaultComponentsDirName  = "components"
+	defaultConfigFileName     = "config.yaml"
+	defaultResiliencyFileName = "resiliency.yaml"
 )
 
 func defaultDaprDirPath() string {
@@ -49,4 +50,8 @@ func DefaultComponentsDirPath() string {
 
 func DefaultConfigFilePath() string {
 	return path_filepath.Join(defaultDaprDirPath(), defaultConfigFileName)
+}
+
+func DefaultResiliencyConfigFilePath() string {
+	return path_filepath.Join(defaultDaprDirPath(), defaultResiliencyFileName)
 }

--- a/pkg/standalone/run.go
+++ b/pkg/standalone/run.go
@@ -51,6 +51,7 @@ type RunConfig struct {
 	MetricsPort        int
 	MaxRequestBodySize int
 	UnixDomainSocket   string
+	ResiliencyFile     string
 }
 
 // RunOutput represents the run output.
@@ -63,7 +64,7 @@ type RunOutput struct {
 }
 
 func getDaprCommand(appID string, daprHTTPPort int, daprGRPCPort int, appPort int, configFile, protocol string, enableProfiling bool,
-	profilePort int, logLevel string, maxConcurrency int, placementHostAddr string, componentsPath string, appSSL bool, metricsPort int, requestBodySize int, unixDomainSocket string) (*exec.Cmd, int, int, int, error) {
+	profilePort int, logLevel string, maxConcurrency int, placementHostAddr string, componentsPath string, appSSL bool, metricsPort int, requestBodySize int, unixDomainSocket string, resiliencyFile string) (*exec.Cmd, int, int, int, error) {
 	if daprHTTPPort < 0 {
 		port, err := freeport.GetFreePort()
 		if err != nil {
@@ -159,6 +160,10 @@ func getDaprCommand(appID string, daprHTTPPort int, daprGRPCPort int, appPort in
 		args = append(args, "--unix-domain-socket", unixDomainSocket)
 	}
 
+	if resiliencyFile != "" {
+		args = append(args, "--resiliency", resiliencyFile)
+	}
+
 	cmd := exec.Command(daprCMD, args...)
 	return cmd, daprHTTPPort, daprGRPCPort, metricsPort, nil
 }
@@ -225,7 +230,8 @@ func Run(config *RunConfig) (*RunOutput, error) {
 		return nil, err
 	}
 
-	daprCMD, daprHTTPPort, daprGRPCPort, metricsPort, err := getDaprCommand(appID, config.HTTPPort, config.GRPCPort, config.AppPort, config.ConfigFile, config.Protocol, config.EnableProfiling, config.ProfilePort, config.LogLevel, config.MaxConcurrency, config.PlacementHostAddr, config.ComponentsPath, config.AppSSL, config.MetricsPort, config.MaxRequestBodySize, config.UnixDomainSocket)
+	daprCMD, daprHTTPPort, daprGRPCPort, metricsPort, err := getDaprCommand(appID, config.HTTPPort, config.GRPCPort, config.AppPort, config.ConfigFile, config.Protocol, config.EnableProfiling, config.ProfilePort, config.LogLevel,
+		config.MaxConcurrency, config.PlacementHostAddr, config.ComponentsPath, config.AppSSL, config.MetricsPort, config.MaxRequestBodySize, config.UnixDomainSocket, config.ResiliencyFile)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/standalone/run_test.go
+++ b/pkg/standalone/run_test.go
@@ -93,6 +93,7 @@ func TestRun(t *testing.T) {
 		AppSSL:             true,
 		MetricsPort:        9001,
 		MaxRequestBodySize: -1,
+		ResiliencyFile:     "resiliency.yaml",
 	}
 
 	t.Run("run happy http", func(t *testing.T) {
@@ -116,6 +117,7 @@ func TestRun(t *testing.T) {
 		assertArgumentEqual(t, "components-path", DefaultComponentsDirPath(), output.DaprCMD.Args)
 		assertArgumentEqual(t, "app-ssl", "", output.DaprCMD.Args)
 		assertArgumentEqual(t, "metrics-port", "9001", output.DaprCMD.Args)
+		assertArgumentEqual(t, "resiliency", "resiliency.yaml", output.DaprCMD.Args)
 		if runtime.GOOS == "windows" {
 			assertArgumentEqual(t, "placement-host-address", "localhost:6050", output.DaprCMD.Args)
 		} else {


### PR DESCRIPTION
# Description

This commit allows for a resiliency configuration to be specified
and passed to the dapr runtime.

Signed-off-by: Hal Spang <halspang@microsoft.com>

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Partial: https://github.com/dapr/dapr/issues/3586

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Created/updated tests
* [ ] Extended the documentation
