### PR TITLE
Removing the use of the ioutil package

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -59,7 +59,7 @@ linters-settings:
     # [deprecated] comma-separated list of pairs of the form pkg:regex
     # the regex is used to ignore names within pkg. (default "fmt:.*").
     # see https://github.com/kisielk/errcheck#the-deprecated-method for details
-    ignore: fmt:.*,io/ioutil:^Read.*
+    # ignore: fmt:.*,io/ioutil:^Read.*
 
     # path to a file containing a list of functions to exclude from checking
     # see https://github.com/kisielk/errcheck#excluding-functions for details

--- a/cmd/annotate.go
+++ b/cmd/annotate.go
@@ -17,7 +17,6 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 	"os"
@@ -169,7 +168,7 @@ func readInputsFromURL(url string) ([]io.Reader, error) {
 	}
 
 	var b []byte
-	b, err = ioutil.ReadAll(resp.Body)
+	b, err = io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/invoke.go
+++ b/cmd/invoke.go
@@ -15,7 +15,6 @@ package cmd
 
 import (
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"runtime"
@@ -59,7 +58,7 @@ dapr invoke --unix-domain-socket --app-id target --method sample --verb GET
 		}
 
 		if invokeDataFile != "" {
-			bytePayload, err = ioutil.ReadFile(invokeDataFile)
+			bytePayload, err = os.ReadFile(invokeDataFile)
 			if err != nil {
 				print.FailureStatusEvent(os.Stderr, "Error reading payload from '%s'. Error: %s", invokeDataFile, err)
 				os.Exit(1)

--- a/cmd/publish.go
+++ b/cmd/publish.go
@@ -16,7 +16,6 @@ package cmd
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"runtime"
 
@@ -58,7 +57,7 @@ dapr publish --publish-app-id myapp --pubsub target --topic sample --data '{"key
 		}
 
 		if publishPayloadFile != "" {
-			bytePayload, err = ioutil.ReadFile(publishPayloadFile)
+			bytePayload, err = os.ReadFile(publishPayloadFile)
 			if err != nil {
 				print.FailureStatusEvent(os.Stderr, "Error reading payload from '%s'. Error: %s", publishPayloadFile, err)
 				os.Exit(1)

--- a/pkg/kubernetes/annotator_test.go
+++ b/pkg/kubernetes/annotator_test.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path"
 	"sort"
@@ -315,7 +314,7 @@ func TestAnnotate(t *testing.T) {
 			outString := out.String()
 			outDocs := strings.Split(outString, "---")
 
-			expected, err := ioutil.ReadFile(tt.expectedFilePath)
+			expected, err := os.ReadFile(tt.expectedFilePath)
 			assert.NoError(t, err)
 
 			expectedString := string(expected)

--- a/pkg/kubernetes/kubernetes.go
+++ b/pkg/kubernetes/kubernetes.go
@@ -16,7 +16,6 @@ package kubernetes
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -59,7 +58,7 @@ func Init(config InitConfiguration) error {
 
 	stopSpinning := print.Spinner(os.Stdout, msg)
 	defer stopSpinning(print.Failure)
-	//nolint
+	// nolint
 	err := install(config)
 	if err != nil {
 		return err
@@ -108,7 +107,7 @@ func getVersion(version string) (string, error) {
 }
 
 func createTempDir() (string, error) {
-	dir, err := ioutil.TempDir("", "dapr")
+	dir, err := os.MkdirTemp("", "dapr")
 	if err != nil {
 		return "", fmt.Errorf("error creating temp dir: %w", err)
 	}
@@ -116,7 +115,7 @@ func createTempDir() (string, error) {
 }
 
 func locateChartFile(dirPath string) (string, error) {
-	files, err := ioutil.ReadDir(dirPath)
+	files, err := os.ReadDir(dirPath)
 	if err != nil {
 		return "", err
 	}

--- a/pkg/kubernetes/mtls.go
+++ b/pkg/kubernetes/mtls.go
@@ -19,7 +19,6 @@ import (
 	"encoding/pem"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"time"
@@ -92,17 +91,17 @@ func ExportTrustChain(outputDir string) error {
 	issuerCert := secret.Data["issuer.crt"]
 	issuerKey := secret.Data["issuer.key"]
 
-	err = ioutil.WriteFile(filepath.Join(outputDir, "ca.crt"), ca, 0o600)
+	err = os.WriteFile(filepath.Join(outputDir, "ca.crt"), ca, 0o600)
 	if err != nil {
 		return err
 	}
 
-	err = ioutil.WriteFile(filepath.Join(outputDir, "issuer.crt"), issuerCert, 0o600)
+	err = os.WriteFile(filepath.Join(outputDir, "issuer.crt"), issuerCert, 0o600)
 	if err != nil {
 		return err
 	}
 
-	err = ioutil.WriteFile(filepath.Join(outputDir, "issuer.key"), issuerKey, 0o600)
+	err = os.WriteFile(filepath.Join(outputDir, "issuer.key"), issuerKey, 0o600)
 	if err != nil {
 		return err
 	}

--- a/pkg/kubernetes/portforward.go
+++ b/pkg/kubernetes/portforward.go
@@ -15,7 +15,7 @@ package kubernetes
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 	"os"
@@ -102,8 +102,8 @@ func (pf *PortForward) run() error {
 		return err
 	}
 
-	out := ioutil.Discard
-	errOut := ioutil.Discard
+	out := io.Discard
+	errOut := io.Discard
 	if pf.EmitLogs {
 		out = os.Stdout
 		errOut = os.Stderr

--- a/pkg/kubernetes/renew_certificate.go
+++ b/pkg/kubernetes/renew_certificate.go
@@ -19,7 +19,6 @@ import (
 	"encoding/pem"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"time"
 
@@ -72,15 +71,15 @@ func RenewCertificate(conf RenewCertificateParams) error {
 }
 
 func parseCertificateFiles(rootCert, issuerCert, issuerKey string) ([]byte, []byte, []byte, error) {
-	rootCertBytes, err := ioutil.ReadFile(rootCert)
+	rootCertBytes, err := os.ReadFile(rootCert)
 	if err != nil {
 		return nil, nil, nil, err
 	}
-	issuerCertBytes, err := ioutil.ReadFile(issuerCert)
+	issuerCertBytes, err := os.ReadFile(issuerCert)
 	if err != nil {
 		return nil, nil, nil, err
 	}
-	issuerKeyBytes, err := ioutil.ReadFile(issuerKey)
+	issuerKeyBytes, err := os.ReadFile(issuerKey)
 	if err != nil {
 		return nil, nil, nil, err
 	}
@@ -150,7 +149,7 @@ func createHelmParamsForNewCertificates(ca, issuerCert, issuerKey string) (map[s
 func GenerateNewCertificates(validUntil time.Duration, privateKeyFile string) ([]byte, []byte, []byte, error) {
 	var rootKey *ecdsa.PrivateKey
 	if privateKeyFile != "" {
-		privateKeyBytes, err := ioutil.ReadFile(privateKeyFile)
+		privateKeyBytes, err := os.ReadFile(privateKeyFile)
 		if err != nil {
 			return nil, nil, nil, err
 		}

--- a/pkg/metadata/metadata.go
+++ b/pkg/metadata/metadata.go
@@ -17,7 +17,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net"
 	"net/http"
 	"os"
@@ -108,7 +108,7 @@ func makeMetadataPutEndpoint(httpPort int, key string) string {
 }
 
 func handleMetadataResponse(response *http.Response) (*api.Metadata, error) {
-	rb, err := ioutil.ReadAll(response.Body)
+	rb, err := io.ReadAll(response.Body)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/standalone/bundle.go
+++ b/pkg/standalone/bundle.go
@@ -16,7 +16,7 @@ package standalone
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"strings"
 )
 
@@ -34,7 +34,7 @@ type bundleDetails struct {
 
 // readAndParseDetails reads the file in detailsFilePath and tries to parse it into the bundleDetails struct.
 func (b *bundleDetails) readAndParseDetails(detailsFilePath string) error {
-	bytes, err := ioutil.ReadFile(detailsFilePath)
+	bytes, err := os.ReadFile(detailsFilePath)
 	if err != nil {
 		return err
 	}

--- a/pkg/standalone/invoke.go
+++ b/pkg/standalone/invoke.go
@@ -17,7 +17,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net"
 	"net/http"
 
@@ -72,7 +72,7 @@ func handleResponse(response *http.Response) (string, error) {
 		return "", fmt.Errorf("%s", response.Status)
 	}
 
-	rb, err := ioutil.ReadAll(response.Body)
+	rb, err := io.ReadAll(response.Body)
 	if err != nil {
 		return "", err
 	}

--- a/pkg/standalone/run.go
+++ b/pkg/standalone/run.go
@@ -15,7 +15,6 @@ package standalone
 
 import (
 	"fmt"
-	"io/ioutil"
 	"net"
 	"os"
 	"os/exec"
@@ -184,7 +183,7 @@ func (meta *DaprMeta) portExists(port int) bool {
 	if port <= 0 {
 		return false
 	}
-	//nolint
+	// nolint
 	_, ok := meta.ExistingPorts[port]
 	if ok {
 		return true
@@ -301,7 +300,7 @@ func mtlsEndpoint(configFile string) string {
 		return ""
 	}
 
-	b, err := ioutil.ReadFile(configFile)
+	b, err := os.ReadFile(configFile)
 	if err != nil {
 		return ""
 	}
@@ -339,7 +338,7 @@ func getAppCommand(config *RunConfig) *exec.Cmd {
 }
 
 func Run(config *RunConfig) (*RunOutput, error) {
-	//nolint
+	// nolint
 	err := config.validate()
 	if err != nil {
 		return nil, err
@@ -350,7 +349,7 @@ func Run(config *RunConfig) (*RunOutput, error) {
 		return nil, err
 	}
 
-	//nolint
+	// nolint
 	var appCMD *exec.Cmd = getAppCommand(config)
 	return &RunOutput{
 		DaprCMD:      daprCMD,

--- a/pkg/standalone/standalone.go
+++ b/pkg/standalone/standalone.go
@@ -21,7 +21,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net"
 	"net/http"
 	"os"
@@ -688,7 +687,7 @@ func createSlimConfiguration(wg *sync.WaitGroup, errorChan chan<- error, info in
 func makeDefaultComponentsDir() error {
 	// Make default components directory.
 	componentsDir := DefaultComponentsDirPath()
-	//nolint
+	// nolint
 	_, err := os.Stat(componentsDir)
 	if os.IsNotExist(err) {
 		errDir := os.MkdirAll(componentsDir, 0o755)
@@ -813,7 +812,7 @@ func untar(reader io.Reader, targetDir string, binaryFilePrefix string) (string,
 	foundBinary := ""
 	for {
 		header, err := tr.Next()
-		//nolint
+		// nolint
 		if err == io.EOF {
 			break
 		} else if err != nil {
@@ -862,7 +861,7 @@ func moveFileToPath(filepath string, installLocation string) (string, error) {
 	destDir := installLocation
 	destFilePath = path.Join(destDir, fileName)
 
-	input, err := ioutil.ReadFile(filepath)
+	input, err := os.ReadFile(filepath)
 	if err != nil {
 		return "", err
 	}
@@ -873,7 +872,7 @@ func moveFileToPath(filepath string, installLocation string) (string, error) {
 	}
 
 	// #nosec G306
-	if err = ioutil.WriteFile(destFilePath, input, 0o644); err != nil {
+	if err = os.WriteFile(destFilePath, input, 0o644); err != nil {
 		if runtime.GOOS != daprWindowsOS && strings.Contains(err.Error(), "permission denied") {
 			err = errors.New(err.Error() + " - please run with sudo")
 		}
@@ -994,7 +993,7 @@ func checkAndOverWriteFile(filePath string, b []byte) error {
 	_, err := os.Stat(filePath)
 	if os.IsNotExist(err) {
 		// #nosec G306
-		if err = ioutil.WriteFile(filePath, b, 0o644); err != nil {
+		if err = os.WriteFile(filePath, b, 0o644); err != nil {
 			return err
 		}
 	}
@@ -1091,7 +1090,8 @@ func downloadFile(dir string, url string) (string, error) {
 	return filepath, nil
 }
 
-/*!
+/*
+!
 See: https://github.com/microsoft/vscode-winsta11er/blob/4b42060da64aea6f47adebe1dd654980ed87a046/common/common.go
 Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT License.
 */

--- a/pkg/standalone/standalone_test.go
+++ b/pkg/standalone/standalone_test.go
@@ -14,7 +14,6 @@ limitations under the License.
 package standalone
 
 import (
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -38,7 +37,7 @@ spec:
 		os.Remove(testFile)
 		createDefaultConfiguration("test_zipkin_host", testFile)
 		assert.FileExists(t, testFile)
-		content, err := ioutil.ReadFile(testFile)
+		content, err := os.ReadFile(testFile)
 		assert.NoError(t, err)
 		assert.Equal(t, expectConfigZipkin, string(content))
 	})
@@ -53,7 +52,7 @@ spec: {}
 		os.Remove(testFile)
 		createDefaultConfiguration("", testFile)
 		assert.FileExists(t, testFile)
-		content, err := ioutil.ReadFile(testFile)
+		content, err := os.ReadFile(testFile)
 		assert.NoError(t, err)
 		assert.Equal(t, expectConfigSlim, string(content))
 	})

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -16,7 +16,7 @@ package version
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"os"
 	"strings"
@@ -91,7 +91,7 @@ func GetVersionFromURL(releaseURL string, parseVersion func(body []byte) (string
 		return "", fmt.Errorf("%s - %s", releaseURL, resp.Status)
 	}
 
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return "", err
 	}

--- a/tests/e2e/standalone/standalone_test.go
+++ b/tests/e2e/standalone/standalone_test.go
@@ -21,7 +21,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"os/exec"
@@ -395,7 +394,7 @@ func verifyArtifactsAfterInstall(t *testing.T) {
 	for filename, contents := range configs {
 		t.Run(filename, func(t *testing.T) {
 			fullpath := filepath.Join(path, filename)
-			contentBytes, err := ioutil.ReadFile(fullpath)
+			contentBytes, err := os.ReadFile(fullpath)
 			if !assert.NoError(t, err) {
 				return
 			}

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -20,7 +20,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net"
 	"os"
 	"os/exec"
@@ -98,13 +97,13 @@ func RunCmdAndWait(name string, args ...string) (string, error) {
 		return "", err
 	}
 
-	resp, err := ioutil.ReadAll(stdout)
+	resp, err := io.ReadAll(stdout)
 	if err != nil {
 		return "", err
 	}
-	errB, err := ioutil.ReadAll(stderr)
+	errB, err := io.ReadAll(stderr)
 	if err != nil {
-		//nolint
+		// nolint
 		return "", nil
 	}
 


### PR DESCRIPTION
# Description

The current minimum version of dapr is golang 1.18, which is no longer compatible with the previous version and can remove the marked deprecated functions.

## Issue reference


## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [ ] Created/updated tests
* [ ] Extended the documentation
