### PR TITLE
Fix for panic during upgrade of edge version dapr

### DIFF
--- a/pkg/kubernetes/upgrade.go
+++ b/pkg/kubernetes/upgrade.go
@@ -173,7 +173,7 @@ func isDowngrade(targetVersion, existingVersion string) bool {
 	if err != nil {
 		print.FailureStatusEvent(
 			os.Stderr,
-			fmt.Sprintf("Upgrade failed, %s. Upgrading an edge version of Dapr is not supported!", err.Error()))
+			fmt.Sprintf("Upgrade failed, %s. The current installed version does not have sematic versioning", err.Error()))
 		os.Exit(1)
 	}
 	return target.LessThan(existing)

--- a/pkg/kubernetes/upgrade.go
+++ b/pkg/kubernetes/upgrade.go
@@ -169,7 +169,12 @@ func upgradeChartValues(ca, issuerCert, issuerKey string, haMode, mtls bool, arg
 
 func isDowngrade(targetVersion, existingVersion string) bool {
 	target, _ := version.NewVersion(targetVersion)
-	existing, _ := version.NewVersion(existingVersion)
-
+	existing, err := version.NewVersion(existingVersion)
+	if err != nil {
+		print.FailureStatusEvent(
+			os.Stderr,
+			fmt.Sprintf("Upgrade failed, %s. Upgrading an edge version of Dapr is not supported!", err.Error()))
+		os.Exit(1)
+	}
 	return target.LessThan(existing)
 }


### PR DESCRIPTION
Signed-off-by: Pravin Pushkar <ppushkar@microsoft.com>

# Description

Handle panic caused while trying to upgrade an edge version of Dapr.

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #954 

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [ ] Created/updated tests
* [ ] Extended the documentation
