### PR TITLE
Fix for image pull from private registry

### DIFF
--- a/pkg/standalone/standalone.go
+++ b/pkg/standalone/standalone.go
@@ -146,9 +146,11 @@ func Init(runtimeVersion, dashboardVersion string, dockerNetwork string, slimMod
 		if !dockerInstalled {
 			return errors.New("could not connect to Docker. Docker may not be installed or running")
 		}
-		defaultImageRegistryName, err = utils.GetDefaultRegistry(githubContainerRegistryName, dockerContainerRegistryName)
-		if err != nil {
-			return err
+		if imageRegistryURL == "" {
+			defaultImageRegistryName, err = utils.GetDefaultRegistry(githubContainerRegistryName, dockerContainerRegistryName)
+			if err != nil {
+				return err
+			}
 		}
 	}
 
@@ -427,7 +429,7 @@ func runPlacementService(wg *sync.WaitGroup, errorChan chan<- error, info initIn
 	}
 	image = getPlacementImageWithTag(image, info.runtimeVersion)
 
-	if defaultImageRegistryName == githubContainerRegistryName {
+	if info.imageRegistryURL == "" && defaultImageRegistryName == githubContainerRegistryName {
 		if !TryPullImage(image) {
 			print.InfoStatusEvent(os.Stdout, "Placement image not found in Github container registry, pulling it from Docker Hub")
 			image = getPlacementImageWithTag(daprDockerImageName, info.runtimeVersion)

--- a/pkg/standalone/standalone.go
+++ b/pkg/standalone/standalone.go
@@ -147,7 +147,7 @@ func Init(runtimeVersion, dashboardVersion string, dockerNetwork string, slimMod
 			return errors.New("could not connect to Docker. Docker may not be installed or running")
 		}
 
-		// Initialise default registry only if it is not airgap mode or init for private registries.
+		// Initialize default registry only if it is not airgap mode or from private registries.
 		if len(strings.TrimSpace(imageRegistryURL)) == 0 && len(strings.TrimSpace(fromDir)) == 0 {
 			defaultImageRegistryName, err = utils.GetDefaultRegistry(githubContainerRegistryName, dockerContainerRegistryName)
 			if err != nil {
@@ -1072,6 +1072,8 @@ func getPlacementImageWithTag(name, version string) string {
 	return fmt.Sprintf("%s:%s", name, version)
 }
 
+// Try for fallback image from docker iff this init flow is using GHCR as default registry.
+// TODO: We may want to remove this logic completely after next couple of releases.
 func checkFallbackImgForPlacement(imageInfo daprImageInfo, fromDir string) bool {
 	if imageInfo.imageRegistryURL != "" || fromDir != "" {
 		return false

--- a/pkg/standalone/standalone.go
+++ b/pkg/standalone/standalone.go
@@ -430,7 +430,7 @@ func runPlacementService(wg *sync.WaitGroup, errorChan chan<- error, info initIn
 	}
 	image = getPlacementImageWithTag(image, info.runtimeVersion)
 
-	if checkFallbackImg(imgInfo) {
+	if checkFallbackImg(imgInfo, info.fromDir) {
 		if !TryPullImage(image) {
 			print.InfoStatusEvent(os.Stdout, "Placement image not found in Github container registry, pulling it from Docker Hub")
 			image = getPlacementImageWithTag(daprDockerImageName, info.runtimeVersion)
@@ -1070,8 +1070,8 @@ func getPlacementImageWithTag(name, version string) string {
 	return fmt.Sprintf("%s:%s", name, version)
 }
 
-func checkFallbackImg(imageInfo daprImageInfo) bool {
-	if imageInfo.imageRegistryURL != "" {
+func checkFallbackImg(imageInfo daprImageInfo, fromDir string) bool {
+	if imageInfo.imageRegistryURL != "" || fromDir != "" {
 		return false
 	}
 	return imageInfo.imageRegistryName == githubContainerRegistryName

--- a/pkg/standalone/standalone_test.go
+++ b/pkg/standalone/standalone_test.go
@@ -282,48 +282,7 @@ func TestCheckFallbackImg(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			got := checkFallbackImg(test.imageInfo, test.fromDir)
-			assert.Equal(t, test.expect, got)
-		})
-	}
-}
-
-func TestUseDefReg(t *testing.T) {
-	type testArgs struct {
-		privateReg string
-		fromDir    string
-	}
-	testObj1 := testArgs{
-		privateReg: "example.io/user",
-		fromDir:    "",
-	}
-	testObj2 := testArgs{
-		privateReg: "example.io/user",
-		fromDir:    "somedir",
-	}
-	testObj3 := testArgs{
-		privateReg: "",
-		fromDir:    "somedir",
-	}
-	testObj4 := testArgs{
-		privateReg: "",
-		fromDir:    "",
-	}
-
-	tests := []struct {
-		name   string
-		args   testArgs
-		expect bool
-	}{
-		{"useDefaultReg() with private registry", testObj1, false},
-		{"useDefaultReg() with private registry and airgap mode", testObj2, false},
-		{"useDefaultReg() in air gap mode", testObj3, false},
-		{"useDefaultReg() with no private registry and no airgap mode", testObj4, true},
-	}
-
-	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
-			got := useDefaultReg(test.args.privateReg, test.args.fromDir)
+			got := checkFallbackImgForPlacement(test.imageInfo, test.fromDir)
 			assert.Equal(t, test.expect, got)
 		})
 	}

--- a/pkg/standalone/standalone_test.go
+++ b/pkg/standalone/standalone_test.go
@@ -266,20 +266,23 @@ func TestCheckFallbackImg(t *testing.T) {
 	}
 
 	tests := []struct {
-		name   string
-		args   daprImageInfo
-		expect bool
+		name      string
+		imageInfo daprImageInfo
+		fromDir   string
+		expect    bool
 	}{
-		{"checkFallbackImg() with private registry and def as Docker Hub", daprImgWithPrivateRegAndDefAsDocker, false},
-		{"checkFallbackImg() with private registry and def as GHCR", daprImgWithPrivateRegAndDefAsGHCR, false},
-		{"checkFallbackImg() with private registry with no Def", daprImgWithPrivateRegAndNoDef, false},
-		{"checkFallbackImg() with no private registry and def as Docker Hub", daprImgWithDefAsDocker, false},
-		{"checkFallbackImg() with no private registry and def as GHCR", daprImgWithDefAsGHCR, true},
+		{"checkFallbackImg() with private registry and def as Docker Hub", daprImgWithPrivateRegAndDefAsDocker, "", false},
+		{"checkFallbackImg() with private registry and def as GHCR", daprImgWithPrivateRegAndDefAsGHCR, "", false},
+		{"checkFallbackImg() with private registry with no Def", daprImgWithPrivateRegAndNoDef, "", false},
+		{"checkFallbackImg() with no private registry and def as Docker Hub", daprImgWithDefAsDocker, "", false},
+		{"checkFallbackImg() with no private registry and def as GHCR", daprImgWithDefAsGHCR, "", true},
+		{"checkFallbackImg() airgap mode with no private registry and def as GHCR", daprImgWithDefAsGHCR, "testDir", false},
+		{"checkFallbackImg() airgap mode with no private registry and def as Docker Hub", daprImgWithDefAsDocker, "testDir", false},
 	}
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			got := checkFallbackImg(test.args)
+			got := checkFallbackImg(test.imageInfo, test.fromDir)
 			assert.Equal(t, test.expect, got)
 		})
 	}


### PR DESCRIPTION
Signed-off-by: Pravin Pushkar <ppushkar@microsoft.com>

# Description

Added a check to not retry pull and not print unnecessary log when image-registry flag is provided

## Issue reference

Please reference the issue this PR will close: #939 

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [ ] Created/updated tests
* [ ] Extended the documentation
