### PR TITLE
Update KinD e2e tests to use GH API instead of helm for fetching latest releases

### DIFF
--- a/.github/workflows/kind_e2e.yaml
+++ b/.github/workflows/kind_e2e.yaml
@@ -51,7 +51,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       GOVER: 1.19.3
-      DAPR_RUNTIME_VERSION: 1.9.0
+      DAPR_RUNTIME_VERSION: 1.9.4
       DAPR_DASHBOARD_VERSION: 0.11.0
       DAPR_TGZ: dapr-1.9.0.tgz
     strategy:
@@ -132,16 +132,24 @@ jobs:
     - name: Determine latest Dapr Runtime version including Pre-releases
       if: github.base_ref == 'master'
       run: |
-        helm repo add dapr https://dapr.github.io/helm-charts/ && helm repo update && export RUNTIME_VERSION=$(helm search repo dapr/dapr --devel --versions | awk '/dapr\/dapr/ {print $3; exit}' )
-        echo "DAPR_RUNTIME_VERSION=$RUNTIME_VERSION" >> $GITHUB_ENV
-        echo "Found $RUNTIME_VERSION"
+        export RUNTIME_VERSION=$(curl -s -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" https://api.github.com/repos/dapr/dapr/releases | grep tag_name | awk -F':' '{print $2}' | tr -d '", ' | sed '/-/! s/$/_/' | sort -V | sed 's/_$//' | tr -d 'v' | tail -1)
+        if [[ -z "$RUNTIME_VERSION" ]]; then
+            echo "Could not fetch the latest Dapr Runtime version. Using default version $DAPR_RUNTIME_VERSION"
+        else
+          echo "DAPR_RUNTIME_VERSION=$RUNTIME_VERSION" >> $GITHUB_ENV
+          echo "Found $RUNTIME_VERSION"
+        fi
       shell: bash
     - name: Determine latest Dapr Dashboard version including Pre-releases
       if: github.base_ref == 'master'
       run: |
-        curl -L -o dapr.tgz https://github.com/dapr/helm-charts/raw/master/$DAPR_TGZ && tar -xzf dapr.tgz && export DASHBOARD_VERSION=$(cat ./dapr/charts/dapr_dashboard/Chart.yaml | grep version | awk '{ print $2; exit }') && rm -rf dapr
-        echo "DAPR_DASHBOARD_VERSION=$DASHBOARD_VERSION" >> $GITHUB_ENV
-        echo "Found $DASHBOARD_VERSION"
+        export DASHBOARD_VERSION=$(curl -s -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" https://api.github.com/repos/dapr/dashboard/releases | grep tag_name | awk -F':' '{print $2}' | tr -d '", ' | sed '/-/! s/$/_/' | sort -V | sed 's/_$//' | tr -d 'v' | tail -1)
+        if [[ -z "$DASHBOARD_VERSION" ]]; then
+          echo "Could not fetch the latest Dapr Dashboard version. Using default version $DAPR_DASHBOARD_VERSION"
+        else
+          echo "DAPR_DASHBOARD_VERSION=$DASHBOARD_VERSION" >> $GITHUB_ENV
+          echo "Found $DASHBOARD_VERSION"
+        fi
       shell: bash
     - name: Run tests with GHCR
       # runs every 6hrs


### PR DESCRIPTION
Signed-off-by: Shubham Sharma <shubhash@microsoft.com>

# Description

Similar to standalone e2e, use the GH API in KinD e2e tests instead of helm.

## Issue reference

Please reference the issue this PR will close: #1130

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [ ] Extended the documentation
