### PR TITLE
Support environments with broken $HOME

### DIFF
--- a/cmd/run.go
+++ b/cmd/run.go
@@ -352,9 +352,12 @@ dapr run --app-id myapp --app-port 3000 --app-protocol grpc -- go run main.go
 }
 
 func init() {
+	defaultConfig := standalone.DaprConfigPath(standalone.DefaultDaprDirPath())
+	defaultComponents := standalone.DaprComponentsPath(standalone.DefaultDaprDirPath())
+
 	RunCmd.Flags().IntVarP(&appPort, "app-port", "p", -1, "The port your application is listening on")
 	RunCmd.Flags().StringVarP(&appID, "app-id", "a", "", "The id for your application, used for service discovery")
-	RunCmd.Flags().StringVarP(&configFile, "config", "c", standalone.DefaultConfigFilePath(), "Dapr configuration file")
+	RunCmd.Flags().StringVarP(&configFile, "config", "c", defaultConfig, "Dapr configuration file")
 	RunCmd.Flags().IntVarP(&port, "dapr-http-port", "H", -1, "The HTTP port for Dapr to listen on")
 	RunCmd.Flags().IntVarP(&grpcPort, "dapr-grpc-port", "G", -1, "The gRPC port for Dapr to listen on")
 	RunCmd.Flags().IntVarP(&internalGRPCPort, "dapr-internal-grpc-port", "I", -1, "The gRPC port for the Dapr internal API to listen on")
@@ -363,7 +366,7 @@ func init() {
 	RunCmd.Flags().StringVarP(&logLevel, "log-level", "", "info", "The log verbosity. Valid values are: debug, info, warn, error, fatal, or panic")
 	RunCmd.Flags().IntVarP(&maxConcurrency, "app-max-concurrency", "", -1, "The concurrency level of the application, otherwise is unlimited")
 	RunCmd.Flags().StringVarP(&protocol, "app-protocol", "P", "http", "The protocol (gRPC or HTTP) Dapr uses to talk to the application")
-	RunCmd.Flags().StringVarP(&componentsPath, "components-path", "d", standalone.DefaultComponentsDirPath(), "The path for components directory")
+	RunCmd.Flags().StringVarP(&componentsPath, "components-path", "d", defaultComponents, "The path for components directory")
 	RunCmd.Flags().String("placement-host-address", "localhost", "The address of the placement service. Format is either <hostname> for default port or <hostname>:<port> for custom port")
 	RunCmd.Flags().BoolVar(&appSSL, "app-ssl", false, "Enable https when Dapr invokes the application")
 	RunCmd.Flags().IntVarP(&metricsPort, "metrics-port", "M", -1, "The port of metrics on dapr")

--- a/pkg/standalone/dashboard.go
+++ b/pkg/standalone/dashboard.go
@@ -17,23 +17,17 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"runtime"
 	"strconv"
 )
 
 // NewDashboardCmd creates the command to run dashboard.
 func NewDashboardCmd(port int) *exec.Cmd {
-	// Use the default binary install location.
-	dashboardPath := defaultDaprBinPath()
-	binaryName := "dashboard"
-	if runtime.GOOS == daprWindowsOS {
-		binaryName = "dashboard.exe"
-	}
+	dashboardPath := lookupBinaryFilePath("dashboard")
 
 	// Construct command to run dashboard.
 	return &exec.Cmd{
-		Path:   filepath.Join(dashboardPath, binaryName),
-		Args:   []string{binaryName, "--port", strconv.Itoa(port)},
+		Path:   dashboardPath,
+		Args:   []string{filepath.Base(dashboardPath), "--port", strconv.Itoa(port)},
 		Dir:    dashboardPath,
 		Stdout: os.Stdout,
 	}

--- a/pkg/standalone/run.go
+++ b/pkg/standalone/run.go
@@ -295,7 +295,7 @@ type RunOutput struct {
 }
 
 func getDaprCommand(config *RunConfig) (*exec.Cmd, error) {
-	daprCMD := binaryFilePath(defaultDaprBinPath(), "daprd")
+	daprCMD := lookupBinaryFilePath("daprd")
 	args := config.getArgs()
 	cmd := exec.Command(daprCMD, args...)
 	return cmd, nil

--- a/pkg/standalone/run_test.go
+++ b/pkg/standalone/run_test.go
@@ -55,8 +55,8 @@ func assertArgumentNotEqual(t *testing.T, key string, expectedValue string, args
 }
 
 func setupRun(t *testing.T) {
-	componentsDir := DefaultComponentsDirPath()
-	configFile := DefaultConfigFilePath()
+	componentsDir := DaprComponentsPath(DefaultDaprDirPath())
+	configFile := DaprConfigPath(DefaultDaprDirPath())
 	err := os.MkdirAll(componentsDir, 0o700)
 	assert.Equal(t, nil, err, "Unable to setup components dir before running test")
 	file, err := os.Create(configFile)
@@ -65,9 +65,9 @@ func setupRun(t *testing.T) {
 }
 
 func tearDownRun(t *testing.T) {
-	err := os.RemoveAll(DefaultComponentsDirPath())
+	err := os.RemoveAll(DaprComponentsPath(DefaultDaprDirPath()))
 	assert.Equal(t, nil, err, "Unable to delete default components dir after running test")
-	err = os.Remove(DefaultConfigFilePath())
+	err = os.Remove(DaprConfigPath(DefaultDaprDirPath()))
 	assert.Equal(t, nil, err, "Unable to delete default config file after running test")
 }
 
@@ -86,7 +86,7 @@ func assertCommonArgs(t *testing.T, basicConfig *RunConfig, output *RunOutput) {
 	assertArgumentEqual(t, "app-max-concurrency", "-1", output.DaprCMD.Args)
 	assertArgumentEqual(t, "app-protocol", "http", output.DaprCMD.Args)
 	assertArgumentEqual(t, "app-port", "3000", output.DaprCMD.Args)
-	assertArgumentEqual(t, "components-path", DefaultComponentsDirPath(), output.DaprCMD.Args)
+	assertArgumentEqual(t, "components-path", DaprComponentsPath(DefaultDaprDirPath()), output.DaprCMD.Args)
 	assertArgumentEqual(t, "app-ssl", "", output.DaprCMD.Args)
 	assertArgumentEqual(t, "metrics-port", "9001", output.DaprCMD.Args)
 	assertArgumentEqual(t, "dapr-http-max-request-size", "-1", output.DaprCMD.Args)
@@ -146,7 +146,7 @@ func TestRun(t *testing.T) {
 		EnableProfiling:    false,
 		ProfilePort:        9090,
 		Protocol:           "http",
-		ComponentsPath:     DefaultComponentsDirPath(),
+		ComponentsPath:     DaprComponentsPath(DefaultDaprDirPath()),
 		AppSSL:             true,
 		MetricsPort:        9001,
 		MaxRequestBodySize: -1,
@@ -169,12 +169,12 @@ func TestRun(t *testing.T) {
 		basicConfig.Arguments = nil
 		basicConfig.LogLevel = "INFO"
 		basicConfig.EnableAPILogging = true
-		basicConfig.ConfigFile = DefaultConfigFilePath()
+		basicConfig.ConfigFile = DaprConfigPath(DefaultDaprDirPath())
 		output, err := Run(basicConfig)
 		assert.Nil(t, err)
 
 		assertCommonArgs(t, basicConfig, output)
-		assertArgumentEqual(t, "config", DefaultConfigFilePath(), output.DaprCMD.Args)
+		assertArgumentEqual(t, "config", DaprConfigPath(DefaultDaprDirPath()), output.DaprCMD.Args)
 		assert.Nil(t, output.AppCMD)
 	})
 

--- a/pkg/standalone/standalone.go
+++ b/pkg/standalone/standalone.go
@@ -117,6 +117,7 @@ type componentMetadataItem struct {
 
 type initInfo struct {
 	fromDir          string
+	installDir       string
 	bundleDet        *bundleDetails
 	slimMode         bool
 	runtimeVersion   string
@@ -135,8 +136,8 @@ type daprImageInfo struct {
 }
 
 // Check if the previous version is already installed.
-func isBinaryInstallationRequired(binaryFilePrefix, installDir string) (bool, error) {
-	binaryPath := binaryFilePath(installDir, binaryFilePrefix)
+func isBinaryInstallationRequired(binaryFilePrefix, binInstallDir string) (bool, error) {
+	binaryPath := binaryFilePathWithDir(binInstallDir, binaryFilePrefix)
 
 	// first time install?
 	_, err := os.Stat(binaryPath)
@@ -147,11 +148,12 @@ func isBinaryInstallationRequired(binaryFilePrefix, installDir string) (bool, er
 }
 
 // Init installs Dapr on a local machine using the supplied runtimeVersion.
-func Init(runtimeVersion, dashboardVersion string, dockerNetwork string, slimMode bool, imageRegistryURL string, fromDir string, containerRuntime string, imageVariant string) error {
+func Init(runtimeVersion, dashboardVersion string, dockerNetwork string, slimMode bool, imageRegistryURL string, fromDir string, containerRuntime string, imageVariant string, installDir string) error {
 	var err error
 	var bundleDet bundleDetails
 	containerRuntime = strings.TrimSpace(containerRuntime)
 	fromDir = strings.TrimSpace(fromDir)
+	installDir = strings.TrimSpace(installDir)
 	// AirGap init flow is true when fromDir var is set i.e. --from-dir flag has value.
 	setAirGapInit(fromDir)
 	if !slimMode {
@@ -209,7 +211,10 @@ func Init(runtimeVersion, dashboardVersion string, dockerNetwork string, slimMod
 
 	print.InfoStatusEvent(os.Stdout, "Installing runtime version %s", runtimeVersion)
 
-	daprBinDir := defaultDaprBinPath()
+	if len(installDir) == 0 {
+		installDir = DefaultDaprDirPath()
+	}
+	daprBinDir := daprBinPath(installDir)
 	err = prepareDaprInstallDir(daprBinDir)
 	if err != nil {
 		return err
@@ -244,7 +249,7 @@ func Init(runtimeVersion, dashboardVersion string, dockerNetwork string, slimMod
 	defer stopSpinning(print.Failure)
 
 	// Make default components directory.
-	err = makeDefaultComponentsDir()
+	err = makeDefaultComponentsDir(installDir)
 	if err != nil {
 		return err
 	}
@@ -253,6 +258,7 @@ func Init(runtimeVersion, dashboardVersion string, dockerNetwork string, slimMod
 		// values in bundleDet can be nil if fromDir is empty, so must be used in conjunction with fromDir.
 		bundleDet:        &bundleDet,
 		fromDir:          fromDir,
+		installDir:       installDir,
 		slimMode:         slimMode,
 		runtimeVersion:   runtimeVersion,
 		dashboardVersion: dashboardVersion,
@@ -599,7 +605,7 @@ func installBinary(version, binaryFilePrefix, githubRepo string, info initInfo) 
 		filepath string
 	)
 
-	dir := defaultDaprBinPath()
+	dir := daprBinPath(info.installDir)
 	if isAirGapInit {
 		filepath = path_filepath.Join(info.fromDir, *info.bundleDet.BinarySubDir, binaryName(binaryFilePrefix))
 	} else {
@@ -658,8 +664,9 @@ func createComponentsAndConfiguration(wg *sync.WaitGroup, errorChan chan<- error
 	}
 	var err error
 
-	// Make default components directory.
-	componentsDir := DefaultComponentsDirPath()
+	// Make default components & config.
+	componentsDir := DaprComponentsPath(info.installDir)
+	configPath := DaprConfigPath(info.installDir)
 
 	err = createRedisPubSub(redisHost, componentsDir)
 	if err != nil {
@@ -671,7 +678,7 @@ func createComponentsAndConfiguration(wg *sync.WaitGroup, errorChan chan<- error
 		errorChan <- fmt.Errorf("error creating redis statestore component file: %w", err)
 		return
 	}
-	err = createDefaultConfiguration(zipkinHost, DefaultConfigFilePath())
+	err = createDefaultConfiguration(zipkinHost, configPath)
 	if err != nil {
 		errorChan <- fmt.Errorf("error creating default configuration file: %w", err)
 		return
@@ -685,17 +692,18 @@ func createSlimConfiguration(wg *sync.WaitGroup, errorChan chan<- error, info in
 		return
 	}
 
+	configPath := DaprConfigPath(info.installDir)
 	// For --slim we pass empty string so that we do not configure zipkin.
-	err := createDefaultConfiguration("", DefaultConfigFilePath())
+	err := createDefaultConfiguration("", configPath)
 	if err != nil {
 		errorChan <- fmt.Errorf("error creating default configuration file: %w", err)
 		return
 	}
 }
 
-func makeDefaultComponentsDir() error {
+func makeDefaultComponentsDir(installDir string) error {
 	// Make default components directory.
-	componentsDir := DefaultComponentsDirPath()
+	componentsDir := DaprComponentsPath(installDir)
 	//nolint
 	_, err := os.Stat(componentsDir)
 	if os.IsNotExist(err) {

--- a/pkg/standalone/standalone_test.go
+++ b/pkg/standalone/standalone_test.go
@@ -304,3 +304,16 @@ func TestIsAirGapInit(t *testing.T) {
 		})
 	}
 }
+
+func TestNonDefaultInstall(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "daprtest-nondefault-install-*")
+	assert.NoError(t, err)
+	defer os.RemoveAll(tmpDir) // clean up
+
+	err = Init(latestVersion, latestVersion, "", true, "", "", "docker", "", tmpDir)
+	assert.NoError(t, err)
+
+	daprCMD := binaryFilePathWithDir(daprBinPath(tmpDir), "daprd")
+
+	assert.FileExists(t, daprCMD)
+}

--- a/pkg/standalone/uninstall.go
+++ b/pkg/standalone/uninstall.go
@@ -83,12 +83,15 @@ func removeDir(dirPath string) error {
 
 // Uninstall reverts all changes made by init. Deletes all installed containers, removes default dapr folder,
 // removes the installed binary and unsets env variables.
-func Uninstall(uninstallAll bool, dockerNetwork string, containerRuntime string) error {
+func Uninstall(uninstallAll bool, dockerNetwork string, containerRuntime string, installDir string) error {
 	var containerErrs []error
-	daprDefaultDir := defaultDaprDirPath()
-	daprBinDir := defaultDaprBinPath()
+	installDir = strings.TrimSpace(installDir)
+	if len(installDir) == 0 {
+		installDir = DefaultDaprDirPath()
+	}
+	daprBinDir := daprBinPath(installDir)
 
-	placementFilePath := binaryFilePath(daprBinDir, placementServiceFilePrefix)
+	placementFilePath := binaryFilePathWithDir(daprBinDir, placementServiceFilePrefix)
 	_, placementErr := os.Stat(placementFilePath) // check if the placement binary exists.
 	uninstallPlacementContainer := errors.Is(placementErr, fs.ErrNotExist)
 	// Remove .dapr/bin.
@@ -106,9 +109,9 @@ func Uninstall(uninstallAll bool, dockerNetwork string, containerRuntime string)
 	}
 
 	if uninstallAll {
-		err = removeDir(daprDefaultDir)
+		err = removeDir(installDir)
 		if err != nil {
-			print.WarningStatusEvent(os.Stdout, "WARNING: could not delete default dapr dir: %s", daprDefaultDir)
+			print.WarningStatusEvent(os.Stdout, "WARNING: could not delete dapr dir %s: %v", installDir, err)
 		}
 	}
 

--- a/pkg/standalone/version.go
+++ b/pkg/standalone/version.go
@@ -26,8 +26,7 @@ var (
 
 // GetRuntimeVersion returns the version for the local Dapr runtime.
 func GetRuntimeVersion() string {
-	daprBinDir := defaultDaprBinPath()
-	daprCMD := binaryFilePath(daprBinDir, "daprd")
+	daprCMD := lookupBinaryFilePath("daprd")
 
 	out, err := exec.Command(daprCMD, "--version").Output()
 	if err != nil {
@@ -38,8 +37,7 @@ func GetRuntimeVersion() string {
 
 // GetDashboardVersion returns the version for the local Dapr dashboard.
 func GetDashboardVersion() string {
-	daprBinDir := defaultDaprBinPath()
-	dashboardCMD := binaryFilePath(daprBinDir, "dashboard")
+	dashboardCMD := lookupBinaryFilePath("dashboard")
 
 	out, err := exec.Command(dashboardCMD, "--version").Output()
 	if err != nil {
@@ -50,8 +48,7 @@ func GetDashboardVersion() string {
 
 // GetBuildInfo returns build info for the CLI and the local Dapr runtime.
 func GetBuildInfo(version string) string {
-	daprBinDir := defaultDaprBinPath()
-	daprCMD := binaryFilePath(daprBinDir, "daprd")
+	daprCMD := lookupBinaryFilePath("daprd")
 
 	strs := []string{
 		"CLI:",


### PR DESCRIPTION
# Description

Currently in standalone mode dapr cli will install the dapr runtime
binaries into $HOME/.dapr. However, in some environments $HOME is
readonly or os.UserHomeDir() can fail (e.g. AWS Lambda). To support
dapr in these environments this change does 3 things:

  1. When os.UserHomeDir() fails the default changes from $HOME/.dapr
  to /usr/local/dapr

  2. Allows the user to specify install location with a new
  --install-dir init&uninstall flag

  3. Employs the user's $PATH to find the dapr runtime binaries rather
  than assume they can be found in the default install location. If
  the dapr runtime binaries cannot be found in $PATH, we fallback to
  the existing behavior of looking in the default install location.

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #_1056]_

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Created/updated tests
* [x] Extended the documentation
