### PR TITLE
fix kubernetes init to pick correct runtime version

### DIFF
--- a/pkg/kubernetes/kubernetes.go
+++ b/pkg/kubernetes/kubernetes.go
@@ -153,7 +153,7 @@ func daprChart(version string, config *helm.Configuration) (*chart.Chart, error)
 	return loader.Load(chartPath)
 }
 
-func chartValues(config InitConfiguration) (map[string]interface{}, error) {
+func chartValues(config InitConfiguration, version string) (map[string]interface{}, error) {
 	chartVals := map[string]interface{}{}
 	err := utils.ValidateImageVariant(config.ImageVariant)
 	if err != nil {
@@ -162,7 +162,7 @@ func chartValues(config InitConfiguration) (map[string]interface{}, error) {
 	globalVals := []string{
 		fmt.Sprintf("global.ha.enabled=%t", config.EnableHA),
 		fmt.Sprintf("global.mtls.enabled=%t", config.EnableMTLS),
-		fmt.Sprintf("global.tag=%s", utils.GetVariantVersion(config.Version, config.ImageVariant)),
+		fmt.Sprintf("global.tag=%s", utils.GetVariantVersion(version, config.ImageVariant)),
 	}
 	if len(config.ImageRegistryURI) != 0 {
 		globalVals = append(globalVals, fmt.Sprintf("global.registry=%s", config.ImageRegistryURI))
@@ -209,7 +209,7 @@ func install(config InitConfiguration) error {
 	installClient.Wait = config.Wait
 	installClient.Timeout = time.Duration(config.Timeout) * time.Second
 
-	values, err := chartValues(config)
+	values, err := chartValues(config, version)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Signed-off-by: shivam <shivamkm07@gmail.com>

# Description

`dapr init -k` installs "latest" dapr runtime instead of the latest version (1.9.0 currently). The PR fixes it to pick up the correct version

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #1104 

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [ ] Extended the documentation
