### PR TITLE
Do not allow mixing of flags in renew cert

### DIFF
--- a/pkg/kubernetes/mtls.go
+++ b/pkg/kubernetes/mtls.go
@@ -165,7 +165,10 @@ func Expiry() (*time.Time, error) {
 		return nil, err
 	}
 
-	caCrt := secret.Data["ca.crt"]
+	caCrt, ok := secret.Data["ca.crt"]
+	if !ok {
+		return nil, errors.New("root certificate not loaded yet, please try again in few minutes")
+	}
 	block, _ := pem.Decode(caCrt)
 	cert, err := x509.ParseCertificate(block.Bytes)
 	if err != nil {

--- a/tests/e2e/common/common.go
+++ b/tests/e2e/common/common.go
@@ -486,6 +486,50 @@ func UseProvidedNewCertAndRenew(details VersionDetails, opts TestOptions) func(t
 	}
 }
 
+func NegativeScenarioForCertRenew() func(t *testing.T) {
+	return func(t *testing.T) {
+		daprPath := getDaprPath()
+		args := []string{
+			"mtls", "renew-certificate", "-k",
+			"--ca-root-certificate", "invalid_cert_file.pem",
+		}
+		output, err := spawn.Command(daprPath, args...)
+		t.Log(output)
+		require.Error(t, err, "expected error on certificate renewal")
+		assert.Contains(t, output, "certificate rotation failed: all required flags for this certificate rotation path")
+
+		args = []string{
+			"mtls", "renew-certificate", "-k",
+			"--ca-root-certificate", "invalid_cert_file.pem",
+			"--issuer-private-key", "invalid_cert_key.pem",
+			"--issuer-public-certificate", "invalid_cert_file.pem",
+		}
+		output, err = spawn.Command(daprPath, args...)
+		t.Log(output)
+		require.Error(t, err, "expected error on certificate renewal")
+		assert.Contains(t, output, "certificate rotation failed: open invalid_cert_file.pem: no such file or directory")
+
+		args = []string{
+			"mtls", "renew-certificate", "-k",
+			"--ca-root-certificate", "invalid_cert_file.pem",
+			"--private-key", "invalid_root_key.pem",
+		}
+		output, err = spawn.Command(daprPath, args...)
+		t.Log(output)
+		require.Error(t, err, "expected error on certificate renewal")
+		assert.Contains(t, output, "certificate rotation failed: all required flags for this certificate rotation path")
+
+		args = []string{
+			"mtls", "renew-certificate", "-k",
+			"--private-key", "invalid_root_key.pem",
+		}
+		output, err = spawn.Command(daprPath, args...)
+		t.Log(output)
+		require.Error(t, err, "expected error on certificate renewal")
+		assert.Contains(t, output, "certificate rotation failed: open invalid_root_key.pem: no such file or directory")
+	}
+}
+
 func CheckMTLSStatus(details VersionDetails, opts TestOptions, shouldWarningExist bool) func(t *testing.T) {
 	return func(t *testing.T) {
 		daprPath := getDaprPath()

--- a/tests/e2e/kubernetes/kubernetes_test.go
+++ b/tests/e2e/kubernetes/kubernetes_test.go
@@ -306,3 +306,39 @@ func TestRenewCertWithPrivateKey(t *testing.T) {
 		t.Run(tc.Name, tc.Callable)
 	}
 }
+
+func TestRenewCertWithIncorrectFlags(t *testing.T) {
+	common.EnsureUninstall(true)
+
+	tests := []common.TestCase{}
+	var installOpts = common.TestOptions{
+		HAEnabled:             false,
+		MTLSEnabled:           true,
+		ApplyComponentChanges: true,
+		CheckResourceExists: map[common.Resource]bool{
+			common.CustomResourceDefs:  true,
+			common.ClusterRoles:        true,
+			common.ClusterRoleBindings: true,
+		},
+	}
+
+	tests = append(tests, common.GetTestsOnInstall(currentVersionDetails, installOpts)...)
+
+	// tests for certifcate renewal with incorrect set of flags provided.
+	tests = append(tests, []common.TestCase{
+		{"Renew certificate with incorrect flags", common.NegativeScenarioForCertRenew()},
+	}...)
+
+	// teardown everything
+	tests = append(tests, common.GetTestsOnUninstall(currentVersionDetails, common.TestOptions{
+		CheckResourceExists: map[common.Resource]bool{
+			common.CustomResourceDefs:  true,
+			common.ClusterRoles:        false,
+			common.ClusterRoleBindings: false,
+		},
+	})...)
+
+	for _, tc := range tests {
+		t.Run(tc.Name, tc.Callable)
+	}
+}


### PR DESCRIPTION
# Description

Made changes, so that to flags present in below commands cannot be mixed.
a. `dapr mtls renew-certificate -k --ca-root-certificate <ca.crt> --issuer-private-key <issuer.key> --issuer-public-certificate <issuer.crt>`

b. `dapr mtls renew-certificate -k --private-key myprivatekey.key`

if any one of the flags is provided in 1st command, it will still try to execute the flow assuming all 3 are provided and will throw error if not all params are provided.

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #941 

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Created/updated tests
* [ ] Extended the documentation
