### PR TITLE
mariner renew-certificate fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -537,6 +537,10 @@ Use user provided ca.crt, issuer.crt and issuer.key
 ```bash
 dapr mtls renew-certificate -k --ca-root-certificate <ca.crt> --issuer-private-key <issuer.key> --issuer-public-certificate <issuer.crt> --restart
 ```
+#### To view the complete list of flags and their combination, run below command:
+```bash
+dapr mtls renew-certificate -h
+```
 
 ### List Components
 

--- a/cmd/renew_certificate.go
+++ b/cmd/renew_certificate.go
@@ -39,7 +39,7 @@ func RenewCertificateCmd() *cobra.Command {
 	command := &cobra.Command{
 		Use:     "renew-certificate",
 		Aliases: []string{"renew-cert", "rc"},
-		Short:   "Rotates Dapr root certificate of your kubernetes cluster",
+		Short:   "Rotates the Dapr root certificate on your Kubernetes cluster",
 
 		Example: `
 # Generates new root and issuer certificates for kubernetes cluster

--- a/cmd/renew_certificate.go
+++ b/cmd/renew_certificate.go
@@ -38,7 +38,7 @@ var (
 func RenewCertificateCmd() *cobra.Command {
 	command := &cobra.Command{
 		Use:     "renew-certificate",
-		Aliases: []string{"renew-cert", "rc"},
+		Aliases: []string{"renew-cert", "rnc"},
 		Short:   "Rotates the Dapr root certificate on your Kubernetes cluster",
 
 		Example: `
@@ -50,6 +50,13 @@ dapr mtls renew-certificate -k --private-key myprivatekey.key --valid-until <no 
 
 # Rotates certificate of your kubernetes cluster with provided ca.cert, issuer.crt and issuer.key file path
 dapr mtls renew-certificate -k --ca-root-certificate <root.pem> --issuer-private-key <issuer.key> --issuer-public-certificate <issuer.pem> --restart
+
+# Generates new root and issuer certificates for kubernetes cluster with provided image variant
+dapr mtls renew-certificate -k --valid-until <no of days> --image-variant mariner --restart
+
+# Use alias to renew certificate command
+dapr mtls rnc -k --valid-until <no of days> --restart
+dapr mtls renew-cert -k --valid-until <no of days> --restart
 
 # See more at: https://docs.dapr.io/getting-started/
 `,

--- a/pkg/kubernetes/renew_certificate.go
+++ b/pkg/kubernetes/renew_certificate.go
@@ -26,6 +26,7 @@ import (
 	"k8s.io/helm/pkg/strvals"
 
 	"github.com/dapr/cli/pkg/print"
+	"github.com/dapr/cli/utils"
 	"github.com/dapr/dapr/pkg/sentry/ca"
 	"github.com/dapr/dapr/pkg/sentry/certs"
 )
@@ -37,6 +38,7 @@ type RenewCertificateParams struct {
 	RootPrivateKeyFilePath    string
 	ValidUntil                time.Duration
 	Timeout                   uint
+	ImageVariant              string
 }
 
 func RenewCertificate(conf RenewCertificateParams) error {
@@ -63,7 +65,7 @@ func RenewCertificate(conf RenewCertificateParams) error {
 		}
 	}
 	print.InfoStatusEvent(os.Stdout, "Updating certifcates in your Kubernetes cluster")
-	err = renewCertificate(rootCertBytes, issuerCertBytes, issuerKeyBytes, conf.Timeout)
+	err = renewCertificate(rootCertBytes, issuerCertBytes, issuerKeyBytes, conf.Timeout, conf.ImageVariant)
 	if err != nil {
 		return err
 	}
@@ -86,13 +88,22 @@ func parseCertificateFiles(rootCert, issuerCert, issuerKey string) ([]byte, []by
 	return rootCertBytes, issuerCertBytes, issuerKeyBytes, nil
 }
 
-func renewCertificate(rootCert, issuerCert, issuerKey []byte, timeout uint) error {
+func renewCertificate(rootCert, issuerCert, issuerKey []byte, timeout uint, imageVariant string) error {
+	var daprVersion, daprImageVariant string
 	status, err := GetDaprResourcesStatus()
 	if err != nil {
 		return err
 	}
-	daprVersion := GetDaprVersion(status)
+	daprVersion = GetDaprVersion(status)
 	print.InfoStatusEvent(os.Stdout, "Dapr control plane version %s detected in namespace %s", daprVersion, status[0].Namespace)
+
+	// Get the current version if image variant is provided.
+	if imageVariant != "" {
+		daprVersion, daprImageVariant = utils.GetVersionAndImageVariant(daprVersion)
+		if daprImageVariant != imageVariant {
+			return fmt.Errorf("error in parsing dapr version. found image variant \"%s\" is not same as provided value \"%s\"", daprImageVariant, imageVariant)
+		}
+	}
 
 	helmConf, err := helmConfig(status[0].Namespace)
 	if err != nil {

--- a/pkg/kubernetes/renew_certificate.go
+++ b/pkg/kubernetes/renew_certificate.go
@@ -101,7 +101,7 @@ func renewCertificate(rootCert, issuerCert, issuerKey []byte, timeout uint, imag
 	if imageVariant != "" {
 		daprVersion, daprImageVariant = utils.GetVersionAndImageVariant(daprVersion)
 		if daprImageVariant != imageVariant {
-			return fmt.Errorf("error in parsing dapr version. found image variant \"%s\" is not same as provided value \"%s\"", daprImageVariant, imageVariant)
+			return fmt.Errorf("error in parsing dapr version. found image variant %q is not same as provided value %q", daprImageVariant, imageVariant)
 		}
 	}
 

--- a/tests/e2e/common/common.go
+++ b/tests/e2e/common/common.go
@@ -437,7 +437,17 @@ func GenerateNewCertAndRenew(details VersionDetails, opts TestOptions) func(t *t
 		err := exportCurrentCertificate(daprPath)
 		require.NoError(t, err, "expected no error on certificate exporting")
 
-		output, err := spawn.Command(daprPath, "mtls", "renew-certificate", "-k", "--valid-until", "20", "--restart")
+		args := []string{
+			"mtls",
+			"renew-certificate",
+			"-k",
+			"--valid-until", "20",
+			"--restart",
+		}
+		if details.ImageVariant != "" {
+			args = append(args, "--image-variant", details.ImageVariant)
+		}
+		output, err := spawn.Command(daprPath, args...)
 		t.Log(output)
 		require.NoError(t, err, "expected no error on certificate renewal")
 

--- a/tests/e2e/kubernetes/kubernetes_test.go
+++ b/tests/e2e/kubernetes/kubernetes_test.go
@@ -381,7 +381,9 @@ func TestRenewCertWithIncorrectFlags(t *testing.T) {
 	}
 }
 
-func TestKubernetesInstallwithMarinerImages(t *testing.T) {
+// install dapr control plane with mariner docker images.
+// Renew the certificate of this control plane.
+func TestK8sInstallwithMarinerImagesAndRenewCertificate(t *testing.T) {
 	// ensure clean env for test
 	ensureCleanEnv(t)
 
@@ -401,6 +403,15 @@ func TestKubernetesInstallwithMarinerImages(t *testing.T) {
 	}
 
 	tests = append(tests, common.GetTestsOnInstall(currentVersionDetails, installOpts)...)
+
+	// tests for certifcate renewal with newly generated certificates.
+	tests = append(tests, []common.TestCase{
+		{"Renew certificate which expires in less than 30 days", common.GenerateNewCertAndRenew(currentVersionDetails, installOpts)},
+	}...)
+	tests = append(tests, common.GetTestsPostCertificateRenewal(currentVersionDetails, installOpts)...)
+	tests = append(tests, []common.TestCase{
+		{"Cert Expiry warning message check " + currentVersionDetails.RuntimeVersion, common.CheckMTLSStatus(currentVersionDetails, installOpts, true)},
+	}...)
 
 	// teardown everything
 	tests = append(tests, common.GetTestsOnUninstall(currentVersionDetails, common.TestOptions{

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -310,3 +310,11 @@ func GetVariantVersion(version, imageVariant string) string {
 	}
 	return fmt.Sprintf("%s-%s", version, imageVariant)
 }
+
+func GetVersionAndImageVariant(version string) (string, string) {
+	if strings.Contains(version, "-") {
+		split := strings.Split(version, "-")
+		return split[0], split[1]
+	}
+	return version, ""
+}

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -41,6 +41,8 @@ const (
 	DOCKER ContainerRuntime = "docker"
 	PODMAN ContainerRuntime = "podman"
 
+	marinerImageVariantName = "mariner"
+
 	socketFormat = "%s/dapr-%s-%s.socket"
 )
 
@@ -71,8 +73,6 @@ func Contains[T comparable](vs []T, x T) bool {
 	}
 	return false
 }
-
-const marinerImageVariantName = "mariner"
 
 // PrintTable to print in the table format.
 func PrintTable(csvContent string) {
@@ -312,11 +312,12 @@ func GetVariantVersion(version, imageVariant string) string {
 }
 
 // Returns image version and variant.
-// Expected imageTag format: <version>-<variant>, i.e. 1.0.0-mariner.
+// Expected imageTag format: <version>-<variant>, i.e. 1.0.0-mariner or 1.0.0-rc.1-mariner
 func GetVersionAndImageVariant(imageTag string) (string, string) {
-	if strings.Contains(imageTag, "-") {
-		split := strings.Split(imageTag, "-")
-		return split[0], split[1]
+	imageVersionOffset := strings.LastIndex(imageTag, "-")
+	imageVariant := imageTag[imageVersionOffset+1:]
+	if imageVariant == marinerImageVariantName {
+		return imageTag[:imageVersionOffset], imageVariant
 	}
 	return imageTag, ""
 }

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -311,10 +311,12 @@ func GetVariantVersion(version, imageVariant string) string {
 	return fmt.Sprintf("%s-%s", version, imageVariant)
 }
 
-func GetVersionAndImageVariant(version string) (string, string) {
-	if strings.Contains(version, "-") {
-		split := strings.Split(version, "-")
+// Returns image version and variant.
+// Expected imageTag format: <version>-<variant>, i.e. 1.0.0-mariner
+func GetVersionAndImageVariant(imageTag string) (string, string) {
+	if strings.Contains(imageTag, "-") {
+		split := strings.Split(imageTag, "-")
 		return split[0], split[1]
 	}
-	return version, ""
+	return imageTag, ""
 }

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -312,7 +312,7 @@ func GetVariantVersion(version, imageVariant string) string {
 }
 
 // Returns image version and variant.
-// Expected imageTag format: <version>-<variant>, i.e. 1.0.0-mariner
+// Expected imageTag format: <version>-<variant>, i.e. 1.0.0-mariner.
 func GetVersionAndImageVariant(imageTag string) (string, string) {
 	if strings.Contains(imageTag, "-") {
 		split := strings.Split(imageTag, "-")

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -312,7 +312,7 @@ func GetVariantVersion(version, imageVariant string) string {
 }
 
 // Returns image version and variant.
-// Expected imageTag format: <version>-<variant>, i.e. 1.0.0-mariner or 1.0.0-rc.1-mariner
+// Expected imageTag format: <version>-<variant>, i.e. 1.0.0-mariner or 1.0.0-rc.1-mariner.
 func GetVersionAndImageVariant(imageTag string) (string, string) {
 	imageVersionOffset := strings.LastIndex(imageTag, "-")
 	imageVariant := imageTag[imageVersionOffset+1:]

--- a/utils/utils_test.go
+++ b/utils/utils_test.go
@@ -141,6 +141,18 @@ func TestGetVersionAndImageVariant(t *testing.T) {
 			expectedVersion:      "1.9.0",
 			expectedImageVariant: "",
 		},
+		{
+			name:                 "image tag contains only version",
+			input:                "1.9.0-rc.1-mariner",
+			expectedVersion:      "1.9.0-rc.1",
+			expectedImageVariant: "mariner",
+		},
+		{
+			name:                 "image tag contains only version",
+			input:                "1.9.0-rc.1",
+			expectedVersion:      "1.9.0-rc.1",
+			expectedImageVariant: "",
+		},
 	}
 
 	for _, tc := range testcases {

--- a/utils/utils_test.go
+++ b/utils/utils_test.go
@@ -13,7 +13,11 @@ limitations under the License.
 
 package utils
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
 
 func TestContainerRuntimeUtils(t *testing.T) {
 	testcases := []struct {
@@ -114,6 +118,36 @@ func TestContains(t *testing.T) {
 			if actualValid != tc.valid {
 				t.Errorf("expected %v, got %v", tc.valid, actualValid)
 			}
+		})
+	}
+}
+
+func TestGetVersionAndImageVariant(t *testing.T) {
+	testcases := []struct {
+		name                 string
+		input                string
+		expectedVersion      string
+		expectedImageVariant string
+	}{
+		{
+			name:                 "image tag contains version and variant",
+			input:                "1.9.0-mariner",
+			expectedVersion:      "1.9.0",
+			expectedImageVariant: "mariner",
+		},
+		{
+			name:                 "image tag contains only version",
+			input:                "1.9.0",
+			expectedVersion:      "1.9.0",
+			expectedImageVariant: "",
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			version, imageVariant := GetVersionAndImageVariant(tc.input)
+			assert.Equal(t, tc.expectedVersion, version)
+			assert.Equal(t, tc.expectedImageVariant, imageVariant)
 		})
 	}
 }

--- a/utils/utils_test.go
+++ b/utils/utils_test.go
@@ -142,7 +142,7 @@ func TestGetVersionAndImageVariant(t *testing.T) {
 			expectedImageVariant: "",
 		},
 		{
-			name:                 "image tag contains only version",
+			name:                 "image tag contains only rc version and variant",
 			input:                "1.9.0-rc.1-mariner",
 			expectedVersion:      "1.9.0-rc.1",
 			expectedImageVariant: "mariner",

--- a/utils/utils_test.go
+++ b/utils/utils_test.go
@@ -148,7 +148,7 @@ func TestGetVersionAndImageVariant(t *testing.T) {
 			expectedImageVariant: "mariner",
 		},
 		{
-			name:                 "image tag contains only version",
+			name:                 "image tag contains only rc version",
 			input:                "1.9.0-rc.1",
 			expectedVersion:      "1.9.0-rc.1",
 			expectedImageVariant: "",


### PR DESCRIPTION
Signed-off-by: Pravin Pushkar <ppushkar@microsoft.com>

# Description

In case, where control plane has mariner variant images, the renew-cert will fail while getting the helm chart for current version(1.9.0-mariner) in this case. 
Here, the version is read from `Status` command which appends `mariner` to the actual version. So, we need extract the version from complete tag.

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #1125 

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [ ] Extended the documentation
