### PR TITLE
Validate and limit container runtime configuration in init and uninstall commands

### DIFF
--- a/cmd/init.go
+++ b/cmd/init.go
@@ -183,6 +183,6 @@ func init() {
 	InitCmd.Flags().BoolP("help", "h", false, "Print this help message")
 	InitCmd.Flags().StringArrayVar(&values, "set", []string{}, "set values on the command line (can specify multiple or separate values with commas: key1=val1,key2=val2)")
 	InitCmd.Flags().String("image-registry", "", "Custom/private docker image repository URL")
-	InitCmd.Flags().StringVarP(&containerRuntime, "container-runtime", "", "docker", "The container runtime to use (defaults to docker)")
+	InitCmd.Flags().StringVarP(&containerRuntime, "container-runtime", "", "docker", "The container runtime to use. Supported values are docker (default) and podman")
 	RootCmd.AddCommand(InitCmd)
 }

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -24,6 +24,7 @@ import (
 	"github.com/dapr/cli/pkg/kubernetes"
 	"github.com/dapr/cli/pkg/print"
 	"github.com/dapr/cli/pkg/standalone"
+	"github.com/dapr/cli/utils"
 )
 
 var (
@@ -136,6 +137,10 @@ dapr init --image-variant <variant>
 			if len(imageRegistryURI) != 0 {
 				warnForPrivateRegFeat()
 			}
+			if !utils.IsValidContainerRuntime(containerRuntime) {
+				print.FailureStatusEvent(os.Stdout, "Invalid container runtime. Supported values are docker and podman.")
+				os.Exit(1)
+			}
 			err := standalone.Init(runtimeVersion, dashboardVersion, dockerNetwork, slimMode, imageRegistryURI, fromDir, containerRuntime, imageVariant)
 			if err != nil {
 				print.FailureStatusEvent(os.Stderr, err.Error())
@@ -177,7 +182,7 @@ func init() {
 	InitCmd.Flags().StringVarP(&imageVariant, "image-variant", "", "", "The image variant to use for the Dapr runtime, for example: mariner")
 	InitCmd.Flags().BoolP("help", "h", false, "Print this help message")
 	InitCmd.Flags().StringArrayVar(&values, "set", []string{}, "set values on the command line (can specify multiple or separate values with commas: key1=val1,key2=val2)")
-	InitCmd.Flags().String("image-registry", "", "Custom/Private docker image repository url")
+	InitCmd.Flags().String("image-registry", "", "Custom/private docker image repository URL")
 	InitCmd.Flags().StringVarP(&containerRuntime, "container-runtime", "", "docker", "The container runtime to use (defaults to docker)")
 	RootCmd.AddCommand(InitCmd)
 }

--- a/cmd/uninstall.go
+++ b/cmd/uninstall.go
@@ -82,6 +82,6 @@ func init() {
 	UninstallCmd.Flags().String("network", "", "The Docker network from which to remove the Dapr runtime")
 	UninstallCmd.Flags().StringVarP(&uninstallNamespace, "namespace", "n", "dapr-system", "The Kubernetes namespace to uninstall Dapr from")
 	UninstallCmd.Flags().BoolP("help", "h", false, "Print this help message")
-	UninstallCmd.Flags().StringVarP(&uninstallContainerRuntime, "container-runtime", "", "docker", "The container runtime to use (defaults to docker)")
+	UninstallCmd.Flags().StringVarP(&uninstallContainerRuntime, "container-runtime", "", "docker", "The container runtime to use. Supported values are docker (default) and podman")
 	RootCmd.AddCommand(UninstallCmd)
 }

--- a/cmd/uninstall.go
+++ b/cmd/uninstall.go
@@ -23,6 +23,7 @@ import (
 	"github.com/dapr/cli/pkg/kubernetes"
 	"github.com/dapr/cli/pkg/print"
 	"github.com/dapr/cli/pkg/standalone"
+	"github.com/dapr/cli/utils"
 )
 
 var (
@@ -57,6 +58,10 @@ dapr uninstall -k
 			print.InfoStatusEvent(os.Stdout, "Removing Dapr from your cluster...")
 			err = kubernetes.Uninstall(uninstallNamespace, uninstallAll, timeout)
 		} else {
+			if !utils.IsValidContainerRuntime(uninstallContainerRuntime) {
+				print.FailureStatusEvent(os.Stdout, "Invalid container runtime. Supported values are docker and podman.")
+				os.Exit(1)
+			}
 			print.InfoStatusEvent(os.Stdout, "Removing Dapr from your machine...")
 			dockerNetwork := viper.GetString("network")
 			err = standalone.Uninstall(uninstallAll, dockerNetwork, uninstallContainerRuntime)

--- a/tests/e2e/standalone/commands.go
+++ b/tests/e2e/standalone/commands.go
@@ -119,7 +119,7 @@ func cmdStop(appId string, args ...string) (string, error) {
 }
 
 // cmdUninstall uninstalls Dapr with --all flag and returns the command output and error.
-func cmdUninstall() (string, error) {
+func cmdUninstall(args ...string) (string, error) {
 	daprContainerRuntime := containerRuntime()
 	if !isSlimMode() && daprContainerRuntime != "" {
 		return spawn.Command(common.GetDaprPath(), "uninstall", "--container-runtime", daprContainerRuntime, "--all")

--- a/tests/e2e/standalone/init_test.go
+++ b/tests/e2e/standalone/init_test.go
@@ -118,7 +118,8 @@ func TestStandaloneInit(t *testing.T) {
 func verifyContainers(t *testing.T, daprRuntimeVersion string) {
 	t.Run("verifyContainers", func(t *testing.T) {
 		if isSlimMode() {
-			t.Skip("Skipping container verification because of slim installation")
+			t.Log("Skipping container verification because of slim installation")
+			return
 		}
 
 		cli, err := dockerClient.NewClientWithOpts(dockerClient.FromEnv)

--- a/tests/e2e/standalone/init_test.go
+++ b/tests/e2e/standalone/init_test.go
@@ -62,6 +62,15 @@ func TestStandaloneInit(t *testing.T) {
 		require.Contains(t, output, "both --image-registry and --from-dir flags cannot be given at the same time")
 	})
 
+	t.Run("init should error out if container runtime is not valid", func(t *testing.T) {
+		// Ensure a clean environment
+		must(t, cmdUninstall, "failed to uninstall Dapr")
+
+		output, err := cmdInit(daprRuntimeVersion, "--container-runtime", "invalid")
+		require.Error(t, err, "expected error if container runtime is invalid")
+		require.Contains(t, output, "Invalid container runtime")
+	})
+
 	t.Run("init", func(t *testing.T) {
 		// Ensure a clean environment
 		must(t, cmdUninstall, "failed to uninstall Dapr")

--- a/tests/e2e/standalone/uninstall_test.go
+++ b/tests/e2e/standalone/uninstall_test.go
@@ -58,7 +58,8 @@ func TestStandaloneUninstall(t *testing.T) {
 // verifyNoContainers verifies that no Dapr containers are running.
 func verifyNoContainers(t *testing.T) {
 	if isSlimMode() {
-		t.Skip("Skipping verifyNoContainers test in slim mode")
+		t.Log("Skipping verifyNoContainers test in slim mode")
+		return
 	}
 
 	cli, err := dockerClient.NewClientWithOpts(dockerClient.FromEnv)

--- a/tests/e2e/standalone/uninstall_test.go
+++ b/tests/e2e/standalone/uninstall_test.go
@@ -30,21 +30,29 @@ import (
 )
 
 func TestStandaloneUninstall(t *testing.T) {
-	ensureDaprInstallation(t)
+	t.Run("uninstall should error out if container runtime is not valid", func(t *testing.T) {
+		output, err := cmdUninstall("--container-runtime", "invalid")
+		require.Error(t, err, "expected error if container runtime is invalid")
+		require.Contains(t, output, "Invalid container runtime")
+	})
 
-	output, err := cmdUninstall()
-	t.Log(output)
-	require.NoError(t, err, "dapr uninstall failed")
-	assert.Contains(t, output, "Dapr has been removed successfully")
+	t.Run("uninstall", func(t *testing.T) {
+		ensureDaprInstallation(t)
 
-	// verify that .dapr directory does not exist.
-	homeDir, err := os.UserHomeDir()
-	require.NoError(t, err, "failed to get user home directory")
+		output, err := cmdUninstall()
+		t.Log(output)
+		require.NoError(t, err, "dapr uninstall failed")
+		assert.Contains(t, output, "Dapr has been removed successfully")
 
-	daprPath := filepath.Join(homeDir, ".dapr")
-	require.NoDirExists(t, daprPath, "Directory %s does not exist", daprPath)
+		// verify that .dapr directory does not exist.
+		homeDir, err := os.UserHomeDir()
+		require.NoError(t, err, "failed to get user home directory")
 
-	verifyNoContainers(t)
+		daprPath := filepath.Join(homeDir, ".dapr")
+		require.NoDirExists(t, daprPath, "Directory %s does not exist", daprPath)
+
+		verifyNoContainers(t)
+	})
 }
 
 // verifyNoContainers verifies that no Dapr containers are running.

--- a/tests/e2e/standalone/utils.go
+++ b/tests/e2e/standalone/utils.go
@@ -42,8 +42,8 @@ func getSocketCases() []string {
 }
 
 // must is a helper function that executes a function and expects it to succeed.
-func must(t *testing.T, f func() (string, error), message string) {
-	_, err := f()
+func must(t *testing.T, f func(args ...string) (string, error), message string, fArgs ...string) {
+	_, err := f(fArgs...)
 	require.NoError(t, err, message)
 }
 

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -62,6 +62,16 @@ func GetContainerRuntimeCmd(containerRuntime string) string {
 	return string(DOCKER)
 }
 
+// Contains returns true if vs contains x.
+func Contains[T comparable](vs []T, x T) bool {
+	for _, v := range vs {
+		if v == x {
+			return true
+		}
+	}
+	return false
+}
+
 const marinerImageVariantName = "mariner"
 
 // PrintTable to print in the table format.

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -39,17 +39,27 @@ type ContainerRuntime string
 
 const (
 	DOCKER ContainerRuntime = "docker"
+	PODMAN ContainerRuntime = "podman"
 
 	socketFormat = "%s/dapr-%s-%s.socket"
 )
 
+// IsValidContainerRuntime checks if the input is a valid container runtime.
+// Valid container runtimes are docker and podman.
+func IsValidContainerRuntime(containerRuntime string) bool {
+	containerRuntime = strings.TrimSpace(containerRuntime)
+	return containerRuntime == string(DOCKER) || containerRuntime == string(PODMAN)
+}
+
+// GetContainerRuntimeCmd returns a valid container runtime to be used by CLI operations.
+// If the input is a valid container runtime, it is returned as is.
+// Otherwise the default container runtime, docker, is returned.
 func GetContainerRuntimeCmd(containerRuntime string) string {
-	switch len(containerRuntime) {
-	case 0:
-		return string(DOCKER)
-	default:
-		return containerRuntime
+	if IsValidContainerRuntime(containerRuntime) {
+		return strings.TrimSpace(containerRuntime)
 	}
+	// default to docker
+	return string(DOCKER)
 }
 
 const marinerImageVariantName = "mariner"

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -58,7 +58,7 @@ func GetContainerRuntimeCmd(containerRuntime string) string {
 	if IsValidContainerRuntime(containerRuntime) {
 		return strings.TrimSpace(containerRuntime)
 	}
-	// default to docker
+	// Default to docker.
 	return string(DOCKER)
 }
 

--- a/utils/utils_test.go
+++ b/utils/utils_test.go
@@ -1,0 +1,82 @@
+/*
+Copyright 2022 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package utils
+
+import "testing"
+
+func TestContainerRuntimeUtils(t *testing.T) {
+	testcases := []struct {
+		name     string
+		input    string
+		expected string
+		valid    bool
+	}{
+		{
+			name:     "podman runtime is valid, and is returned as is",
+			input:    "podman",
+			expected: "podman",
+			valid:    true,
+		},
+		{
+			name:     "podman runtime with extra spaces is valid, and is returned as is",
+			input:    "  podman  ",
+			expected: "podman",
+			valid:    true,
+		},
+		{
+			name:     "docker runtime is valid, and is returned as is",
+			input:    "docker",
+			expected: "docker",
+			valid:    true,
+		},
+		{
+			name:     "docker runtime with extra spaces is valid, and is returned as is",
+			input:    "     docker  ",
+			expected: "docker",
+			valid:    true,
+		},
+		{
+			name:     "empty runtime is invalid, and docker is returned as default",
+			input:    "",
+			expected: "docker",
+			valid:    false,
+		},
+		{
+			name:     "invalid runtime is invalid, and docker is returned as default",
+			input:    "invalid",
+			expected: "docker",
+			valid:    false,
+		},
+		{
+			name:     "invalid runtime with extra spaces is invalid, and docker is returned as default",
+			input:    "   invalid  ",
+			expected: "docker",
+			valid:    false,
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			actualValid := IsValidContainerRuntime(tc.input)
+			if actualValid != tc.valid {
+				t.Errorf("expected %v, got %v", tc.valid, actualValid)
+			}
+
+			actualCmd := GetContainerRuntimeCmd(tc.input)
+			if actualCmd != tc.expected {
+				t.Errorf("expected %s, got %s", tc.expected, actualCmd)
+			}
+		})
+	}
+}

--- a/utils/utils_test.go
+++ b/utils/utils_test.go
@@ -80,3 +80,40 @@ func TestContainerRuntimeUtils(t *testing.T) {
 		})
 	}
 }
+
+func TestContains(t *testing.T) {
+	testcases := []struct {
+		name     string
+		input    []string
+		expected string
+		valid    bool
+	}{
+		{
+			name:     "empty list",
+			input:    []string{},
+			expected: "foo",
+			valid:    false,
+		},
+		{
+			name:     "list contains element",
+			input:    []string{"foo", "bar", "baz"},
+			expected: "foo",
+			valid:    true,
+		},
+		{
+			name:     "list does not contain element",
+			input:    []string{"foo", "bar", "baz"},
+			expected: "qux",
+			valid:    false,
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			actualValid := Contains(tc.input, tc.expected)
+			if actualValid != tc.valid {
+				t.Errorf("expected %v, got %v", tc.valid, actualValid)
+			}
+		})
+	}
+}


### PR DESCRIPTION
# Description

This PR limits the container runtime configuration to `docker` and `podman` only. 

## Issue reference

Please reference the issue this PR will close: #1098

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [X] Code compiles correctly
* [X] Created/updated tests
* [ ] Extended the documentation
