### PR TITLE
Add e2e timeout to Dockerhub runs and update Makefile default

### DIFF
--- a/.github/workflows/self_hosted_e2e.yaml
+++ b/.github/workflows/self_hosted_e2e.yaml
@@ -1,5 +1,3 @@
---- # ------------------------------------------------------------
-
 # ------------------------------------------------------------
 # Copyright 2021 The Dapr Authors
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -11,6 +9,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+# ------------------------------------------------------------
+
 name: E2E - Self-hosted
 
 on:
@@ -19,16 +19,16 @@ on:
       - master
       - release-*
     paths-ignore:
-      - "**.md"
+      - '**.md'
   schedule:
-    - cron: "0 */3 * * *"
-    - cron: "0 */6 * * *"
+    - cron: '0 */3 * * *'
+    - cron: '0 */6 * * *'
   pull_request:
     branches:
       - master
-      - "release-*"
+      - 'release-*'
     paths-ignore:
-      - "**.md"
+      - '**.md'
 
 jobs:
   self-hosted-e2e:

--- a/.github/workflows/self_hosted_e2e.yaml
+++ b/.github/workflows/self_hosted_e2e.yaml
@@ -1,3 +1,5 @@
+--- # ------------------------------------------------------------
+
 # ------------------------------------------------------------
 # Copyright 2021 The Dapr Authors
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -9,8 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# ------------------------------------------------------------
-
 name: E2E - Self-hosted
 
 on:
@@ -19,16 +19,16 @@ on:
       - master
       - release-*
     paths-ignore:
-      - '**.md'
+      - "**.md"
   schedule:
-    - cron: '0 */3 * * *'
-    - cron: '0 */6 * * *'
+    - cron: "0 */3 * * *"
+    - cron: "0 */6 * * *"
   pull_request:
     branches:
       - master
-      - 'release-*'
+      - "release-*"
     paths-ignore:
-      - '**.md'
+      - "**.md"
 
 jobs:
   self-hosted-e2e:
@@ -132,6 +132,7 @@ jobs:
         env:
           DAPR_E2E_INIT_SLIM: ${{ contains(matrix.os, 'windows-latest') || contains(matrix.dapr_install_mode, 'slim') }}
           CONTAINER_RUNTIME: ${{ env.CONTAINER_RUNTIME }}
+          E2E_SH_TEST_TIMEOUT: ${{ env.E2E_SH_TEST_TIMEOUT }}
         run: |
           export TEST_OUTPUT_FILE=$GITHUB_WORKSPACE/test-e2e-standalone.json
           echo "TEST_OUTPUT_FILE=$TEST_OUTPUT_FILE" >> $GITHUB_ENV

--- a/Makefile
+++ b/Makefile
@@ -70,7 +70,9 @@ export GOOS ?= $(TARGET_OS_LOCAL)
 export BINARY_EXT ?= $(BINARY_EXT_LOCAL)
 
 TEST_OUTPUT_FILE ?= test_output.json
-E2E_SH_TEST_TIMEOUT ?= 10m
+
+# Set the default timeout for tests to 10 minutes
+E2E_SH_TEST_TIMEOUT ?= $(if $(E2E_SH_TEST_TIMEOUT), $(E2E_SH_TEST_TIMEOUT), 10m)
 
 # Use the variable H to add a header (equivalent to =>) to informational output
 H = $(shell printf "\033[34;1m=>\033[0m")

--- a/Makefile
+++ b/Makefile
@@ -72,7 +72,9 @@ export BINARY_EXT ?= $(BINARY_EXT_LOCAL)
 TEST_OUTPUT_FILE ?= test_output.json
 
 # Set the default timeout for tests to 10 minutes
-E2E_SH_TEST_TIMEOUT ?= $(if $(E2E_SH_TEST_TIMEOUT), $(E2E_SH_TEST_TIMEOUT), 10m)
+ifndef E2E_SH_TEST_TIMEOUT
+  override E2E_SH_TEST_TIMEOUT := 10m
+endif
 
 # Use the variable H to add a header (equivalent to =>) to informational output
 H = $(shell printf "\033[34;1m=>\033[0m")


### PR DESCRIPTION
Signed-off-by: Shubham Sharma <shubhash@microsoft.com>

# Description

Earlier e2e test timeout was only applicable for GHCR cron runs, now it's also extended to Dockerhub.
The Makefile is also updated to always use a default value if the environment variable is unset.

## Issue reference

NA

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [ ] Extended the documentation
