### PR TITLE
Change `--from-dir` init flow

### DIFF
--- a/cmd/init.go
+++ b/cmd/init.go
@@ -16,6 +16,7 @@ package cmd
 import (
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
@@ -52,7 +53,8 @@ var InitCmd = &cobra.Command{
 # Initialize Dapr in self-hosted mode
 dapr init
 
-#Initialize Dapr in self-hosted mode with a provided docker image registry. Image looked up as <registry-url>/<image>
+# Initialize Dapr in self-hosted mode with a provided docker image registry. Image looked up as <registry-url>/<image>.
+# Check docs or README for more information on the format of the image path that is required. 
 dapr init --image-registry <registry-url>
 
 # Initialize Dapr in Kubernetes
@@ -103,10 +105,15 @@ dapr init --from-dir <path-to-directory>
 				dockerNetwork = viper.GetString("network")
 				imageRegistryURL = viper.GetString("image-registry")
 			}
-			if fromDir != "" {
+			// If both --image-registry and --from-dir flags are given, error out saying only one can be given.
+			if len(strings.TrimSpace(imageRegistryURL)) != 0 && len(strings.TrimSpace(fromDir)) != 0 {
+				print.FailureStatusEvent(os.Stderr, "both --image-registry and --from-dir flags cannot be given at the same time")
+				os.Exit(1)
+			}
+			if len(strings.TrimSpace(fromDir)) != 0 {
 				print.WarningStatusEvent(os.Stdout, "Local bundle installation using from-dir flag is currently a preview feature.")
 			}
-			if imageRegistryURL != "" {
+			if len(strings.TrimSpace(imageRegistryURL)) != 0 {
 				print.WarningStatusEvent(os.Stdout, "Flag --image-registry is a preview feature and is subject to change. It is only available from CLI version 1.7 onwards.")
 			}
 			err := standalone.Init(runtimeVersion, dashboardVersion, dockerNetwork, slimMode, imageRegistryURL, fromDir)
@@ -142,9 +149,9 @@ func init() {
 	InitCmd.Flags().BoolVarP(&enableMTLS, "enable-mtls", "", true, "Enable mTLS in your cluster")
 	InitCmd.Flags().BoolVarP(&enableHA, "enable-ha", "", false, "Enable high availability (HA) mode")
 	InitCmd.Flags().String("network", "", "The Docker network on which to deploy the Dapr runtime")
-	InitCmd.Flags().StringVarP(&fromDir, "from-dir", "", "", "Use Dapr artifacts from local directory instead of from network to init")
+	InitCmd.Flags().StringVarP(&fromDir, "from-dir", "", "", "Use Dapr artifacts from local directory for self-hosted installation")
 	InitCmd.Flags().BoolP("help", "h", false, "Print this help message")
 	InitCmd.Flags().StringArrayVar(&values, "set", []string{}, "set values on the command line (can specify multiple or separate values with commas: key1=val1,key2=val2)")
-	InitCmd.Flags().String("image-registry", "", "Custom/Private docker image repository url")
+	InitCmd.Flags().String("image-registry", "", "Custom/Private docker image repository URL")
 	RootCmd.AddCommand(InitCmd)
 }

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -111,7 +111,7 @@ dapr init --from-dir <path-to-directory>
 				os.Exit(1)
 			}
 			if len(strings.TrimSpace(fromDir)) != 0 {
-				print.WarningStatusEvent(os.Stdout, "Local bundle installation using from-dir flag is currently a preview feature.")
+				print.WarningStatusEvent(os.Stdout, "Local bundle installation using --from-dir flag is currently a preview feature and is subject to change. It is only available from CLI version 1.7 onwards.")
 			}
 			if len(strings.TrimSpace(imageRegistryURL)) != 0 {
 				print.WarningStatusEvent(os.Stdout, "Flag --image-registry is a preview feature and is subject to change. It is only available from CLI version 1.7 onwards.")

--- a/pkg/standalone/bundle.go
+++ b/pkg/standalone/bundle.go
@@ -1,0 +1,56 @@
+/*
+Copyright 2021 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package standalone
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+)
+
+const bundleDetailsFileName = "details.json"
+
+type bundleDetails struct {
+	RuntimeVersion    *string `json:"daprd"`
+	DashboardVersion  *string `json:"dashboard"`
+	CLIVersion        *string `json:"cli"`
+	BinarySubDir      *string `json:"daprBinarySubDir"`
+	ImageSubDir       *string `json:"dockerImageSubDir"`
+	DaprImageName     *string `json:"daprImageName"`
+	DaprImageFileName *string `json:"daprImageFileName"`
+}
+
+func (b *bundleDetails) parseDetails(detailsFilePath string) error {
+	bytes, err := ioutil.ReadFile(detailsFilePath)
+	if err != nil {
+		return err
+	}
+
+	err = json.Unmarshal(bytes, &b)
+	if err != nil {
+		return err
+	}
+	if b.RuntimeVersion == nil || b.DashboardVersion == nil || b.DaprImageName == nil || b.DaprImageFileName == nil {
+		return fmt.Errorf("required fields are missing in %s", detailsFilePath)
+	}
+	return nil
+}
+
+func (b *bundleDetails) getPlacementImageName() string {
+	return *b.DaprImageName
+}
+
+func (b *bundleDetails) getPlacementImageFileName() string {
+	return *b.DaprImageFileName
+}

--- a/pkg/standalone/bundle.go
+++ b/pkg/standalone/bundle.go
@@ -33,7 +33,7 @@ type bundleDetails struct {
 }
 
 // readAndParseDetails reads the file in detailsFilePath and tries to parse it into the bundleDetails struct.
-func (b *bundleDetails) readAndparseDetails(detailsFilePath string) error {
+func (b *bundleDetails) readAndParseDetails(detailsFilePath string) error {
 	bytes, err := ioutil.ReadFile(detailsFilePath)
 	if err != nil {
 		return err

--- a/pkg/standalone/bundle.go
+++ b/pkg/standalone/bundle.go
@@ -17,6 +17,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
+	"strings"
 )
 
 const bundleDetailsFileName = "details.json"
@@ -31,7 +32,8 @@ type bundleDetails struct {
 	DaprImageFileName *string `json:"daprImageFileName"`
 }
 
-func (b *bundleDetails) parseDetails(detailsFilePath string) error {
+// readAndParseDetails reads the file in detailsFilePath and tries to parse it into the bundleDetails struct.
+func (b *bundleDetails) readAndparseDetails(detailsFilePath string) error {
 	bytes, err := ioutil.ReadFile(detailsFilePath)
 	if err != nil {
 		return err
@@ -41,10 +43,15 @@ func (b *bundleDetails) parseDetails(detailsFilePath string) error {
 	if err != nil {
 		return err
 	}
-	if b.RuntimeVersion == nil || b.DashboardVersion == nil || b.DaprImageName == nil || b.DaprImageFileName == nil {
+	if isStringNilOrEmpty(b.RuntimeVersion) || isStringNilOrEmpty(b.DashboardVersion) ||
+		isStringNilOrEmpty(b.DaprImageName) || isStringNilOrEmpty(b.DaprImageFileName) {
 		return fmt.Errorf("required fields are missing in %s", detailsFilePath)
 	}
 	return nil
+}
+
+func isStringNilOrEmpty(val *string) bool {
+	return val == nil || strings.TrimSpace(*val) == ""
 }
 
 func (b *bundleDetails) getPlacementImageName() string {

--- a/pkg/standalone/bundle.go
+++ b/pkg/standalone/bundle.go
@@ -44,7 +44,8 @@ func (b *bundleDetails) readAndParseDetails(detailsFilePath string) error {
 		return err
 	}
 	if isStringNilOrEmpty(b.RuntimeVersion) || isStringNilOrEmpty(b.DashboardVersion) ||
-		isStringNilOrEmpty(b.DaprImageName) || isStringNilOrEmpty(b.DaprImageFileName) {
+		isStringNilOrEmpty(b.DaprImageName) || isStringNilOrEmpty(b.DaprImageFileName) ||
+		isStringNilOrEmpty(b.BinarySubDir) || isStringNilOrEmpty(b.ImageSubDir) {
 		return fmt.Errorf("required fields are missing in %s", detailsFilePath)
 	}
 	return nil

--- a/pkg/standalone/bundle_test.go
+++ b/pkg/standalone/bundle_test.go
@@ -38,7 +38,7 @@ func TestParseDetails(t *testing.T) {
 	f.WriteString(correctDetails)
 	f.Close()
 	bd := bundleDetails{}
-	err = bd.readAndparseDetails(f.Name())
+	err = bd.readAndParseDetails(f.Name())
 	assert.NoError(t, err, "expected no error on parsing correct details in file")
 	assert.Equal(t, "1.7.0-rc.2", *bd.RuntimeVersion, "expected versions to match")
 	assert.Equal(t, "0.10.0-rc.2", *bd.DashboardVersion, "expected versions to match")
@@ -63,7 +63,7 @@ func TestParseDetailsMissingDetails(t *testing.T) {
 	f.WriteString(missingDetails)
 	f.Close()
 	bd := bundleDetails{}
-	err = bd.readAndparseDetails(f.Name())
+	err = bd.readAndParseDetails(f.Name())
 	assert.Error(t, err, "expected error on parsing missing details in file")
 }
 
@@ -85,7 +85,7 @@ func TestParseDetailsEmptyDetails(t *testing.T) {
 	f.WriteString(missingDetails)
 	f.Close()
 	bd := bundleDetails{}
-	err = bd.readAndparseDetails(f.Name())
+	err = bd.readAndParseDetails(f.Name())
 	assert.Error(t, err, "expected error on parsing missing details in file")
 }
 
@@ -97,6 +97,6 @@ func TestParseDetailsMissingFile(t *testing.T) {
 	f.Close()
 	os.Remove(f.Name())
 	bd := bundleDetails{}
-	err = bd.readAndparseDetails(f.Name())
+	err = bd.readAndParseDetails(f.Name())
 	assert.Error(t, err, "expected error on parsing missing details file")
 }

--- a/pkg/standalone/bundle_test.go
+++ b/pkg/standalone/bundle_test.go
@@ -1,0 +1,80 @@
+/*
+Copyright 2021 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package standalone
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestParseDetails(t *testing.T) {
+	correctDetails := `{
+		"daprd" : "1.7.0-rc.2",
+		"dashboard": "0.10.0-rc.2",
+		"cli": "1.7.0-rc.2",
+		"daprBinarySubDir": "dist",
+		"dockerImageSubDir": "docker",
+		"daprImageName": "daprio/dapr:1.7.2-rc.2",
+		"daprImageFileName": "daprio-dapr-1.7.2-rc.2.tar.gz"
+	}`
+	f, err := os.CreateTemp("", "*-details.json")
+	if err != nil {
+		t.Fatalf("error creating temp directory for testing: %s", err)
+	}
+	defer os.Remove(f.Name())
+	f.WriteString(correctDetails)
+	f.Close()
+	bd := bundleDetails{}
+	err = bd.parseDetails(f.Name())
+	assert.NoError(t, err, "expected no error on parsing correct details in file")
+	assert.Equal(t, "1.7.0-rc.2", *bd.RuntimeVersion, "expected versions to match")
+	assert.Equal(t, "0.10.0-rc.2", *bd.DashboardVersion, "expected versions to match")
+	assert.Equal(t, "dist", *bd.BinarySubDir, "expected value to match")
+	assert.Equal(t, "docker", *bd.ImageSubDir, "expected value to match")
+	assert.Equal(t, "daprio/dapr:1.7.2-rc.2", bd.getPlacementImageName(), "expected value to match")
+	assert.Equal(t, "daprio-dapr-1.7.2-rc.2.tar.gz", bd.getPlacementImageFileName(), "expected value to match")
+}
+
+func TestParseDetailsMissingDetails(t *testing.T) {
+	missingDetails := `{
+		"daprd" : "1.7.0-rc.2",
+		"dashboard": "0.10.0-rc.2",
+		"cli": "1.7.0-rc.2",
+		"daprImageFileName": "daprio-dapr-1.7.2-rc.2.tar.gz"
+	}`
+	f, err := os.CreateTemp("", "*-details.json")
+	if err != nil {
+		t.Fatalf("error creating temp directory for testing: %s", err)
+	}
+	defer os.Remove(f.Name())
+	f.WriteString(missingDetails)
+	f.Close()
+	bd := bundleDetails{}
+	err = bd.parseDetails(f.Name())
+	assert.Error(t, err, "expected error on parsing missing details in file")
+}
+
+func TestParseDetailsMissingFile(t *testing.T) {
+	f, err := os.CreateTemp("", "*-details.json")
+	if err != nil {
+		t.Fatalf("error creating temp directory for testing: %s", err)
+	}
+	f.Close()
+	os.Remove(f.Name())
+	bd := bundleDetails{}
+	err = bd.parseDetails(f.Name())
+	assert.Error(t, err, "expected error on parsing missing details file")
+}

--- a/pkg/standalone/bundle_test.go
+++ b/pkg/standalone/bundle_test.go
@@ -38,7 +38,7 @@ func TestParseDetails(t *testing.T) {
 	f.WriteString(correctDetails)
 	f.Close()
 	bd := bundleDetails{}
-	err = bd.parseDetails(f.Name())
+	err = bd.readAndparseDetails(f.Name())
 	assert.NoError(t, err, "expected no error on parsing correct details in file")
 	assert.Equal(t, "1.7.0-rc.2", *bd.RuntimeVersion, "expected versions to match")
 	assert.Equal(t, "0.10.0-rc.2", *bd.DashboardVersion, "expected versions to match")
@@ -63,7 +63,29 @@ func TestParseDetailsMissingDetails(t *testing.T) {
 	f.WriteString(missingDetails)
 	f.Close()
 	bd := bundleDetails{}
-	err = bd.parseDetails(f.Name())
+	err = bd.readAndparseDetails(f.Name())
+	assert.Error(t, err, "expected error on parsing missing details in file")
+}
+
+func TestParseDetailsEmptyDetails(t *testing.T) {
+	missingDetails := `{
+		"daprd" : "",
+		"dashboard": "",
+		"cli": "1.7.0-rc.2",
+		"daprBinarySubDir": "dist",
+		"dockerImageSubDir": "docker",
+		"daprImageName": "daprio/dapr:1.7.2-rc.2",
+		"daprImageFileName": "daprio-dapr-1.7.2-rc.2.tar.gz"
+	}`
+	f, err := os.CreateTemp("", "*-details.json")
+	if err != nil {
+		t.Fatalf("error creating temp directory for testing: %s", err)
+	}
+	defer os.Remove(f.Name())
+	f.WriteString(missingDetails)
+	f.Close()
+	bd := bundleDetails{}
+	err = bd.readAndparseDetails(f.Name())
 	assert.Error(t, err, "expected error on parsing missing details in file")
 }
 
@@ -75,6 +97,6 @@ func TestParseDetailsMissingFile(t *testing.T) {
 	f.Close()
 	os.Remove(f.Name())
 	bd := bundleDetails{}
-	err = bd.parseDetails(f.Name())
+	err = bd.readAndparseDetails(f.Name())
 	assert.Error(t, err, "expected error on parsing missing details file")
 }

--- a/pkg/standalone/bundle_test.go
+++ b/pkg/standalone/bundle_test.go
@@ -53,6 +53,7 @@ func TestParseDetailsMissingDetails(t *testing.T) {
 		"daprd" : "1.7.0-rc.2",
 		"dashboard": "0.10.0-rc.2",
 		"cli": "1.7.0-rc.2",
+		"daprImageName": "daprio/dapr:1.7.2-rc.2"
 		"daprImageFileName": "daprio-dapr-1.7.2-rc.2.tar.gz"
 	}`
 	f, err := os.CreateTemp("", "*-details.json")

--- a/pkg/standalone/docker.go
+++ b/pkg/standalone/docker.go
@@ -53,16 +53,16 @@ func runDockerLoad(in io.Reader) error {
 	return nil
 }
 
-func loadDocker(dir string, dockerImage string) error {
+func loadDocker(dir string, dockerImageFileName string) error {
 	var imageFile io.Reader
 	var err error
-	imageFile, err = os.Open(path_filepath.Join(dir, imageFileName(dockerImage)))
+	imageFile, err = os.Open(path_filepath.Join(dir, dockerImageFileName))
 	if err != nil {
-		return fmt.Errorf("fail to read docker image file %s: %w", dockerImage, err)
+		return fmt.Errorf("fail to read docker image file %s: %w", dockerImageFileName, err)
 	}
 	err = runDockerLoad(imageFile)
 	if err != nil {
-		return fmt.Errorf("fail to load docker image %s: %w", dockerImage, err)
+		return fmt.Errorf("fail to load docker image from file %s: %w", dockerImageFileName, err)
 	}
 
 	return nil
@@ -121,14 +121,7 @@ func parseDockerError(component string, err error) error {
 	return err
 }
 
-func imageFileName(image string) string {
-	filename := image + ".tar.gz"
-	filename = strings.ReplaceAll(filename, "/", "-")
-	filename = strings.ReplaceAll(filename, ":", "-")
-	return filename
-}
-
-func TryPullImage(imageName string) bool {
+func tryPullImage(imageName string) bool {
 	args := []string{
 		"pull",
 		imageName,

--- a/pkg/standalone/standalone.go
+++ b/pkg/standalone/standalone.go
@@ -17,7 +17,6 @@ import (
 	"archive/tar"
 	"archive/zip"
 	"compress/gzip"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -39,24 +38,34 @@ import (
 )
 
 const (
-	daprDockerImageName        = "daprio/dapr"
 	daprRuntimeFilePrefix      = "daprd"
 	dashboardFilePrefix        = "dashboard"
 	placementServiceFilePrefix = "placement"
-	daprWindowsOS              = "windows"
-	latestVersion              = "latest"
-	daprDefaultHost            = "localhost"
-	pubSubYamlFileName         = "pubsub.yaml"
-	stateStoreYamlFileName     = "statestore.yaml"
-	redisDockerImageName       = "redis"
-	zipkinDockerImageName      = "openzipkin/zipkin"
 
+	daprWindowsOS = "windows"
+
+	latestVersion   = "latest"
+	daprDefaultHost = "localhost"
+
+	pubSubYamlFileName     = "pubsub.yaml"
+	stateStoreYamlFileName = "statestore.yaml"
+
+	// used when DAPR_DEFAULT_IMAGE_REGISTRY is not set.
+	dockerContainerRegistryName = "dockerhub"
+	daprDockerImageName         = "daprio/dapr"
+	redisDockerImageName        = "redis"
+	zipkinDockerImageName       = "openzipkin/zipkin"
+
+	// used when DAPR_DEFAULT_IMAGE_REGISTRY is set as GHCR.
 	githubContainerRegistryName = "ghcr"
 	ghcrURI                     = "ghcr.io/dapr"
 	daprGhcrImageName           = "dapr"
-	dockerContainerRegistryName = "dockerhub"
 	redisGhcrImageName          = "3rdparty/redis"
 	zipkinGhcrImageName         = "3rdparty/zipkin"
+
+	// used when --from-dir flag is specified.
+	daprBinarySubDir = "dist"
+	daprImageSubDir  = "docker"
 
 	// DaprPlacementContainerName is the container name of placement service.
 	DaprPlacementContainerName = "dapr_placement"
@@ -66,9 +75,6 @@ const (
 	DaprZipkinContainerName = "dapr_zipkin"
 
 	errInstallTemplate = "please run `dapr uninstall` first before running `dapr init`"
-
-	daprBinarySubDir  = "dist"
-	dockerImageSubDir = "docker"
 )
 
 var (
@@ -112,6 +118,7 @@ type componentMetadataItem struct {
 
 type initInfo struct {
 	fromDir          string
+	bundleDet        *bundleDetails
 	slimMode         bool
 	runtimeVersion   string
 	dashboardVersion string
@@ -141,14 +148,16 @@ func isBinaryInstallationRequired(binaryFilePrefix, installDir string) (bool, er
 // Init installs Dapr on a local machine using the supplied runtimeVersion.
 func Init(runtimeVersion, dashboardVersion string, dockerNetwork string, slimMode bool, imageRegistryURL string, fromDir string) error {
 	var err error
+	var bundleDet bundleDetails
 	if !slimMode {
+		// If --slim installation is not requested, check if docker is installed.
 		dockerInstalled := utils.IsDockerInstalled()
 		if !dockerInstalled {
 			return errors.New("could not connect to Docker. Docker may not be installed or running")
 		}
 
-		// Initialize default registry only if it is not airgap mode or from private registries.
-		if len(strings.TrimSpace(imageRegistryURL)) == 0 && len(strings.TrimSpace(fromDir)) == 0 {
+		// Initialize default registry only if --slim or --image-registry or --from-dir are not given.
+		if len(strings.TrimSpace(imageRegistryURL)) == 0 && !isAirGapInit(fromDir) {
 			defaultImageRegistryName, err = utils.GetDefaultRegistry(githubContainerRegistryName, dockerContainerRegistryName)
 			if err != nil {
 				return err
@@ -156,16 +165,16 @@ func Init(runtimeVersion, dashboardVersion string, dockerNetwork string, slimMod
 		}
 	}
 
-	if runtimeVersion == latestVersion && fromDir == "" {
+	// Set runtime version.
+
+	if runtimeVersion == latestVersion && !isAirGapInit(fromDir) {
 		runtimeVersion, err = cli_ver.GetDaprVersion()
 		if err != nil {
 			return fmt.Errorf("cannot get the latest release version: '%w'. Try specifying --runtime-version=<desired_version>", err)
 		}
 	}
 
-	print.InfoStatusEvent(os.Stdout, "Installing runtime version %s", runtimeVersion)
-
-	if dashboardVersion == latestVersion && fromDir == "" {
+	if dashboardVersion == latestVersion && !isAirGapInit(fromDir) {
 		dashboardVersion, err = cli_ver.GetDashboardVersion()
 		if err != nil {
 			print.WarningStatusEvent(os.Stdout, "cannot get the latest dashboard version: '%s'. Try specifying --dashboard-version=<desired_version>", err)
@@ -173,14 +182,27 @@ func Init(runtimeVersion, dashboardVersion string, dockerNetwork string, slimMod
 		}
 	}
 
-	if fromDir != "" {
-		v1, v2 := parseVersionFile(fromDir)
-		if v1 != "" && v2 != "" {
-			runtimeVersion, dashboardVersion = v1, v2
-		} else {
-			return fmt.Errorf("runtime and dashboard versions cannot be parsed from version file in directory")
+	// If --from-dir flag is given try parsing the details from the expected details file in the specified directory.
+	if isAirGapInit(fromDir) {
+		bundleDet = bundleDetails{}
+		detailsFilePath := path_filepath.Join(fromDir, bundleDetailsFileName)
+		err = bundleDet.parseDetails(detailsFilePath)
+		if err != nil {
+			return fmt.Errorf("error parsing details file from bundle location: %w", err)
 		}
+
+		// Set runtime and dashboard versions from the bundle details parsed.
+
+		runtimeVersion = *bundleDet.RuntimeVersion
+		dashboardVersion = *bundleDet.DashboardVersion
 	}
+
+	// At this point the runtimeVersion variable is parsed either from the details file if --fromDir is specified or
+	// got from running the command cli_ver.GetRuntimeVersion().
+
+	// After this point runtimeVersion will not be latest string but rather actual version.
+
+	print.InfoStatusEvent(os.Stdout, "Installing runtime version %s", runtimeVersion)
 
 	daprBinDir := defaultDaprBinPath()
 	err = prepareDaprInstallDir(daprBinDir)
@@ -210,7 +232,7 @@ func Init(runtimeVersion, dashboardVersion string, dockerNetwork string, slimMod
 	wg.Add(len(initSteps))
 
 	msg := "Downloading binaries and setting up components..."
-	if fromDir != "" {
+	if isAirGapInit(fromDir) {
 		msg = "Extracting binaries and setting up components..."
 	}
 	stopSpinning := print.Spinner(os.Stdout, msg)
@@ -223,6 +245,7 @@ func Init(runtimeVersion, dashboardVersion string, dockerNetwork string, slimMod
 	}
 
 	info := initInfo{
+		bundleDet:        &bundleDet, // will be nil if fromDir is empty, so must be used in conjunction with fromDir.
 		fromDir:          fromDir,
 		slimMode:         slimMode,
 		runtimeVersion:   runtimeVersion,
@@ -249,7 +272,7 @@ func Init(runtimeVersion, dashboardVersion string, dockerNetwork string, slimMod
 	stopSpinning(print.Success)
 
 	msg = "Downloaded binaries and completed components set up."
-	if fromDir != "" {
+	if isAirGapInit(fromDir) {
 		msg = "Extracted binaries and completed components set up."
 	}
 	print.SuccessStatusEvent(os.Stdout, msg)
@@ -260,7 +283,7 @@ func Init(runtimeVersion, dashboardVersion string, dockerNetwork string, slimMod
 	} else {
 		dockerContainerNames := []string{DaprPlacementContainerName, DaprRedisContainerName, DaprZipkinContainerName}
 		// Skip redis and zipkin in local installation mode.
-		if fromDir != "" {
+		if isAirGapInit(fromDir) {
 			dockerContainerNames = []string{DaprPlacementContainerName}
 		}
 		for _, container := range dockerContainerNames {
@@ -281,7 +304,7 @@ func Init(runtimeVersion, dashboardVersion string, dockerNetwork string, slimMod
 func runZipkin(wg *sync.WaitGroup, errorChan chan<- error, info initInfo) {
 	defer wg.Done()
 
-	if info.slimMode || info.fromDir != "" {
+	if info.slimMode || isAirGapInit(info.fromDir) {
 		return
 	}
 
@@ -348,7 +371,7 @@ func runZipkin(wg *sync.WaitGroup, errorChan chan<- error, info initInfo) {
 func runRedis(wg *sync.WaitGroup, errorChan chan<- error, info initInfo) {
 	defer wg.Done()
 
-	if info.slimMode || info.fromDir != "" {
+	if info.slimMode || isAirGapInit(info.fromDir) {
 		return
 	}
 
@@ -419,26 +442,6 @@ func runPlacementService(wg *sync.WaitGroup, errorChan chan<- error, info initIn
 
 	placementContainerName := utils.CreateContainerName(DaprPlacementContainerName, info.dockerNetwork)
 
-	imgInfo := daprImageInfo{
-		ghcrImageName:      daprGhcrImageName,
-		dockerHubImageName: daprDockerImageName,
-		imageRegistryURL:   info.imageRegistryURL,
-		imageRegistryName:  defaultImageRegistryName,
-	}
-	image, err := resolveImageURI(imgInfo)
-	if err != nil {
-		errorChan <- err
-		return
-	}
-	image = getPlacementImageWithTag(image, info.runtimeVersion)
-
-	if checkFallbackImgForPlacement(imgInfo, info.fromDir) {
-		if !TryPullImage(image) {
-			print.InfoStatusEvent(os.Stdout, "Placement image not found in Github container registry, pulling it from Docker Hub")
-			image = getPlacementImageWithTag(daprDockerImageName, info.runtimeVersion)
-		}
-	}
-
 	exists, err := confirmContainerIsRunningOrExists(placementContainerName, false)
 
 	if err != nil {
@@ -448,10 +451,27 @@ func runPlacementService(wg *sync.WaitGroup, errorChan chan<- error, info initIn
 		errorChan <- fmt.Errorf("%s container exists or is running. %s", placementContainerName, errInstallTemplate)
 		return
 	}
+	var image string
 
-	if info.fromDir != "" {
-		dir := path_filepath.Join(info.fromDir, dockerImageSubDir)
-		err = loadDocker(dir, image)
+	imgInfo := daprImageInfo{
+		ghcrImageName:      daprGhcrImageName,
+		dockerHubImageName: daprDockerImageName,
+		imageRegistryURL:   info.imageRegistryURL,
+		imageRegistryName:  defaultImageRegistryName,
+	}
+
+	if isAirGapInit(info.fromDir) {
+		// if --from-dir flag is given load the image details from the installer-bundle.
+		dir := path_filepath.Join(info.fromDir, daprImageSubDir)
+		image = info.bundleDet.getPlacementImageName()
+		err = loadDocker(dir, info.bundleDet.getPlacementImageFileName())
+		if err != nil {
+			errorChan <- err
+			return
+		}
+	} else {
+		// otherwise load the image from the specified repository.
+		image, err = getPlacementImageName(imgInfo, info)
 		if err != nil {
 			errorChan <- err
 			return
@@ -529,7 +549,7 @@ func moveDashboardFiles(extractedFilePath string, dir string) (string, error) {
 func installDaprRuntime(wg *sync.WaitGroup, errorChan chan<- error, info initInfo) {
 	defer wg.Done()
 
-	err := installBinary(info.runtimeVersion, daprRuntimeFilePrefix, cli_ver.DaprGitHubRepo, info.fromDir)
+	err := installBinary(info.runtimeVersion, daprRuntimeFilePrefix, cli_ver.DaprGitHubRepo, info)
 	if err != nil {
 		errorChan <- err
 	}
@@ -541,7 +561,7 @@ func installDashboard(wg *sync.WaitGroup, errorChan chan<- error, info initInfo)
 		return
 	}
 
-	err := installBinary(info.dashboardVersion, dashboardFilePrefix, cli_ver.DashboardGitHubRepo, info.fromDir)
+	err := installBinary(info.dashboardVersion, dashboardFilePrefix, cli_ver.DashboardGitHubRepo, info)
 	if err != nil {
 		errorChan <- err
 	}
@@ -554,26 +574,27 @@ func installPlacement(wg *sync.WaitGroup, errorChan chan<- error, info initInfo)
 		return
 	}
 
-	err := installBinary(info.runtimeVersion, placementServiceFilePrefix, cli_ver.DaprGitHubRepo, info.fromDir)
+	err := installBinary(info.runtimeVersion, placementServiceFilePrefix, cli_ver.DaprGitHubRepo, info)
 	if err != nil {
 		errorChan <- err
 	}
 }
 
-func installBinary(version, binaryFilePrefix string, githubRepo string, fromDir string) error {
+// installBinary installs the daprd, placement or dashboard binaries and associated files inside the default dapr bin directory.
+func installBinary(version, binaryFilePrefix, githubRepo string, info initInfo) error {
 	var (
 		err      error
 		filepath string
 	)
 
 	dir := defaultDaprBinPath()
-	if fromDir == "" {
+	if isAirGapInit(info.fromDir) {
+		filepath = path_filepath.Join(info.fromDir, daprBinarySubDir, binaryName(binaryFilePrefix))
+	} else {
 		filepath, err = downloadBinary(dir, version, binaryFilePrefix, githubRepo)
 		if err != nil {
 			return fmt.Errorf("error downloading %s binary: %w", binaryFilePrefix, err)
 		}
-	} else {
-		filepath = path_filepath.Join(fromDir, daprBinarySubDir, binaryName(binaryFilePrefix))
 	}
 
 	extractedFilePath, err := extractFile(filepath, dir, binaryFilePrefix)
@@ -581,7 +602,8 @@ func installBinary(version, binaryFilePrefix string, githubRepo string, fromDir 
 		return err
 	}
 
-	if fromDir == "" {
+	// remove downloaded archive from the default dapr bin path.
+	if !isAirGapInit(info.fromDir) {
 		err = os.Remove(filepath)
 		if err != nil {
 			return fmt.Errorf("failed to remove archive: %w", err)
@@ -1050,19 +1072,24 @@ func downloadFile(dir string, url string) (string, error) {
 	return filepath, nil
 }
 
-func parseVersionFile(fromDir string) (string, string) {
-	bytes, err := ioutil.ReadFile(path_filepath.Join(fromDir, "version.json"))
+// getPlacementImageName returns the resolved placement image name for online `dapr init`.
+// It can either be resolved to the image-registry if given, otherwise GitHub container registry if
+// selected or fallback to Docker Hub.
+func getPlacementImageName(imageInfo daprImageInfo, info initInfo) (string, error) {
+	image, err := resolveImageURI(imageInfo)
 	if err != nil {
-		return "", ""
+		return "", err
 	}
 
-	var versions map[string]string
-	err = json.Unmarshal(bytes, &versions)
-	if err != nil {
-		return "", ""
-	}
+	image = getPlacementImageWithTag(image, info.runtimeVersion)
 
-	return versions[daprRuntimeFilePrefix], versions[dashboardFilePrefix]
+	// if default registry is GHCR and the image is not available in or cannot be pulled from GHCR
+	// fallback to using dockerhub.
+	if useGHCR(imageInfo, info.fromDir) && !tryPullImage(image) {
+		print.InfoStatusEvent(os.Stdout, "Placement image not found in Github container registry, pulling it from Docker Hub")
+		image = getPlacementImageWithTag(daprDockerImageName, info.runtimeVersion)
+	}
+	return image, nil
 }
 
 func getPlacementImageWithTag(name, version string) string {
@@ -1072,9 +1099,9 @@ func getPlacementImageWithTag(name, version string) string {
 	return fmt.Sprintf("%s:%s", name, version)
 }
 
-// Try for fallback image from docker iff this init flow is using GHCR as default registry.
+// useGHCR returns true iff default registry is set as GHCR and --image-registry and --from-dir flags are not set.
 // TODO: We may want to remove this logic completely after next couple of releases.
-func checkFallbackImgForPlacement(imageInfo daprImageInfo, fromDir string) bool {
+func useGHCR(imageInfo daprImageInfo, fromDir string) bool {
 	if imageInfo.imageRegistryURL != "" || fromDir != "" {
 		return false
 	}
@@ -1084,7 +1111,7 @@ func checkFallbackImgForPlacement(imageInfo daprImageInfo, fromDir string) bool 
 func resolveImageURI(imageInfo daprImageInfo) (string, error) {
 	if imageInfo.imageRegistryURL != "" {
 		if imageInfo.imageRegistryURL == ghcrURI || imageInfo.imageRegistryURL == "docker.io" {
-			err := fmt.Errorf("flag %s not set correctly", "--image-registry")
+			err := fmt.Errorf("flag --image-registry not set correctly. It cannot be %q or \"docker.io\"", ghcrURI)
 			return "", err
 		}
 		return fmt.Sprintf(privateRegTemplateString, imageInfo.imageRegistryURL, imageInfo.ghcrImageName), nil
@@ -1095,6 +1122,11 @@ func resolveImageURI(imageInfo daprImageInfo) (string, error) {
 	case githubContainerRegistryName:
 		return fmt.Sprintf("%s/%s", ghcrURI, imageInfo.ghcrImageName), nil
 	default:
-		return "", errors.New("imageRegistryName not set correctly")
+		return "", fmt.Errorf("imageRegistryName not set correctly %s", imageInfo.imageRegistryName)
 	}
+}
+
+// isAirGapInit checks if fromDir is specified. If so the init flow is considered to be an offline init.
+func isAirGapInit(fromDir string) bool {
+	return len(strings.TrimSpace(fromDir)) != 0
 }

--- a/pkg/standalone/standalone.go
+++ b/pkg/standalone/standalone.go
@@ -190,7 +190,7 @@ func Init(runtimeVersion, dashboardVersion string, dockerNetwork string, slimMod
 	if isAirGapInit {
 		bundleDet = bundleDetails{}
 		detailsFilePath := path_filepath.Join(fromDir, bundleDetailsFileName)
-		err = bundleDet.readAndparseDetails(detailsFilePath)
+		err = bundleDet.readAndParseDetails(detailsFilePath)
 		if err != nil {
 			return fmt.Errorf("error parsing details file from bundle location: %w", err)
 		}

--- a/pkg/standalone/standalone_test.go
+++ b/pkg/standalone/standalone_test.go
@@ -300,8 +300,8 @@ func TestIsAirGapInit(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			got := isAirGapInit(test.fromDir)
-			assert.Equal(t, test.expect, got)
+			setAirGapInit(test.fromDir)
+			assert.Equal(t, test.expect, isAirGapInit)
 		})
 	}
 }

--- a/pkg/standalone/standalone_test.go
+++ b/pkg/standalone/standalone_test.go
@@ -282,7 +282,25 @@ func TestCheckFallbackImg(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			got := checkFallbackImgForPlacement(test.imageInfo, test.fromDir)
+			got := useGHCR(test.imageInfo, test.fromDir)
+			assert.Equal(t, test.expect, got)
+		})
+	}
+}
+
+func TestIsAirGapInit(t *testing.T) {
+	tests := []struct {
+		name    string
+		fromDir string
+		expect  bool
+	}{
+		{"empty string", "", false},
+		{"string with spaces", "   ", false},
+		{"string with value", "./local-dir", true},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got := isAirGapInit(test.fromDir)
 			assert.Equal(t, test.expect, got)
 		})
 	}

--- a/tests/e2e/common/common.go
+++ b/tests/e2e/common/common.go
@@ -72,7 +72,7 @@ type TestCase struct {
 
 // GetFromEnvVar will return values from required environment variables,
 // if environment variables are not set it fails the test.
-func GetFromEnvVar(t *testing.T) (daprRuntimeVersion string, daprDashboardVersion string) {
+func GetVersionsFromEnv(t *testing.T) (daprRuntimeVersion string, daprDashboardVersion string) {
 	if runtimeVersion, ok := os.LookupEnv("DAPR_RUNTIME_VERSION"); ok {
 		daprRuntimeVersion = runtimeVersion
 	} else {

--- a/tests/e2e/common/common.go
+++ b/tests/e2e/common/common.go
@@ -70,7 +70,7 @@ type TestCase struct {
 	Callable func(*testing.T)
 }
 
-// GetFromEnvVar will return values from required environment variables,
+// GetVersionsFromEnv will return values from required environment variables,
 // if environment variables are not set it fails the test.
 func GetVersionsFromEnv(t *testing.T) (daprRuntimeVersion string, daprDashboardVersion string) {
 	if runtimeVersion, ok := os.LookupEnv("DAPR_RUNTIME_VERSION"); ok {

--- a/tests/e2e/common/common.go
+++ b/tests/e2e/common/common.go
@@ -71,7 +71,7 @@ type TestCase struct {
 }
 
 // GetFromEnvVar will return values from required environment variables,
-// if not environemt variables are not set it fails the test.
+// if environment variables are not set it fails the test.
 func GetFromEnvVar(t *testing.T) (daprRuntimeVersion string, daprDashboardVersion string) {
 	if runtimeVersion, ok := os.LookupEnv("DAPR_RUNTIME_VERSION"); ok {
 		daprRuntimeVersion = runtimeVersion

--- a/tests/e2e/common/common.go
+++ b/tests/e2e/common/common.go
@@ -70,6 +70,22 @@ type TestCase struct {
 	Callable func(*testing.T)
 }
 
+// GetFromEnvVar will return values from required environment variables,
+// if not environemt variables are not set it fails the test.
+func GetFromEnvVar(t *testing.T) (daprRuntimeVersion string, daprDashboardVersion string) {
+	if runtimeVersion, ok := os.LookupEnv("DAPR_RUNTIME_VERSION"); ok {
+		daprRuntimeVersion = runtimeVersion
+	} else {
+		t.Fatalf("env var \"DAPR_RUNTIME_VERSION\" not set")
+	}
+	if dashboardVersion, ok := os.LookupEnv("DAPR_DASHBOARD_VERSION"); ok {
+		daprDashboardVersion = dashboardVersion
+	} else {
+		t.Fatalf("env var \"DAPR_DASHBOARD_VERSION\" not set")
+	}
+	return
+}
+
 func UpgradeTest(details VersionDetails, opts TestOptions) func(t *testing.T) {
 	return func(t *testing.T) {
 		daprPath := getDaprPath()

--- a/tests/e2e/kubernetes/kubernetes_test.go
+++ b/tests/e2e/kubernetes/kubernetes_test.go
@@ -31,7 +31,7 @@ var (
 // ensureCleanEnv function needs to be called in every Test function.
 // sets necessary variable values and uninstalls any previously installed `dapr`.
 func ensureCleanEnv(t *testing.T) {
-	currentRuntimeVersion, currentDashboardVersion = common.GetFromEnvVar(t)
+	currentRuntimeVersion, currentDashboardVersion = common.GetVersionsFromEnv(t)
 
 	currentVersionDetails = common.VersionDetails{
 		RuntimeVersion:      currentRuntimeVersion,

--- a/tests/e2e/kubernetes/kubernetes_test.go
+++ b/tests/e2e/kubernetes/kubernetes_test.go
@@ -17,30 +17,36 @@ limitations under the License.
 package kubernetes_test
 
 import (
-	"os"
 	"testing"
 
 	"github.com/dapr/cli/tests/e2e/common"
 )
 
-var currentRuntimeVersion, currentDashboardVersion = common.GetFromEnvVar(t)
+var (
+	currentRuntimeVersion   string
+	currentDashboardVersion string
+	currentVersionDetails   common.VersionDetails
+)
 
-var currentVersionDetails = common.VersionDetails{
-	RuntimeVersion:      currentRuntimeVersion,
-	DashboardVersion:    currentDashboardVersion,
-	CustomResourceDefs:  []string{"components.dapr.io", "configurations.dapr.io", "subscriptions.dapr.io"},
-	ClusterRoles:        []string{"dapr-operator-admin", "dashboard-reader"},
-	ClusterRoleBindings: []string{"dapr-operator", "dapr-role-tokenreview-binding", "dashboard-reader-global"},
-}
+// ensureCleanEnv function needs to be called in every Test function.
+// sets necessary variable values and uninstalls any previously installed `dapr`.
+func ensureCleanEnv(t *testing.T) {
+	currentRuntimeVersion, currentDashboardVersion = common.GetFromEnvVar(t)
 
-func ensureCleanEnv(t *testing.T, details common.VersionDetails) {
+	currentVersionDetails = common.VersionDetails{
+		RuntimeVersion:      currentRuntimeVersion,
+		DashboardVersion:    currentDashboardVersion,
+		CustomResourceDefs:  []string{"components.dapr.io", "configurations.dapr.io", "subscriptions.dapr.io"},
+		ClusterRoles:        []string{"dapr-operator-admin", "dashboard-reader"},
+		ClusterRoleBindings: []string{"dapr-operator", "dapr-role-tokenreview-binding", "dashboard-reader-global"},
+	}
 	// Ensure a clean environment
 	common.EnsureUninstall(true) // does not wait for pod deletion
 }
 
 func TestKubernetesNonHAModeMTLSDisabled(t *testing.T) {
 	// ensure clean env for test
-	ensureCleanEnv(t, currentVersionDetails)
+	ensureCleanEnv(t)
 
 	// setup tests
 	tests := []common.TestCase{}
@@ -71,7 +77,7 @@ func TestKubernetesNonHAModeMTLSDisabled(t *testing.T) {
 
 func TestKubernetesHAModeMTLSDisabled(t *testing.T) {
 	// ensure clean env for test
-	ensureCleanEnv(t, currentVersionDetails)
+	ensureCleanEnv(t)
 
 	// setup tests
 	tests := []common.TestCase{}
@@ -102,7 +108,7 @@ func TestKubernetesHAModeMTLSDisabled(t *testing.T) {
 
 func TestKubernetesNonHAModeMTLSEnabled(t *testing.T) {
 	// ensure clean env for test
-	ensureCleanEnv(t, currentVersionDetails)
+	ensureCleanEnv(t)
 
 	// setup tests
 	tests := []common.TestCase{}
@@ -133,7 +139,7 @@ func TestKubernetesNonHAModeMTLSEnabled(t *testing.T) {
 
 func TestKubernetesHAModeMTLSEnabled(t *testing.T) {
 	// ensure clean env for test
-	ensureCleanEnv(t, currentVersionDetails)
+	ensureCleanEnv(t)
 
 	// setup tests
 	tests := []common.TestCase{}
@@ -166,7 +172,8 @@ func TestKubernetesHAModeMTLSEnabled(t *testing.T) {
 // Test for certificate renewal
 
 func TestRenewCertificateMTLSEnabled(t *testing.T) {
-	common.EnsureUninstall(true)
+	// ensure clean env for test
+	ensureCleanEnv(t)
 
 	tests := []common.TestCase{}
 	installOpts := common.TestOptions{
@@ -215,7 +222,8 @@ func TestRenewCertificateMTLSEnabled(t *testing.T) {
 }
 
 func TestRenewCertificateMTLSDisabled(t *testing.T) {
-	common.EnsureUninstall(true)
+	// ensure clean env for test
+	ensureCleanEnv(t)
 
 	tests := []common.TestCase{}
 	installOpts := common.TestOptions{
@@ -264,7 +272,8 @@ func TestRenewCertificateMTLSDisabled(t *testing.T) {
 }
 
 func TestRenewCertWithPrivateKey(t *testing.T) {
-	common.EnsureUninstall(true)
+	// ensure clean env for test
+	ensureCleanEnv(t)
 
 	tests := []common.TestCase{}
 	installOpts := common.TestOptions{

--- a/tests/e2e/kubernetes/kubernetes_test.go
+++ b/tests/e2e/kubernetes/kubernetes_test.go
@@ -23,10 +23,7 @@ import (
 	"github.com/dapr/cli/tests/e2e/common"
 )
 
-var (
-	currentRuntimeVersion   = os.Getenv("DAPR_RUNTIME_VERSION")
-	currentDashboardVersion = os.Getenv("DAPR_DASHBOARD_VERSION")
-)
+var currentRuntimeVersion, currentDashboardVersion = common.GetFromEnvVar(t)
 
 var currentVersionDetails = common.VersionDetails{
 	RuntimeVersion:      currentRuntimeVersion,
@@ -172,7 +169,7 @@ func TestRenewCertificateMTLSEnabled(t *testing.T) {
 	common.EnsureUninstall(true)
 
 	tests := []common.TestCase{}
-	var installOpts = common.TestOptions{
+	installOpts := common.TestOptions{
 		HAEnabled:             false,
 		MTLSEnabled:           true,
 		ApplyComponentChanges: true,
@@ -221,7 +218,7 @@ func TestRenewCertificateMTLSDisabled(t *testing.T) {
 	common.EnsureUninstall(true)
 
 	tests := []common.TestCase{}
-	var installOpts = common.TestOptions{
+	installOpts := common.TestOptions{
 		HAEnabled:             false,
 		MTLSEnabled:           false,
 		ApplyComponentChanges: true,
@@ -270,7 +267,7 @@ func TestRenewCertWithPrivateKey(t *testing.T) {
 	common.EnsureUninstall(true)
 
 	tests := []common.TestCase{}
-	var installOpts = common.TestOptions{
+	installOpts := common.TestOptions{
 		HAEnabled:             false,
 		MTLSEnabled:           true,
 		ApplyComponentChanges: true,

--- a/tests/e2e/standalone/standalone_test.go
+++ b/tests/e2e/standalone/standalone_test.go
@@ -51,7 +51,7 @@ var socketCases = []string{"", "/tmp"}
 func TestStandaloneInstall(t *testing.T) {
 	// Ensure a clean environment.
 	uninstall()
-	daprRuntimeVersion, daprDashboardVersion = testCommon.GetFromEnvVar(t)
+	daprRuntimeVersion, daprDashboardVersion = testCommon.GetVersionsFromEnv(t)
 
 	tests := []struct {
 		name  string
@@ -75,7 +75,7 @@ func TestStandaloneInstall(t *testing.T) {
 func TestEnableAPILogging(t *testing.T) {
 	// Ensure a clean environment.
 	uninstall()
-	daprRuntimeVersion, daprDashboardVersion = testCommon.GetFromEnvVar(t)
+	daprRuntimeVersion, daprDashboardVersion = testCommon.GetVersionsFromEnv(t)
 
 	tests := []struct {
 		name  string
@@ -94,7 +94,7 @@ func TestEnableAPILogging(t *testing.T) {
 func TestNegativeScenarios(t *testing.T) {
 	// Ensure a clean environment
 	uninstall()
-	daprRuntimeVersion, daprDashboardVersion = testCommon.GetFromEnvVar(t)
+	daprRuntimeVersion, daprDashboardVersion = testCommon.GetVersionsFromEnv(t)
 	daprPath := getDaprPath()
 
 	homeDir, err := os.UserHomeDir()
@@ -165,7 +165,7 @@ func TestNegativeScenarios(t *testing.T) {
 func TestPrivateRegistry(t *testing.T) {
 	// Ensure a clean environment.
 	uninstall()
-	daprRuntimeVersion, daprDashboardVersion = testCommon.GetFromEnvVar(t)
+	daprRuntimeVersion, daprDashboardVersion = testCommon.GetVersionsFromEnv(t)
 
 	tests := []struct {
 		name  string

--- a/tests/e2e/standalone/standalone_test.go
+++ b/tests/e2e/standalone/standalone_test.go
@@ -33,6 +33,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"gopkg.in/yaml.v2"
 
+	testCommon "github.com/dapr/cli/tests/e2e/common"
 	"github.com/dapr/cli/tests/e2e/spawn"
 	"github.com/dapr/go-sdk/service/common"
 	daprHttp "github.com/dapr/go-sdk/service/http"
@@ -47,24 +48,10 @@ var (
 
 var socketCases = []string{"", "/tmp"}
 
-// setFromEnvVar will set local var values from required environment variables, if not fail the test.
-func setFromEnvVar(t *testing.T) {
-	if runtimeVersion, ok := os.LookupEnv("DAPR_RUNTIME_VERSION"); ok {
-		daprRuntimeVersion = runtimeVersion
-	} else {
-		t.Fatalf("env var \"DAPR_RUNTIME_VERSION\" not set")
-	}
-	if dashboardVersion, ok := os.LookupEnv("DAPR_DASHBOARD_VERSION"); ok {
-		daprDashboardVersion = dashboardVersion
-	} else {
-		t.Fatalf("env var \"DAPR_DASHBOARD_VERSION\" not set")
-	}
-}
-
 func TestStandaloneInstall(t *testing.T) {
 	// Ensure a clean environment.
 	uninstall()
-	setFromEnvVar(t)
+	daprRuntimeVersion, daprDashboardVersion = testCommon.GetFromEnvVar(t)
 
 	tests := []struct {
 		name  string
@@ -88,7 +75,7 @@ func TestStandaloneInstall(t *testing.T) {
 func TestEnableAPILogging(t *testing.T) {
 	// Ensure a clean environment.
 	uninstall()
-	setFromEnvVar(t)
+	daprRuntimeVersion, daprDashboardVersion = testCommon.GetFromEnvVar(t)
 
 	tests := []struct {
 		name  string
@@ -107,7 +94,7 @@ func TestEnableAPILogging(t *testing.T) {
 func TestNegativeScenarios(t *testing.T) {
 	// Ensure a clean environment
 	uninstall()
-	setFromEnvVar(t)
+	daprRuntimeVersion, daprDashboardVersion = testCommon.GetFromEnvVar(t)
 	daprPath := getDaprPath()
 
 	homeDir, err := os.UserHomeDir()
@@ -178,7 +165,7 @@ func TestNegativeScenarios(t *testing.T) {
 func TestPrivateRegistry(t *testing.T) {
 	// Ensure a clean environment.
 	uninstall()
-	setFromEnvVar(t)
+	daprRuntimeVersion, daprDashboardVersion = testCommon.GetFromEnvVar(t)
 
 	tests := []struct {
 		name  string


### PR DESCRIPTION
# Description

Fix `--from-dir` init flow. 

Based on the PR https://github.com/dapr/installer-bundle/pull/3, this PR changes init flow when `--from-dir` flag is specified to expect a `details.json` file.
It will parse the `details.json` file to know the image that was saved as well as the file name it was saved as. 
Also as previous flow, the runtime and dashboard versions are determined from the `details.json` file as well.

isAirGapInit just encapsulates the value of bool comparing fromDir length to zero. isAirGapInit seems a more expressive way of checking for a particular condition in a flow.

Added more comments on the current init flow. 

Create a separate `bundle.go` which basically just parses the `details.json` file and added a unit test for the same. 

When both `--from-dir` and `--image-registry` is given, changed `cmd/init.go` flow to error out that both flags are given. 

Fixed the e2e tests to error out gracefully if required env vars are not set.

Output of local tests run 
```bash
$  export DAPR_DEFAULT_IMAGE_REGISTRY=GHCR                                                 

$ ./release/dapr init --from-dir ../bundle/daprbundle
⌛  Making the jump to hyperspace...
⚠  Local bundle installation using from-dir flag is currently a preview feature.
ℹ️  Installing runtime version 1.7.0-rc.2
↓  Extracting binaries and setting up components... 
Dapr runtime installed to /Users/test/.dapr/bin, you may run the following to add it to your path if you want to run daprd directly:
    export PATH=$PATH:/Users/test/.dapr/bin
↙  Extracting binaries and setting up components... Loaded image: daprio/dapr:1.7.0-rc.2
✅  Extracting binaries and setting up components...
✅  Extracted binaries and completed components set up.
ℹ️  daprd binary has been installed to /Users/test/.dapr/bin.
ℹ️  dapr_placement container is running.
ℹ️  Use `docker ps` to check running containers.
✅  Success! Dapr is up and running. To get started, go here: https://aka.ms/dapr-getting-started

$ docker ps 
CONTAINER ID   IMAGE                    COMMAND         CREATED              STATUS              PORTS                      NAMES
fbfbd3403092   daprio/dapr:1.7.0-rc.2   "./placement"   About a minute ago   Up About a minute   0.0.0.0:50005->50005/tcp   dapr_placement

$ ./release/dapr uninstall --all                     
ℹ️  Removing Dapr from your machine...
ℹ️  Removing directory: /Users/test/.dapr/bin
ℹ️  Removing container: dapr_placement
⚠  WARNING: dapr_redis container does not exist
⚠  WARNING: dapr_zipkin container does not exist
ℹ️  Removing directory: /Users/test/.dapr
✅  Dapr has been removed successfully

$ ./release/dapr init —runtime-version 1.7.0-rc.2
⌛  Making the jump to hyperspace...
ℹ️  Container images will be pulled from Dapr GitHub container registry
ℹ️  Installing runtime version 1.7.0-rc.2
↗  Downloading binaries and setting up components... 
Dapr runtime installed to /Users/test/.dapr/bin, you may run the following to add it to your path if you want to run daprd directly:
    export PATH=$PATH:/Users/test/.dapr/bin
✅  Downloading binaries and setting up components...
✅  Downloaded binaries and completed components set up.
ℹ️  daprd binary has been installed to /Users/test/.dapr/bin.
ℹ️  dapr_placement container is running.
ℹ️  dapr_redis container is running.
ℹ️  dapr_zipkin container is running.
ℹ️  Use `docker ps` to check running containers.
✅  Success! Dapr is up and running. To get started, go here: https://aka.ms/dapr-getting-started

$ docker ps 
CONTAINER ID   IMAGE                          COMMAND                  CREATED          STATUS                    PORTS                              NAMES
4ad6ed31c863   ghcr.io/dapr/dapr:1.7.0-rc.2   "./placement"            20 seconds ago   Up 19 seconds             0.0.0.0:50005->50005/tcp           dapr_placement
789f50de37ec   ghcr.io/dapr/3rdparty/zipkin   "start-zipkin"           21 seconds ago   Up 20 seconds (healthy)   9410/tcp, 0.0.0.0:9411->9411/tcp   dapr_zipkin
f6d54c1e00b5   ghcr.io/dapr/3rdparty/redis    "docker-entrypoint.s…"   21 seconds ago   Up 20 seconds             0.0.0.0:6379->6379/tcp             dapr_redis

$ ./release/dapr init           
⌛  Making the jump to hyperspace...
ℹ️  Container images will be pulled from Dapr GitHub container registry
ℹ️  Installing runtime version 1.6.1
↙  Downloading binaries and setting up components... ℹ️  Placement image not found in Github container registry, pulling it from Docker Hub
↑  Downloading binaries and setting up components... 
Dapr runtime installed to /Users/test/.dapr/bin, you may run the following to add it to your path if you want to run daprd directly:
    export PATH=$PATH:/Users/test/.dapr/bin
✅  Downloading binaries and setting up components...
✅  Downloaded binaries and completed components set up.
ℹ️  daprd binary has been installed to /Users/test/.dapr/bin.
ℹ️  dapr_placement container is running.
ℹ️  dapr_redis container is running.
ℹ️  dapr_zipkin container is running.
ℹ️  Use `docker ps` to check running containers.
✅  Success! Dapr is up and running. To get started, go here: https://aka.ms/dapr-getting-started

$ docker ps
CONTAINER ID   IMAGE                          COMMAND                  CREATED          STATUS                    PORTS                              NAMES
8cf807b85281   daprio/dapr:1.6.1              "./placement"            44 seconds ago   Up 43 seconds             0.0.0.0:50005->50005/tcp           dapr_placement
79761ca1a39c   ghcr.io/dapr/3rdparty/redis    "docker-entrypoint.s…"   45 seconds ago   Up 45 seconds             0.0.0.0:6379->6379/tcp             dapr_redis
4b78af8d1428   ghcr.io/dapr/3rdparty/zipkin   "start-zipkin"           45 seconds ago   Up 45 seconds (healthy)   9410/tcp, 0.0.0.0:9411->9411/tcp   dapr_zipkin

$ ./release/dapr uninstall --all 
....
....
$ export DAPR_DEFAULT_IMAGE_REGISTRY=localhost:5000
$ ./release/dapr init --runtime-version 1.7.0-rc.2
⌛  Making the jump to hyperspace...
❌  environment variable "DAPR_DEFAULT_IMAGE_REGISTRY" can only be set to GHCR
```

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

closes #938 
closes #916 

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Created/updated tests
* [ ] Extended the documentation
