### PR TITLE
Script for docker install instead of actions-setup-docker

### DIFF
--- a/.github/workflows/self_hosted_e2e.yaml
+++ b/.github/workflows/self_hosted_e2e.yaml
@@ -59,10 +59,12 @@ jobs:
         uses: actions/checkout@v2
       - name: Install docker - MacOS
         if: matrix.os == 'macos-latest'
-        uses: docker-practice/actions-setup-docker@1.0.8
-        with:
-          docker_buildx: false
-          docker_version: 20.10
+        run: |
+          brew install --cask docker
+          sudo /Applications/Docker.app/Contents/MacOS/Docker --unattended --install-privileged-components
+          open -a /Applications/Docker.app --args --unattended --accept-license
+          while ! /Applications/Docker.app/Contents/Resources/bin/docker info &>/dev/null; do sleep 1; done
+          docker --version
       - name: Determine latest Dapr Runtime version including Pre-releases
         if: github.base_ref == 'master'
         run: |


### PR DESCRIPTION
Signed-off-by: Pravin Pushkar <ppushkar@microsoft.com>

# Description

Switching to `brew install` instead of using `actions-setup-docker` github action, as with the action docker setup seems highly unstable. This way it might increase the time to setup docker on macos (can take upto 10 mins) but atleast it looks more stable. It failed once in last 4 runs. See here- https://github.com/pravinpushkar/cli/actions/workflows/self_hosted_e2e.yaml

Related discussions can be found here - https://github.com/docker/for-mac/issues/2359

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #981 

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [ ] Created/updated tests
* [ ] Extended the documentation
