### PR TITLE
Revert "dapr init: enable redis query to work in self-hosted env

### DIFF
--- a/pkg/standalone/standalone.go
+++ b/pkg/standalone/standalone.go
@@ -48,7 +48,7 @@ const (
 	daprDefaultHost            = "localhost"
 	pubSubYamlFileName         = "pubsub.yaml"
 	stateStoreYamlFileName     = "statestore.yaml"
-	redisDockerImageName       = "redislabs/rejson"
+	redisDockerImageName       = "redis"
 	zipkinDockerImageName      = "openzipkin/zipkin"
 
 	githubContainerRegistryName = "ghcr"


### PR DESCRIPTION
This reverts commit f3cecee471ca53e728bb56f59bd74dd26da50915.

# Description

Reference -  PR discussion on https://github.com/dapr/cli/pull/930.  rejson has support for amd64 arch only, whereas redis has support for many archs.
https://hub.docker.com/r/redislabs/rejson/tags
https://hub.docker.com/_/redis/?tab=tags

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: NA

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [ ] Extended the documentation
