### PR TITLE
Changes for cli command to renew certificate

### DIFF
--- a/README.md
+++ b/README.md
@@ -437,6 +437,23 @@ dapr mtls expiry
 
 This can be used when upgrading to a newer version of Dapr, as it's recommended to carry over the existing certs for a zero downtime upgrade.
 
+### Renew Dapr certificates of a kubernetes cluster with one of the 3 ways mentioned below:
+Renew certificate by generating new root and issuer certificates
+
+```bash
+dapr mtls renew-certificate -k --valid-until <no of days> --restart
+```
+Use existing private root.key to generate new root and issuer certificates
+
+```bash
+dapr mtls renew-certificate -k --certificate-password-file myprivatekey.key --valid-until <no of days>
+```
+Use user provided ca.crt, issuer.crt and issuer.key
+
+```bash
+dapr mtls renew-certificate -k --ca-root-certificate <ca.crt> --issuer-private-key <issuer.key> --issuer-public-certificate <issuer.crt> --restart
+```
+
 ### List Components
 
 To list all Dapr components on Kubernetes:

--- a/README.md
+++ b/README.md
@@ -446,7 +446,7 @@ dapr mtls renew-certificate -k --valid-until <no of days> --restart
 Use existing private root.key to generate new root and issuer certificates
 
 ```bash
-dapr mtls renew-certificate -k --certificate-password-file myprivatekey.key --valid-until <no of days>
+dapr mtls renew-certificate -k --private-key myprivatekey.key --valid-until <no of days>
 ```
 Use user provided ca.crt, issuer.crt and issuer.key
 

--- a/cmd/mtls.go
+++ b/cmd/mtls.go
@@ -101,6 +101,6 @@ func init() {
 	MTLSCmd.MarkFlagRequired("kubernetes")
 	MTLSCmd.AddCommand(ExportCMD)
 	MTLSCmd.AddCommand(ExpiryCMD)
-	MTLSCmd.AddCommand(RenewCertificateCmd)
+	MTLSCmd.AddCommand(RenewCertificateCmd())
 	RootCmd.AddCommand(MTLSCmd)
 }

--- a/cmd/mtls.go
+++ b/cmd/mtls.go
@@ -101,5 +101,6 @@ func init() {
 	MTLSCmd.MarkFlagRequired("kubernetes")
 	MTLSCmd.AddCommand(ExportCMD)
 	MTLSCmd.AddCommand(ExpiryCMD)
+	MTLSCmd.AddCommand(RenewCertificateCmd)
 	RootCmd.AddCommand(MTLSCmd)
 }

--- a/cmd/renew_certificate.go
+++ b/cmd/renew_certificate.go
@@ -26,7 +26,7 @@ import (
 )
 
 var (
-	certificatePasswordFile     string
+	privateKey                  string
 	caRootCertificateFile       string
 	issuerPrivateKeyFile        string
 	issuerPublicCertificateFile string
@@ -66,10 +66,10 @@ dapr mtls renew-certificate -k --ca-root-certificate <ca.crt> --issuer-private-k
 					if err != nil {
 						logErrorAndExit(err)
 					}
-				} else if certificatePasswordFile != "" {
+				} else if privateKey != "" {
 					print.InfoStatusEvent(os.Stdout, "Using password file to generate root certificate")
 					err := kubernetes.RenewCertificate(kubernetes.RenewCertificateParams{
-						RootPrivateKeyFilePath: certificatePasswordFile,
+						RootPrivateKeyFilePath: privateKey,
 						ValidUntil:             time.Hour * time.Duration(validUntil*24),
 						Timeout:                timeout,
 					})
@@ -107,7 +107,7 @@ dapr mtls renew-certificate -k --ca-root-certificate <ca.crt> --issuer-private-k
 	}
 
 	command.Flags().BoolVarP(&kubernetesMode, "kubernetes", "k", false, "Renews root and issuer certificates of Dapr in a Kubernetes cluster")
-	command.Flags().StringVarP(&certificatePasswordFile, "certificate-password-file", "", "", "The root.key file which is used to generate root certificate")
+	command.Flags().StringVarP(&privateKey, "private-key", "", "", "The root.key file which is used to generate root certificate")
 	command.Flags().StringVarP(&caRootCertificateFile, "ca-root-certificate", "", "", "The root certificate file")
 	command.Flags().StringVarP(&issuerPrivateKeyFile, "issuer-private-key", "", "", "The issuer certificate private key")
 	command.Flags().StringVarP(&issuerPublicCertificateFile, "issuer-public-certificate", "", "", "The issuer certificate")

--- a/cmd/renew_certificate.go
+++ b/cmd/renew_certificate.go
@@ -59,8 +59,8 @@ dapr mtls renew-certificate -k --ca-root-certificate <ca.crt> --issuer-private-k
 					print.InfoStatusEvent(os.Stdout, "Using provided certificates")
 					err := kubernetes.RenewCertificate(kubernetes.RenewCertificateParams{
 						RootCertificateFilePath:   caRootCertificateFile,
-						IssuerCertificateFilePath: issuerPrivateKeyFile,
-						IssuerPrivateKeyFilePath:  issuerPublicCertificateFile,
+						IssuerCertificateFilePath: issuerPublicCertificateFile,
+						IssuerPrivateKeyFilePath:  issuerPrivateKeyFile,
 						Timeout:                   timeout,
 					})
 					if err != nil {

--- a/cmd/renew_certificate.go
+++ b/cmd/renew_certificate.go
@@ -1,0 +1,67 @@
+/*
+Copyright 2021 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/dapr/cli/pkg/kubernetes"
+	"github.com/spf13/cobra"
+)
+
+var (
+	certificatePasswordFile     string
+	caRootCertificateFile       string
+	issuerPrivateKeyFile        string
+	issuerPublicCertificateFile string
+)
+var RenewCertificateCmd = &cobra.Command{
+	Use:   "renew-cert",
+	Short: "Rotates Dapr root certificate of your kubernetes cluster",
+	Example: `
+# Generates new root and issuer certificates for kubernetest cluster
+dapr upgrade renew-cert -k 
+
+# Uses existing private root.key to generate new root and issuer certificates for kubernetest cluster
+dapr upgrade renew-cert -k --certificate-password-file myprivatekey.key
+
+# Rotates certificate of your kubernetes cluster with provided ca.cert, issuer.crt and issuer.key file path
+dapr upgrade renew-cert -k --ca-root-certificate <ca.crt> --issuer-private-key <issuer.key> --issuer-public-certificate <issuer.crt>
+
+# See more at: https://docs.dapr.io/getting-started/
+`,
+	Run: func(cmd *cobra.Command, args []string) {
+		if kubernetesMode {
+			if caRootCertificateFile != "" && issuerPrivateKeyFile != "" && issuerPublicCertificateFile != "" {
+				kubernetes.RenewCertificate(caRootCertificateFile, issuerPrivateKeyFile, issuerPublicCertificateFile)
+			} else if certificatePasswordFile != "" {
+				fmt.Println("Reuse root password to generatre th root.pem file")
+			} else {
+				fmt.Println("Generate fresh certificate")
+			}
+		} else {
+			fmt.Println("standalone mode")
+		}
+		fmt.Println("in subcommand renew-certificate")
+	},
+}
+
+func init() {
+	RenewCertificateCmd.Flags().BoolVarP(&kubernetesMode, "kubernetes", "k", false, "Upgrades/Renews root certificate of Dapr in a Kubernetes cluster")
+	RenewCertificateCmd.Flags().StringVarP(&certificatePasswordFile, "certificate-password-file", "", "", "The version of the Dapr runtime to upgrade or downgrade to, for example: 1.0.0")
+	RenewCertificateCmd.Flags().StringVarP(&caRootCertificateFile, "ca-root-certificate", "", "", "The version of the Dapr runtime to upgrade or downgrade to, for example: 1.0.0")
+	RenewCertificateCmd.Flags().StringVarP(&issuerPrivateKeyFile, "issuer-private-key", "", "", "The version of the Dapr runtime to upgrade or downgrade to, for example: 1.0.0")
+	RenewCertificateCmd.Flags().StringVarP(&issuerPublicCertificateFile, "issuer-public-certificate", "", "", "The version of the Dapr runtime to upgrade or downgrade to, for example: 1.0.0")
+	UpgradeCmd.AddCommand(RenewCertificateCmd)
+}

--- a/cmd/renew_certificate.go
+++ b/cmd/renew_certificate.go
@@ -44,7 +44,7 @@ func RenewCertificateCmd() *cobra.Command {
 dapr mtls renew-certificate -k --valid-until <no of days> --restart
 
 # Uses existing private root.key to generate new root and issuer certificates for kubernetes cluster
-dapr mtls renew-certificate -k --certificate-password-file myprivatekey.key --valid-until <no of days>
+dapr mtls renew-certificate -k --private-key myprivatekey.key --valid-until <no of days>
 
 # Rotates certificate of your kubernetes cluster with provided ca.cert, issuer.crt and issuer.key file path
 dapr mtls renew-certificate -k --ca-root-certificate <ca.crt> --issuer-private-key <issuer.key> --issuer-public-certificate <issuer.crt> --restart

--- a/cmd/upgrade.go
+++ b/cmd/upgrade.go
@@ -45,7 +45,7 @@ dapr upgrade -k
 		}
 		print.SuccessStatusEvent(os.Stdout, "Dapr control plane successfully upgraded to version %s. Make sure your deployments are restarted to pick up the latest sidecar version.", upgradeRuntimeVersion)
 	},
-	PostRun: func(cmd *cobra.Command, args []string) {
+	PersistentPostRun: func(cmd *cobra.Command, args []string) {
 		kubernetes.CheckForCertExpiry()
 	},
 }

--- a/cmd/upgrade.go
+++ b/cmd/upgrade.go
@@ -45,7 +45,7 @@ dapr upgrade -k
 		}
 		print.SuccessStatusEvent(os.Stdout, "Dapr control plane successfully upgraded to version %s. Make sure your deployments are restarted to pick up the latest sidecar version.", upgradeRuntimeVersion)
 	},
-	PersistentPostRun: func(cmd *cobra.Command, args []string) {
+	PostRun: func(cmd *cobra.Command, args []string) {
 		kubernetes.CheckForCertExpiry()
 	},
 }

--- a/pkg/kubernetes/common.go
+++ b/pkg/kubernetes/common.go
@@ -1,0 +1,64 @@
+/*
+Copyright 2021 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kubernetes
+
+import (
+	"errors"
+	"strings"
+
+	helm "helm.sh/helm/v3/pkg/action"
+)
+
+func GetDaprResourcesStatus() ([]StatusOutput, error) {
+	sc, err := NewStatusClient()
+	if err != nil {
+		return nil, err
+	}
+
+	status, err := sc.Status()
+	if err != nil {
+		return nil, err
+	}
+
+	if len(status) == 0 {
+		return nil, errors.New("dapr is not installed in your cluster")
+	}
+	return status, nil
+}
+
+func GetDaprHelmChartName(helmConf *helm.Configuration) (string, error) {
+	listClient := helm.NewList(helmConf)
+	releases, err := listClient.Run()
+	if err != nil {
+		return "", err
+	}
+	var chart string
+	for _, r := range releases {
+		if r.Chart != nil && strings.Contains(r.Chart.Name(), "dapr") {
+			chart = r.Name
+			break
+		}
+	}
+	return chart, nil
+}
+
+func GetDaprVersion(status []StatusOutput) string {
+	var daprVersion string
+	for _, s := range status {
+		if s.Name == operatorName {
+			daprVersion = s.Version
+		}
+	}
+	return daprVersion
+}

--- a/pkg/kubernetes/renew_certificate.go
+++ b/pkg/kubernetes/renew_certificate.go
@@ -1,0 +1,97 @@
+/*
+Copyright 2021 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kubernetes
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+
+	"github.com/dapr/cli/pkg/print"
+	helm "helm.sh/helm/v3/pkg/action"
+	"k8s.io/helm/pkg/strvals"
+)
+
+func RenewCertificate(caRootCertificateFile, issuerPrivateKeyFile, issuerPublicCertificateFile string) error {
+	ca, err := ioutil.ReadFile(caRootCertificateFile)
+	if err != nil {
+		return err
+	}
+	issuerCert, err := ioutil.ReadFile(issuerPublicCertificateFile)
+	if err != nil {
+		return err
+	}
+	issuerKey, err := ioutil.ReadFile(issuerPrivateKeyFile)
+	if err != nil {
+		return err
+	}
+
+	status, err := GetDaprResourcesStatus()
+	if err != nil {
+		return err
+	}
+
+	daprVersion := GetDaprVersion(status)
+	print.InfoStatusEvent(os.Stdout, "Dapr control plane version %s detected in namespace %s", daprVersion, status[0].Namespace)
+
+	helmConf, err := helmConfig(status[0].Namespace)
+	if err != nil {
+		return err
+	}
+
+	daprChart, err := daprChart(daprVersion, helmConf)
+	if err != nil {
+		return err
+	}
+	upgradeClient := helm.NewUpgrade(helmConf)
+	upgradeClient.ReuseValues = true
+	upgradeClient.Wait = true
+	upgradeClient.Namespace = status[0].Namespace
+
+	vals, err := setCertificateValues(string(ca), string(issuerCert), string(issuerKey))
+	if err != nil {
+		return err
+	}
+
+	chart, err := GetDaprHelmChartName(helmConf)
+	if err != nil {
+		return err
+	}
+
+	if _, err = upgradeClient.Run(chart, daprChart, vals); err != nil {
+		return err
+	}
+	return nil
+}
+
+func setCertificateValues(ca, issuerCert, issuerKey string) (map[string]interface{}, error) {
+	chartVals := map[string]interface{}{}
+	args := []string{}
+
+	if ca != "" && issuerCert != "" && issuerKey != "" {
+		args = append(args, fmt.Sprintf("dapr_sentry.tls.root.certPEM=%s", ca),
+			fmt.Sprintf("dapr_sentry.tls.issuer.certPEM=%s", issuerCert),
+			fmt.Sprintf("dapr_sentry.tls.issuer.keyPEM=%s", issuerKey),
+		)
+	} else {
+		return nil, fmt.Errorf("parameters not found")
+	}
+
+	for _, v := range args {
+		if err := strvals.ParseInto(v, chartVals); err != nil {
+			return nil, err
+		}
+	}
+	return chartVals, nil
+}

--- a/pkg/kubernetes/renew_certificate.go
+++ b/pkg/kubernetes/renew_certificate.go
@@ -59,7 +59,7 @@ func RenewCertificate(caRootCertificateFile, issuerPrivateKeyFile, issuerPublicC
 	upgradeClient.Wait = true
 	upgradeClient.Namespace = status[0].Namespace
 
-	vals, err := setCertificateValues(string(ca), string(issuerCert), string(issuerKey))
+	vals, err := createHelmParamsForNewCertificates(string(ca), string(issuerCert), string(issuerKey))
 	if err != nil {
 		return err
 	}
@@ -75,7 +75,7 @@ func RenewCertificate(caRootCertificateFile, issuerPrivateKeyFile, issuerPublicC
 	return nil
 }
 
-func setCertificateValues(ca, issuerCert, issuerKey string) (map[string]interface{}, error) {
+func createHelmParamsForNewCertificates(ca, issuerCert, issuerKey string) (map[string]interface{}, error) {
 	chartVals := map[string]interface{}{}
 	args := []string{}
 
@@ -94,4 +94,10 @@ func setCertificateValues(ca, issuerCert, issuerKey string) (map[string]interfac
 		}
 	}
 	return chartVals, nil
+}
+
+func GenerateNewCertificates(validUntil int, newCertDir, certificatePasswordFile string) (map[string]interface{}, error) {
+	certPaths := map[string]interface{}{}
+
+	return certPaths, nil
 }

--- a/pkg/kubernetes/renew_certificate.go
+++ b/pkg/kubernetes/renew_certificate.go
@@ -149,7 +149,7 @@ func GenerateNewCertificates(validUntil time.Duration, certificatePasswordFile s
 	if err != nil {
 		return nil, nil, nil, err
 	}
-	rootCsr, err := csr.GenerateRootCertCSR("dapr.io/sentry", "cluster.local", &rootKey.PublicKey, time.Hour*validUntil, time.Minute*15)
+	rootCsr, err := csr.GenerateRootCertCSR("dapr.io/sentry", "cluster.local", &rootKey.PublicKey, validUntil, time.Minute*15)
 	if err != nil {
 		return nil, nil, nil, err
 	}
@@ -173,7 +173,7 @@ func GenerateNewCertificates(validUntil time.Duration, certificatePasswordFile s
 	}
 	issuerKeyPem := pem.EncodeToMemory(&pem.Block{Type: certs.ECPrivateKey, Bytes: encodedKey})
 
-	issuerCsr, err := csr.GenerateIssuerCertCSR("cluster.local", &issuerKey.PublicKey, time.Hour*validUntil, time.Minute*15)
+	issuerCsr, err := csr.GenerateIssuerCertCSR("cluster.local", &issuerKey.PublicKey, validUntil, time.Minute*15)
 	if err != nil {
 		return nil, nil, nil, err
 	}

--- a/tests/e2e/kubernetes/kubernetes_test.go
+++ b/tests/e2e/kubernetes/kubernetes_test.go
@@ -196,7 +196,7 @@ func TestRenewCertificateMTLSEnabled(t *testing.T) {
 
 	// tests for certificate renewal with provided certificates.
 	tests = append(tests, []common.TestCase{
-		{"Renew certificate which expires in after 30 days", common.UseProvidedNewCertAndRenew(currentVersionDetails)},
+		{"Renew certificate which expires in after 30 days", common.UseProvidedNewCertAndRenew(currentVersionDetails, installOpts)},
 	}...)
 	tests = append(tests, common.GetTestsPostCertificateRenewal(currentVersionDetails, installOpts)...)
 	tests = append(tests, []common.TestCase{
@@ -245,7 +245,7 @@ func TestRenewCertificateMTLSDisabled(t *testing.T) {
 
 	// tests for certificate renewal with provided certificates.
 	tests = append(tests, []common.TestCase{
-		{"Renew certificate which expires in after 30 days", common.UseProvidedNewCertAndRenew(currentVersionDetails)},
+		{"Renew certificate which expires in after 30 days", common.UseProvidedNewCertAndRenew(currentVersionDetails, installOpts)},
 	}...)
 	tests = append(tests, common.GetTestsPostCertificateRenewal(currentVersionDetails, installOpts)...)
 	tests = append(tests, []common.TestCase{

--- a/tests/e2e/kubernetes/kubernetes_test.go
+++ b/tests/e2e/kubernetes/kubernetes_test.go
@@ -186,20 +186,11 @@ func TestRenewCertificateMTLSEnabled(t *testing.T) {
 
 	// tests for certifcate renewal with newly generated certificates.
 	tests = append(tests, []common.TestCase{
-		{"Renew certificate which expires in less than 30 days", common.GenerateNewCertAndRenew(currentVersionDetails)},
+		{"Renew certificate which expires in less than 30 days", common.GenerateNewCertAndRenew(currentVersionDetails, installOpts)},
 	}...)
 	tests = append(tests, common.GetTestsPostCertificateRenewal(currentVersionDetails, installOpts)...)
 	tests = append(tests, []common.TestCase{
 		{"Cert Expiry warning message check " + currentVersionDetails.RuntimeVersion, common.CheckMTLSStatus(currentVersionDetails, installOpts, true)},
-	}...)
-
-	// tests for certificate renewal with provided certificates.
-	tests = append(tests, []common.TestCase{
-		{"Renew certificate which expires in after 30 days", common.UseProvidedNewCertAndRenew(currentVersionDetails)},
-	}...)
-	tests = append(tests, common.GetTestsPostCertificateRenewal(currentVersionDetails, installOpts)...)
-	tests = append(tests, []common.TestCase{
-		{"Cert Expiry no warning message check " + currentVersionDetails.RuntimeVersion, common.CheckMTLSStatus(currentVersionDetails, installOpts, false)},
 	}...)
 
 	// teardown everything
@@ -235,20 +226,11 @@ func TestRenewCertificateMTLSDisabled(t *testing.T) {
 
 	// tests for certifcate renewal with newly generated certificates.
 	tests = append(tests, []common.TestCase{
-		{"Renew certificate which expires in less than 30 days", common.GenerateNewCertAndRenew(currentVersionDetails)},
+		{"Renew certificate which expires in less than 30 days", common.GenerateNewCertAndRenew(currentVersionDetails, installOpts)},
 	}...)
 	tests = append(tests, common.GetTestsPostCertificateRenewal(currentVersionDetails, installOpts)...)
 	tests = append(tests, []common.TestCase{
 		{"Cert Expiry warning message check " + currentVersionDetails.RuntimeVersion, common.CheckMTLSStatus(currentVersionDetails, installOpts, true)},
-	}...)
-
-	// tests for certificate renewal with provided certificates.
-	tests = append(tests, []common.TestCase{
-		{"Renew certificate which expires in after 30 days", common.UseProvidedNewCertAndRenew(currentVersionDetails)},
-	}...)
-	tests = append(tests, common.GetTestsPostCertificateRenewal(currentVersionDetails, installOpts)...)
-	tests = append(tests, []common.TestCase{
-		{"Cert Expiry no warning message check " + currentVersionDetails.RuntimeVersion, common.CheckMTLSStatus(currentVersionDetails, installOpts, false)},
 	}...)
 
 	// teardown everything

--- a/tests/e2e/kubernetes/kubernetes_test.go
+++ b/tests/e2e/kubernetes/kubernetes_test.go
@@ -152,8 +152,9 @@ func TestKubernetesHAModeMTLSEnabled(t *testing.T) {
 	})...)
 
 	tests = append(tests, common.GetTestsOnUninstall(currentVersionDetails, common.TestOptions{
+		UninstallAll: true,
 		CheckResourceExists: map[common.Resource]bool{
-			common.CustomResourceDefs:  true,
+			common.CustomResourceDefs:  false,
 			common.ClusterRoles:        false,
 			common.ClusterRoleBindings: false,
 		},
@@ -191,6 +192,15 @@ func TestRenewCertificateMTLSEnabled(t *testing.T) {
 	tests = append(tests, common.GetTestsPostCertificateRenewal(currentVersionDetails, installOpts)...)
 	tests = append(tests, []common.TestCase{
 		{"Cert Expiry warning message check " + currentVersionDetails.RuntimeVersion, common.CheckMTLSStatus(currentVersionDetails, installOpts, true)},
+	}...)
+
+	// tests for certificate renewal with provided certificates.
+	tests = append(tests, []common.TestCase{
+		{"Renew certificate which expires in after 30 days", common.UseProvidedNewCertAndRenew(currentVersionDetails)},
+	}...)
+	tests = append(tests, common.GetTestsPostCertificateRenewal(currentVersionDetails, installOpts)...)
+	tests = append(tests, []common.TestCase{
+		{"Cert Expiry no warning message check " + currentVersionDetails.RuntimeVersion, common.CheckMTLSStatus(currentVersionDetails, installOpts, false)},
 	}...)
 
 	// teardown everything
@@ -231,6 +241,15 @@ func TestRenewCertificateMTLSDisabled(t *testing.T) {
 	tests = append(tests, common.GetTestsPostCertificateRenewal(currentVersionDetails, installOpts)...)
 	tests = append(tests, []common.TestCase{
 		{"Cert Expiry warning message check " + currentVersionDetails.RuntimeVersion, common.CheckMTLSStatus(currentVersionDetails, installOpts, true)},
+	}...)
+
+	// tests for certificate renewal with provided certificates.
+	tests = append(tests, []common.TestCase{
+		{"Renew certificate which expires in after 30 days", common.UseProvidedNewCertAndRenew(currentVersionDetails)},
+	}...)
+	tests = append(tests, common.GetTestsPostCertificateRenewal(currentVersionDetails, installOpts)...)
+	tests = append(tests, []common.TestCase{
+		{"Cert Expiry no warning message check " + currentVersionDetails.RuntimeVersion, common.CheckMTLSStatus(currentVersionDetails, installOpts, false)},
 	}...)
 
 	// teardown everything

--- a/tests/e2e/kubernetes/kubernetes_test.go
+++ b/tests/e2e/kubernetes/kubernetes_test.go
@@ -152,9 +152,8 @@ func TestKubernetesHAModeMTLSEnabled(t *testing.T) {
 	})...)
 
 	tests = append(tests, common.GetTestsOnUninstall(currentVersionDetails, common.TestOptions{
-		UninstallAll: true,
 		CheckResourceExists: map[common.Resource]bool{
-			common.CustomResourceDefs:  false,
+			common.CustomResourceDefs:  true,
 			common.ClusterRoles:        false,
 			common.ClusterRoleBindings: false,
 		},

--- a/tests/e2e/testdata/namespace.yaml
+++ b/tests/e2e/testdata/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: test

--- a/tests/e2e/testdata/statestore.yaml
+++ b/tests/e2e/testdata/statestore.yaml
@@ -16,11 +16,6 @@ spec:
 scopes:
   - app1
 ---
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: test
----
 apiVersion: dapr.io/v1alpha1
 kind: Component
 metadata:


### PR DESCRIPTION
Signed-off-by: Pravin Pushkar <ppushkar@microsoft.com>

# Description

Adding new commands to renew expiring certificate.
```
# Generates new root and issuer certificates for kubernetest cluster
dapr mtls renew-certificate -k --valid-until <no of days> --restart

# Uses existing private root.key to generate new root and issuer certificates for kubernetes cluster
dapr mtls renew-certificate -k --certificate-password-file myprivatekey.key --valid-until <no of days>

# Rotates certificate of your kubernetes cluster with provided ca.cert, issuer.crt and issuer.key file path
dapr mtls renew-certificate -k --ca-root-certificate <ca.crt> --issuer-private-key <issuer.key> --issuer-public-certificate <issuer.crt> --restart
```

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #892 

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Created/updated tests
* [x] Extended the documentation
