### PR TITLE
Feat/resources dir

### DIFF
--- a/cmd/run.go
+++ b/cmd/run.go
@@ -377,7 +377,7 @@ func init() {
 	RunCmd.Flags().StringVarP(&logLevel, "log-level", "", "info", "The log verbosity. Valid values are: debug, info, warn, error, fatal, or panic")
 	RunCmd.Flags().IntVarP(&maxConcurrency, "app-max-concurrency", "", -1, "The concurrency level of the application, otherwise is unlimited")
 	RunCmd.Flags().StringVarP(&protocol, "app-protocol", "P", "http", "The protocol (gRPC or HTTP) Dapr uses to talk to the application")
-	RunCmd.Flags().StringVarP(&componentsPath, "components-path", "d", standalone.DefaultComponentsDirPath(), "The path for components directory")
+	RunCmd.Flags().StringVarP(&componentsPath, "components-path", "d", standalone.DefaultResourcesDirPrecedence(), "The path for components directory")
 	RunCmd.Flags().StringVarP(&resourcesPath, "resources-path", "", "", "The path for resources directory")
 	// TODO: Remove below line once the flag is removed in the future releases.
 	// By marking this as deprecated, the flag will be hidden from the help menu, but will continue to work. It will show a warning message when used.

--- a/pkg/standalone/common.go
+++ b/pkg/standalone/common.go
@@ -23,6 +23,7 @@ const (
 	defaultDaprDirName       = ".dapr"
 	defaultDaprBinDirName    = "bin"
 	defaultComponentsDirName = "components"
+	defaultResourcesDirName  = "resources"
 	defaultConfigFileName    = "config.yaml"
 )
 
@@ -45,6 +46,18 @@ func binaryFilePath(binaryDir string, binaryFilePrefix string) string {
 
 func DefaultComponentsDirPath() string {
 	return path_filepath.Join(defaultDaprDirPath(), defaultComponentsDirName)
+}
+
+func DefaultResourcesDirPath() string {
+	return path_filepath.Join(defaultDaprDirPath(), defaultResourcesDirName)
+}
+
+func DefaultResourcesDirPrecedence() string {
+	defaultResourcesDirPath := DefaultResourcesDirPath()
+	if _, err := os.Stat(defaultResourcesDirPath); os.IsNotExist(err) {
+		return DefaultComponentsDirPath()
+	}
+	return defaultResourcesDirPath
 }
 
 func DefaultConfigFilePath() string {


### PR DESCRIPTION
# Description

- this pr changes `dapr init` behaviour to create `resources` dir instead of `components`
- if there is any pre-existing `components` dir, `dapr init` will also moves its contents into `resources` dir
- `dapr run --resources-path` -> uses provided path in through flag
- `dapr run --components-path` -> uses provided path in through flag 
- `dapr run` -> precedence order is resources dir then components dir.

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #1148 

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [ ] Extended the documentation
