### PR TITLE
use fqdn for all image names when dockerhub is the registry

### DIFF
--- a/pkg/standalone/standalone_test.go
+++ b/pkg/standalone/standalone_test.go
@@ -105,9 +105,9 @@ func TestResolveImageWithGHCR(t *testing.T) {
 }
 
 func TestResolveImageWithDockerHub(t *testing.T) {
-	expectedRedisImageName := "redis:6"
-	expectedZipkinImageName := "openzipkin/zipkin"
-	expectedPlacementImageName := "daprio/dapr"
+	expectedRedisImageName := "docker.io/redis:6"
+	expectedZipkinImageName := "docker.io/openzipkin/zipkin"
+	expectedPlacementImageName := "docker.io/daprio/dapr"
 
 	redisImageInfo := daprImageInfo{
 		ghcrImageName:      redisGhcrImageName,


### PR DESCRIPTION
Signed-off-by: Mukundan Sundararajan <65565396+mukundansundar@users.noreply.github.com>

# Description

Use FQDN when Dockerhub is set as the default regirstry.

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #1090 

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [ ] Extended the documentation
