### PR TITLE
dapr init: enable redis query to work in self-hosted environment

### DIFF
--- a/pkg/standalone/standalone.go
+++ b/pkg/standalone/standalone.go
@@ -48,7 +48,7 @@ const (
 	daprDefaultHost            = "localhost"
 	pubSubYamlFileName         = "pubsub.yaml"
 	stateStoreYamlFileName     = "statestore.yaml"
-	redisDockerImageName       = "redis"
+	redisDockerImageName       = "redislabs/rejson"
 	zipkinDockerImageName      = "openzipkin/zipkin"
 
 	// DaprPlacementContainerName is the container name of placement service.


### PR DESCRIPTION
# Description

Enable Redis Query to work in self-hosted developer deployments with Dapr init

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #906

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [ ] Created/updated tests
* [ ] Extended the documentation
