### PR TITLE
Increase timeout for self hosted e2e tests on MacOS runner

### DIFF
--- a/.github/workflows/self_hosted_e2e.yaml
+++ b/.github/workflows/self_hosted_e2e.yaml
@@ -111,7 +111,7 @@ jobs:
           fi
         shell: bash
       - name: Set the test timeout - MacOS
-        if: matrix.os == 'macOS-latest'
+        if: matrix.os == 'macos-latest'
         run: echo "TEST_TIMEOUT=20m" >> $GITHUB_ENV
       - name: Run E2E tests with GHCR
         # runs every 6hrs

--- a/.github/workflows/self_hosted_e2e.yaml
+++ b/.github/workflows/self_hosted_e2e.yaml
@@ -112,7 +112,7 @@ jobs:
         shell: bash
       - name: Set the test timeout - MacOS
         if: matrix.os == 'macos-latest'
-        run: echo "TEST_TIMEOUT=20m" >> $GITHUB_ENV
+        run: echo "E2E_SH_TEST_TIMEOUT=20m" >> $GITHUB_ENV
       - name: Run E2E tests with GHCR
         # runs every 6hrs
         if: github.event.schedule == '0 */6 * * *'
@@ -120,7 +120,7 @@ jobs:
           DAPR_DEFAULT_IMAGE_REGISTRY: ghcr
           DAPR_E2E_INIT_SLIM: ${{ contains(matrix.os, 'windows-latest') || contains(matrix.dapr_install_mode, 'slim') }}
           CONTAINER_RUNTIME: ${{ env.CONTAINER_RUNTIME }}
-          TEST_TIMEOUT: ${{ env.TEST_TIMEOUT }}
+          E2E_SH_TEST_TIMEOUT: ${{ env.E2E_SH_TEST_TIMEOUT }}
         run: |
           export TEST_OUTPUT_FILE=$GITHUB_WORKSPACE/test-e2e-standalone.json
           echo "TEST_OUTPUT_FILE=$TEST_OUTPUT_FILE" >> $GITHUB_ENV

--- a/.github/workflows/self_hosted_e2e.yaml
+++ b/.github/workflows/self_hosted_e2e.yaml
@@ -110,6 +110,9 @@ jobs:
             fi
           fi
         shell: bash
+      - name: Set the test timeout - MacOS
+        if: matrix.os == 'macOS-latest'
+        run: echo "TEST_TIMEOUT=20m" >> $GITHUB_ENV
       - name: Run E2E tests with GHCR
         # runs every 6hrs
         if: github.event.schedule == '0 */6 * * *'
@@ -117,6 +120,7 @@ jobs:
           DAPR_DEFAULT_IMAGE_REGISTRY: ghcr
           DAPR_E2E_INIT_SLIM: ${{ contains(matrix.os, 'windows-latest') || contains(matrix.dapr_install_mode, 'slim') }}
           CONTAINER_RUNTIME: ${{ env.CONTAINER_RUNTIME }}
+          TEST_TIMEOUT: ${{ env.TEST_TIMEOUT }}
         run: |
           export TEST_OUTPUT_FILE=$GITHUB_WORKSPACE/test-e2e-standalone.json
           echo "TEST_OUTPUT_FILE=$TEST_OUTPUT_FILE" >> $GITHUB_ENV

--- a/Makefile
+++ b/Makefile
@@ -70,7 +70,7 @@ export GOOS ?= $(TARGET_OS_LOCAL)
 export BINARY_EXT ?= $(BINARY_EXT_LOCAL)
 
 TEST_OUTPUT_FILE ?= test_output.json
-TEST_TIMEOUT ?= 10m
+E2E_SH_TEST_TIMEOUT ?= 10m
 
 # Use the variable H to add a header (equivalent to =>) to informational output
 H = $(shell printf "\033[34;1m=>\033[0m")
@@ -176,7 +176,7 @@ e2e-build-run-upgrade: build test-e2e-upgrade
 ################################################################################
 .PHONY: test-e2e-sh
 test-e2e-sh: test-deps
-	gotestsum --jsonfile $(TEST_OUTPUT_FILE) --format standard-verbose -- -timeout $(TEST_TIMEOUT) -count=1 -tags=e2e ./tests/e2e/standalone/...
+	gotestsum --jsonfile $(TEST_OUTPUT_FILE) --format standard-verbose -- -timeout $(E2E_SH_TEST_TIMEOUT) -count=1 -tags=e2e ./tests/e2e/standalone/...
 
 ################################################################################
 # Build, E2E Tests for Self-Hosted											   #

--- a/Makefile
+++ b/Makefile
@@ -70,6 +70,7 @@ export GOOS ?= $(TARGET_OS_LOCAL)
 export BINARY_EXT ?= $(BINARY_EXT_LOCAL)
 
 TEST_OUTPUT_FILE ?= test_output.json
+TEST_TIMEOUT ?= 10m
 
 # Use the variable H to add a header (equivalent to =>) to informational output
 H = $(shell printf "\033[34;1m=>\033[0m")
@@ -175,7 +176,7 @@ e2e-build-run-upgrade: build test-e2e-upgrade
 ################################################################################
 .PHONY: test-e2e-sh
 test-e2e-sh: test-deps
-	gotestsum --jsonfile $(TEST_OUTPUT_FILE) --format standard-verbose -- -count=1 -tags=e2e ./tests/e2e/standalone/...
+	gotestsum --jsonfile $(TEST_OUTPUT_FILE) --format standard-verbose -- -timeout $(TEST_TIMEOUT) -count=1 -tags=e2e ./tests/e2e/standalone/...
 
 ################################################################################
 # Build, E2E Tests for Self-Hosted											   #


### PR DESCRIPTION
Signed-off-by: Shubham Sharma <shubhash@microsoft.com>

# Description

Increase the timeout from 10m to 15m for self-hosted e2e tests. This was causing failures in #1057. This PR has been tested on top of changes from #1057 in #1156

## Issue reference

Please reference the issue this PR will close: NA

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [ ] Extended the documentation
