### PR TITLE
Installer: Remove old Dapr CLI to avoid file corruption

### DIFF
--- a/install/install.sh
+++ b/install/install.sh
@@ -176,6 +176,9 @@ installFile() {
         exit 1
     fi
 
+    if [ -f "$DAPR_CLI_FILE" ]; then
+        runAsRoot rm "$DAPR_CLI_FILE"
+    fi
     chmod o+x $tmp_root_dapr_cli
     runAsRoot cp "$tmp_root_dapr_cli" "$DAPR_INSTALL_DIR"
 


### PR DESCRIPTION
Signed-off-by: Bernd Verst <4535280+berndverst@users.noreply.github.com>

# Description

Currently the installer corrupts binaries when the Dapr version is updated. This addresses the problem.