### PR TITLE
Update golangci-lint-action to v3.1.0

### DIFF
--- a/.github/workflows/dapr_cli.yaml
+++ b/.github/workflows/dapr_cli.yaml
@@ -62,7 +62,7 @@ jobs:
         uses: actions/checkout@v2
       - name: Run golangci-lint
         if: matrix.target_arch == 'amd64' && matrix.target_os == 'linux'
-        uses: golangci/golangci-lint-action@v2
+        uses: golangci/golangci-lint-action@v3.1.0
         with:
           version: ${{ env.GOLANG_CI_LINT_VER }}
           only-new-issues: true


### PR DESCRIPTION
Signed-off-by: Shubham Sharma <shubhash@microsoft.com>

# Description

We currently use golangci/golangci-lint-action's v2.2.1 which installs the latest go version (1.18 in this case). Upgrade to v3.1.0 which reuses the pipeline's go installation.

## Issue reference

Related to https://github.com/dapr/components-contrib/issues/1639

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [ ] Extended the documentation
