### PR TITLE
Fix CRD handling for upgrades and removals

### DIFF
--- a/pkg/kubernetes/uninstall.go
+++ b/pkg/kubernetes/uninstall.go
@@ -14,10 +14,12 @@ limitations under the License.
 package kubernetes
 
 import (
+	"os"
 	"time"
 
 	helm "helm.sh/helm/v3/pkg/action"
 
+	"github.com/dapr/cli/pkg/print"
 	"github.com/dapr/cli/utils"
 )
 
@@ -39,7 +41,7 @@ func Uninstall(namespace string, uninstallAll bool, timeout uint) error {
 		for _, crd := range crdsFullResources {
 			_, err := utils.RunCmdAndWait("kubectl", "delete", "crd", crd)
 			if err != nil {
-				return err
+				print.WarningStatusEvent(os.Stdout, "Failed to remove CRD %s: %s", crd, err)
 			}
 		}
 	}

--- a/pkg/kubernetes/upgrade.go
+++ b/pkg/kubernetes/upgrade.go
@@ -138,7 +138,7 @@ func applyCRDs(version string) error {
 	for _, crd := range crds {
 		url := fmt.Sprintf("https://raw.githubusercontent.com/dapr/dapr/%s/charts/dapr/crds/%s.yaml", version, crd)
 
-		resp, _ := http.Get(url)
+		resp, _ := http.Get(url) // nolint:gosec
 		if resp != nil && resp.StatusCode == 200 {
 			_, err := utils.RunCmdAndWait("kubectl", "apply", "-f", url)
 			if err != nil {

--- a/pkg/kubernetes/upgrade.go
+++ b/pkg/kubernetes/upgrade.go
@@ -41,7 +41,7 @@ var crdsFullResources = []string{
 	"components.dapr.io",
 	"configurations.dapr.io",
 	"subscriptions.dapr.io",
-	"resiliency.dapr.io",
+	"resiliencies.dapr.io",
 }
 
 type UpgradeConfig struct {
@@ -140,6 +140,8 @@ func applyCRDs(version string) error {
 
 		resp, _ := http.Get(url) // nolint:gosec
 		if resp != nil && resp.StatusCode == 200 {
+			defer resp.Body.Close()
+
 			_, err := utils.RunCmdAndWait("kubectl", "apply", "-f", url)
 			if err != nil {
 				return err


### PR DESCRIPTION
Fixes https://github.com/dapr/cli/issues/975.

This PR does several things:

1. Fixes issue #975 by adding the resiliency CRD to the list of CRDs to be applied to the cluster and removed when uninstalled
2. Fixes an issue where a user tries to install a version of Dapr (for example, 1.1.0) with a CLI that tries to apply CRDs that are not available in the desired version (for example, trying to install Dapr 1.1.0 with CLI 1.5.0 will fail because the CLI can't find the subscription CRD for 1.1.0). This is done by checking if the CRD exists for the required version before attempting to apply it to the cluster.
3. Fixes an issue where users trying to uninstall an older version of Dapr with a newer CLI is failing because the older version doesn't have a CRD that the CLI is trying to uninstall. (for example, trying to remove Dapr 1.6.0 with the 1.7.0 CLI will fail because it can't find a resiliency policy). The PR treats the removal of a CRD as a warning instead of an error.