### PR TITLE
Fixing airgap init

### DIFF
--- a/pkg/standalone/standalone.go
+++ b/pkg/standalone/standalone.go
@@ -637,7 +637,7 @@ func installBinary(version, binaryFilePrefix, githubRepo string, info initInfo) 
 func createComponentsAndConfiguration(wg *sync.WaitGroup, errorChan chan<- error, info initInfo) {
 	defer wg.Done()
 
-	if info.slimMode {
+	if info.slimMode || isAirGapInit {
 		return
 	}
 
@@ -673,7 +673,7 @@ func createComponentsAndConfiguration(wg *sync.WaitGroup, errorChan chan<- error
 func createSlimConfiguration(wg *sync.WaitGroup, errorChan chan<- error, info initInfo) {
 	defer wg.Done()
 
-	if !info.slimMode {
+	if !(info.slimMode || isAirGapInit) {
 		return
 	}
 


### PR DESCRIPTION
# Description

Fixes airgap init in standalone mode, where some unnecessary config/component files were being created, causing dapr run to fail afterwards.

## Issue reference


Please reference the issue this PR will close: #970 

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [ ] Extended the documentation
