### PR TITLE
Authenticate requests to GH API to prevent getting throttled

### DIFF
--- a/.github/workflows/self_hosted_e2e.yaml
+++ b/.github/workflows/self_hosted_e2e.yaml
@@ -1,5 +1,3 @@
---- # ------------------------------------------------------------
-
 # ------------------------------------------------------------
 # Copyright 2021 The Dapr Authors
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -11,6 +9,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+# ------------------------------------------------------------
 name: E2E - Self-hosted
 
 on:
@@ -40,7 +39,7 @@ jobs:
       GOARCH: ${{ matrix.target_arch }}
       GOPROXY: https://proxy.golang.org
       ARCHIVE_OUTDIR: dist/archives
-      DAPR_RUNTIME_VERSION: "1.9.0"
+      DAPR_RUNTIME_VERSION: "1.9.4"
       DAPR_DASHBOARD_VERSION: 0.11.0
     strategy:
       matrix:

--- a/.github/workflows/self_hosted_e2e.yaml
+++ b/.github/workflows/self_hosted_e2e.yaml
@@ -1,3 +1,5 @@
+--- # ------------------------------------------------------------
+
 # ------------------------------------------------------------
 # Copyright 2021 The Dapr Authors
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -9,8 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# ------------------------------------------------------------
-
 name: E2E - Self-hosted
 
 on:
@@ -19,16 +19,16 @@ on:
       - master
       - release-*
     paths-ignore:
-      - '**.md'
+      - "**.md"
   schedule:
-    - cron: '0 */3 * * *'
-    - cron: '0 */6 * * *'
+    - cron: "0 */3 * * *"
+    - cron: "0 */6 * * *"
   pull_request:
     branches:
       - master
-      - 'release-*'
+      - "release-*"
     paths-ignore:
-      - '**.md'
+      - "**.md"
 
 jobs:
   self-hosted-e2e:
@@ -79,16 +79,25 @@ jobs:
       - name: Determine latest Dapr Runtime version including Pre-releases
         if: github.base_ref == 'master'
         run: |
-          export RUNTIME_VERSION=$(curl -s https://api.github.com/repos/dapr/dapr/releases | grep tag_name | awk -F':' '{print $2}' | tr -d '", ' | sed '/-/! s/$/_/' | sort -V | sed 's/_$//' | tr -d 'v' | tail -1)
-          echo "DAPR_RUNTIME_VERSION=$RUNTIME_VERSION" >> $GITHUB_ENV
-          echo "Found $RUNTIME_VERSION"
+          curl -s -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" https://api.github.com/rate_limit # TEMP, REMOVE
+          export RUNTIME_VERSION=$(curl -s -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" https://api.github.com/repos/dapr/dapr/releases | grep tag_name | awk -F':' '{print $2}' | tr -d '", ' | sed '/-/! s/$/_/' | sort -V | sed 's/_$//' | tr -d 'v' | tail -1)
+          if [[ -z "$RUNTIME_VERSION" ]]; then
+            echo "Could not fetch the latest Dapr Runtime version. Using default version $DAPR_RUNTIME_VERSION"
+          else
+            echo "DAPR_RUNTIME_VERSION=$RUNTIME_VERSION" >> $GITHUB_ENV
+            echo "Found $RUNTIME_VERSION"
+          fi
         shell: bash
       - name: Determine latest Dapr Dashboard version including Pre-releases
         if: github.base_ref == 'master'
         run: |
-          export DASHBOARD_VERSION=$(curl -s https://api.github.com/repos/dapr/dashboard/releases | grep tag_name | awk -F':' '{print $2}' | tr -d '", ' | sed '/-/! s/$/_/' | sort -V | sed 's/_$//' | tr -d 'v' | tail -1)
-          echo "DAPR_DASHBOARD_VERSION=$DASHBOARD_VERSION" >> $GITHUB_ENV
-          echo "Found $DASHBOARD_VERSION"
+          export DASHBOARD_VERSION=$(curl -s -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" https://api.github.com/repos/dapr/dashboard/releases | grep tag_name | awk -F':' '{print $2}' | tr -d '", ' | sed '/-/! s/$/_/' | sort -V | sed 's/_$//' | tr -d 'v' | tail -1)
+          if [[ -z "$DASHBOARD_VERSION" ]]; then
+            echo "Could not fetch the latest Dapr Dashboard version. Using default version $DAPR_DASHBOARD_VERSION"
+          else
+            echo "DAPR_DASHBOARD_VERSION=$DASHBOARD_VERSION" >> $GITHUB_ENV
+            echo "Found $DASHBOARD_VERSION"
+          fi
         shell: bash
       - name: Run E2E tests with GHCR
         # runs every 6hrs

--- a/.github/workflows/self_hosted_e2e.yaml
+++ b/.github/workflows/self_hosted_e2e.yaml
@@ -10,6 +10,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ------------------------------------------------------------
+
 name: E2E - Self-hosted
 
 on:

--- a/.github/workflows/self_hosted_e2e.yaml
+++ b/.github/workflows/self_hosted_e2e.yaml
@@ -19,16 +19,16 @@ on:
       - master
       - release-*
     paths-ignore:
-      - "**.md"
+      - '**.md'
   schedule:
-    - cron: "0 */3 * * *"
-    - cron: "0 */6 * * *"
+    - cron: '0 */3 * * *'
+    - cron: '0 */6 * * *'
   pull_request:
     branches:
       - master
-      - "release-*"
+      - 'release-*'
     paths-ignore:
-      - "**.md"
+      - '**.md'
 
 jobs:
   self-hosted-e2e:
@@ -79,7 +79,6 @@ jobs:
       - name: Determine latest Dapr Runtime version including Pre-releases
         if: github.base_ref == 'master'
         run: |
-          curl -s -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" https://api.github.com/rate_limit # TEMP, REMOVE
           export RUNTIME_VERSION=$(curl -s -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" https://api.github.com/repos/dapr/dapr/releases | grep tag_name | awk -F':' '{print $2}' | tr -d '", ' | sed '/-/! s/$/_/' | sort -V | sed 's/_$//' | tr -d 'v' | tail -1)
           if [[ -z "$RUNTIME_VERSION" ]]; then
             echo "Could not fetch the latest Dapr Runtime version. Using default version $DAPR_RUNTIME_VERSION"


### PR DESCRIPTION
Signed-off-by: Shubham Sharma <shubhash@microsoft.com>

# Description

Use the GH authentication token to prevent getting throttled. The limit for authenticated requests is 15000 per hour (as opposed to 60 per hour for unauthenticated). Note, if it still does not work, it falls back to the default versions.

## Issue reference

Please reference the issue this PR will close: #1133

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [ ] Extended the documentation
