### PR TITLE
Fix runtime custom path installation logic

### DIFF
--- a/cmd/buildinfo.go
+++ b/cmd/buildinfo.go
@@ -31,7 +31,7 @@ var BuildInfoCmd = &cobra.Command{
 dapr build-info
 `,
 	Run: func(cmd *cobra.Command, args []string) {
-		out, err := standalone.GetBuildInfo(daprPath, RootCmd.Version)
+		out, err := standalone.GetBuildInfo(daprRuntimePath, cliVersion)
 		if err != nil {
 			print.FailureStatusEvent(os.Stderr, "Error getting build info: %s", err.Error())
 			os.Exit(1)

--- a/cmd/dapr.go
+++ b/cmd/dapr.go
@@ -30,15 +30,20 @@ var RootCmd = &cobra.Command{
 	Use:   "dapr",
 	Short: "Dapr CLI",
 	Long: `
-	  __                
+	  __
      ____/ /___ _____  _____
     / __  / __ '/ __ \/ ___/
-   / /_/ / /_/ / /_/ / /    
-   \__,_/\__,_/ .___/_/     
-	     /_/            
-									   
+   / /_/ / /_/ / /_/ / /
+   \__,_/\__,_/ .___/_/
+	     /_/
+
 ===============================
 Distributed Application Runtime`,
+	Run: func(cmd *cobra.Command, args []string) {
+		if versionFlag {
+			printVersion()
+		}
+	},
 }
 
 type daprVersion struct {
@@ -53,27 +58,20 @@ const (
 )
 
 var (
-	daprVer   daprVersion
-	logAsJSON bool
-	daprPath  string
+	cliVersion  string
+	versionFlag bool
+	daprVer     daprVersion
+	logAsJSON   bool
+	daprPath    string
 )
 
 // Execute adds all child commands to the root command.
 func Execute(version, apiVersion string) {
-	RootCmd.Version = version
+	// Need to be set here as it is accessed in initConfig.
+	cliVersion = version
 	api.RuntimeAPIVersion = apiVersion
 
-	// err intentionally ignored since daprd may not yet be installed.
-	runtimeVer, _ := standalone.GetRuntimeVersion(daprPath)
-
-	daprVer = daprVersion{
-		CliVersion:     version,
-		RuntimeVersion: strings.ReplaceAll(runtimeVer, "\n", ""),
-	}
-
 	cobra.OnInitialize(initConfig)
-
-	setVersion()
 
 	if err := RootCmd.Execute(); err != nil {
 		fmt.Println(err)
@@ -81,14 +79,23 @@ func Execute(version, apiVersion string) {
 	}
 }
 
-func setVersion() {
+func printVersion() {
 	template := fmt.Sprintf(cliVersionTemplateString, daprVer.CliVersion, daprVer.RuntimeVersion)
-	RootCmd.SetVersionTemplate(template)
+	fmt.Printf(template)
 }
 
+// Function is called as a preRun initializer for each command executed.
 func initConfig() {
 	if logAsJSON {
 		print.EnableJSONFormat()
+	}
+	// err intentionally ignored since daprd may not yet be installed.
+	runtimeVer, _ := standalone.GetRuntimeVersion(daprPath)
+
+	daprVer = daprVersion{
+		// Set in Execute() method in this file before initConfig() is called by cmd.Execute().
+		CliVersion:     cliVersion,
+		RuntimeVersion: strings.ReplaceAll(runtimeVer, "\n", ""),
 	}
 
 	viper.SetEnvPrefix("dapr")
@@ -97,6 +104,7 @@ func initConfig() {
 }
 
 func init() {
+	RootCmd.Flags().BoolVarP(&versionFlag, "version", "v", false, "version for dapr")
 	RootCmd.PersistentFlags().StringVarP(&daprPath, "dapr-path", "", "", "The path to the dapr installation directory")
 	RootCmd.PersistentFlags().BoolVarP(&logAsJSON, "log-as-json", "", false, "Log output in JSON format")
 }

--- a/cmd/dapr.go
+++ b/cmd/dapr.go
@@ -58,11 +58,11 @@ const (
 )
 
 var (
-	cliVersion  string
-	versionFlag bool
-	daprVer     daprVersion
-	logAsJSON   bool
-	daprPath    string
+	cliVersion      string
+	versionFlag     bool
+	daprVer         daprVersion
+	logAsJSON       bool
+	daprRuntimePath string
 )
 
 // Execute adds all child commands to the root command.
@@ -89,7 +89,7 @@ func initConfig() {
 		print.EnableJSONFormat()
 	}
 	// err intentionally ignored since daprd may not yet be installed.
-	runtimeVer, _ := standalone.GetRuntimeVersion(daprPath)
+	runtimeVer, _ := standalone.GetRuntimeVersion(daprRuntimePath)
 
 	daprVer = daprVersion{
 		// Set in Execute() method in this file before initConfig() is called by cmd.Execute().
@@ -104,6 +104,6 @@ func initConfig() {
 
 func init() {
 	RootCmd.Flags().BoolVarP(&versionFlag, "version", "v", false, "version for dapr")
-	RootCmd.PersistentFlags().StringVarP(&daprPath, "dapr-path", "", "", "The path to the dapr installation directory")
+	RootCmd.PersistentFlags().StringVarP(&daprRuntimePath, "runtime-path", "", "", "The path to the dapr runtime installation directory")
 	RootCmd.PersistentFlags().BoolVarP(&logAsJSON, "log-as-json", "", false, "Log output in JSON format")
 }

--- a/cmd/dapr.go
+++ b/cmd/dapr.go
@@ -80,8 +80,7 @@ func Execute(version, apiVersion string) {
 }
 
 func printVersion() {
-	template := fmt.Sprintf(cliVersionTemplateString, daprVer.CliVersion, daprVer.RuntimeVersion)
-	fmt.Printf(template)
+	fmt.Printf(cliVersionTemplateString, daprVer.CliVersion, daprVer.RuntimeVersion)
 }
 
 // Function is called as a preRun initializer for each command executed.

--- a/cmd/dashboard.go
+++ b/cmd/dashboard.go
@@ -62,14 +62,14 @@ var DashboardCmd = &cobra.Command{
 # Start dashboard locally
 dapr dashboard
 
-# Start dashboard locally in a specified port 
+# Start dashboard locally in a specified port
 dapr dashboard -p 9999
 
 # Start dashboard locally on a random port which is free.
 dapr dashboard -p 0
 
-# Port forward to dashboard in Kubernetes 
-dapr dashboard -k 
+# Port forward to dashboard in Kubernetes
+dapr dashboard -k
 
 # Port forward to dashboard in Kubernetes on all addresses in a specified port
 dapr dashboard -k -p 9999 -a 0.0.0.0
@@ -82,7 +82,7 @@ dapr dashboard -k -p 0
 `,
 	Run: func(cmd *cobra.Command, args []string) {
 		if dashboardVersionCmd {
-			dashboardVer, err := standalone.GetDashboardVersion(daprPath)
+			dashboardVer, err := standalone.GetDashboardVersion(daprRuntimePath)
 			if err != nil {
 				print.FailureStatusEvent(os.Stderr, "Failed to get Dapr install directory: %v", err)
 				os.Exit(1)
@@ -194,7 +194,7 @@ dapr dashboard -k -p 0
 			<-portForward.GetStop()
 		} else {
 			// Standalone mode.
-			dashboardCmd, err := standalone.NewDashboardCmd(daprPath, dashboardLocalPort)
+			dashboardCmd, err := standalone.NewDashboardCmd(daprRuntimePath, dashboardLocalPort)
 			if err != nil {
 				print.FailureStatusEvent(os.Stderr, "Failed to get Dapr install	directory: %v", err)
 			} else {

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -83,7 +83,7 @@ dapr init --image-variant <variant>
 
 # Initialize Dapr inside a ".dapr" directory present in a non-default location
 # Folder .dapr will be created in folder pointed to by <path-to-install-directory>
-dapr init --dapr-path <path-to-install-directory>
+dapr init --runtime-path <path-to-install-directory>
 
 # See more at: https://docs.dapr.io/getting-started/
 `,
@@ -96,8 +96,8 @@ dapr init --dapr-path <path-to-install-directory>
 			imageRegistryURI := ""
 			var err error
 
-			if len(strings.TrimSpace(daprPath)) != 0 {
-				print.FailureStatusEvent(os.Stderr, "--dapr-path is only valid for self-hosted mode")
+			if len(strings.TrimSpace(daprRuntimePath)) != 0 {
+				print.FailureStatusEvent(os.Stderr, "--runtime-path is only valid for self-hosted mode")
 				os.Exit(1)
 			}
 
@@ -151,7 +151,7 @@ dapr init --dapr-path <path-to-install-directory>
 				print.FailureStatusEvent(os.Stdout, "Invalid container runtime. Supported values are docker and podman.")
 				os.Exit(1)
 			}
-			err := standalone.Init(runtimeVersion, dashboardVersion, dockerNetwork, slimMode, imageRegistryURI, fromDir, containerRuntime, imageVariant, daprPath)
+			err := standalone.Init(runtimeVersion, dashboardVersion, dockerNetwork, slimMode, imageRegistryURI, fromDir, containerRuntime, imageVariant, daprRuntimePath)
 			if err != nil {
 				print.FailureStatusEvent(os.Stderr, err.Error())
 				os.Exit(1)

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -57,7 +57,7 @@ var InitCmd = &cobra.Command{
 dapr init
 
 # Initialize Dapr in self-hosted mode with a provided docker image registry. Image looked up as <registry-url>/<image>.
-# Check docs or README for more information on the format of the image path that is required. 
+# Check docs or README for more information on the format of the image path that is required.
 dapr init --image-registry <registry-url>
 
 # Initialize Dapr in Kubernetes
@@ -81,7 +81,8 @@ dapr init --from-dir <path-to-directory>
 # Initialize dapr with a particular image variant. Allowed values: "mariner"
 dapr init --image-variant <variant>
 
-# Initialize Dapr to non-default install directory (default is $HOME/.dapr)
+# Initialize Dapr inside a ".dapr" directory present in a non-default location
+# Folder .dapr will be created in folder pointed to by <path-to-install-directory>
 dapr init --dapr-path <path-to-install-directory>
 
 # See more at: https://docs.dapr.io/getting-started/

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -93,7 +93,7 @@ dapr run --app-id myapp
 dapr run --app-id myapp --app-port 3000 --app-protocol grpc -- go run main.go
 
 # Run sidecar only specifying dapr runtime installation directory
-dapr run --app-id myapp --dapr-path /usr/local/dapr
+dapr run --app-id myapp --runtime-path /usr/local/dapr
 
 # Run multiple apps by providing path of a run config file
 dapr run --run-file dapr.yaml
@@ -123,7 +123,7 @@ dapr run --run-file /path/to/directory
 			fmt.Println(print.WhiteBold("WARNING: no application command found."))
 		}
 
-		daprDirPath, err := standalone.GetDaprPath(daprPath)
+		daprDirPath, err := standalone.GetDaprRuntimePath(daprRuntimePath)
 		if err != nil {
 			print.FailureStatusEvent(os.Stderr, "Failed to get Dapr install directory: %v", err)
 			os.Exit(1)
@@ -171,7 +171,7 @@ dapr run --run-file /path/to/directory
 			AppHealthThreshold: appHealthThreshold,
 			EnableAPILogging:   enableAPILogging,
 			APIListenAddresses: apiListenAddresses,
-			DaprdInstallPath:   daprPath,
+			DaprdInstallPath:   daprRuntimePath,
 		}
 		output, err := runExec.NewOutput(&standalone.RunConfig{
 			AppID:            appID,

--- a/cmd/uninstall.go
+++ b/cmd/uninstall.go
@@ -50,7 +50,7 @@ dapr uninstall -k
 
 # Uninstall Dapr from non-default install directory
 # This will remove the .dapr directory present in the path <path-to-install-directory>
-dapr uninstall --dapr-path <path-to-install-directory>
+dapr uninstall --runtime-path <path-to-install-directory>
 `,
 	PreRun: func(cmd *cobra.Command, args []string) {
 		viper.BindPFlag("network", cmd.Flags().Lookup("network"))
@@ -60,8 +60,8 @@ dapr uninstall --dapr-path <path-to-install-directory>
 		var err error
 
 		if uninstallKubernetes {
-			if len(strings.TrimSpace(daprPath)) != 0 {
-				print.FailureStatusEvent(os.Stderr, "--dapr-path is only valid for self-hosted mode")
+			if len(strings.TrimSpace(daprRuntimePath)) != 0 {
+				print.FailureStatusEvent(os.Stderr, "--runtime-path is only valid for self-hosted mode")
 				os.Exit(1)
 			}
 
@@ -74,7 +74,7 @@ dapr uninstall --dapr-path <path-to-install-directory>
 			}
 			print.InfoStatusEvent(os.Stdout, "Removing Dapr from your machine...")
 			dockerNetwork := viper.GetString("network")
-			err = standalone.Uninstall(uninstallAll, dockerNetwork, uninstallContainerRuntime, daprPath)
+			err = standalone.Uninstall(uninstallAll, dockerNetwork, uninstallContainerRuntime, daprRuntimePath)
 		}
 
 		if err != nil {

--- a/cmd/uninstall.go
+++ b/cmd/uninstall.go
@@ -48,7 +48,8 @@ dapr uninstall --all
 # Uninstall from Kubernetes
 dapr uninstall -k
 
-# Uninstall Dapr from non-default install directory (default is $HOME/.dapr)
+# Uninstall Dapr from non-default install directory
+# This will remove the .dapr directory present in the path <path-to-install-directory>
 dapr uninstall --dapr-path <path-to-install-directory>
 `,
 	PreRun: func(cmd *cobra.Command, args []string) {

--- a/pkg/runexec/runexec_test.go
+++ b/pkg/runexec/runexec_test.go
@@ -74,7 +74,7 @@ func assertArgumentContains(t *testing.T, key string, expectedValue string, args
 }
 
 func setupRun(t *testing.T) {
-	myDaprPath, err := standalone.GetDaprPath("")
+	myDaprPath, err := standalone.GetDaprRuntimePath("")
 	assert.NoError(t, err)
 
 	componentsDir := standalone.GetDaprComponentsPath(myDaprPath)
@@ -87,7 +87,7 @@ func setupRun(t *testing.T) {
 }
 
 func tearDownRun(t *testing.T) {
-	myDaprPath, err := standalone.GetDaprPath("")
+	myDaprPath, err := standalone.GetDaprRuntimePath("")
 	assert.NoError(t, err)
 
 	componentsDir := standalone.GetDaprComponentsPath(myDaprPath)
@@ -106,7 +106,7 @@ func assertCommonArgs(t *testing.T, basicConfig *standalone.RunConfig, output *R
 	assert.Equal(t, 8000, output.DaprHTTPPort)
 	assert.Equal(t, 50001, output.DaprGRPCPort)
 
-	daprPath, err := standalone.GetDaprPath("")
+	daprPath, err := standalone.GetDaprRuntimePath("")
 	assert.NoError(t, err)
 
 	assert.Contains(t, output.DaprCMD.Args[0], "daprd")
@@ -168,7 +168,7 @@ func TestRun(t *testing.T) {
 	// Setup the tearDown routine to run in the end.
 	defer tearDownRun(t)
 
-	myDaprPath, err := standalone.GetDaprPath("")
+	myDaprPath, err := standalone.GetDaprRuntimePath("")
 	assert.NoError(t, err)
 
 	componentsDir := standalone.GetDaprComponentsPath(myDaprPath)

--- a/pkg/standalone/common.go
+++ b/pkg/standalone/common.go
@@ -29,18 +29,18 @@ const (
 	defaultComponentsDirName = "components"
 )
 
-// GetDaprPath returns the dapr installation path.
+// GetDaprRuntimePath returns the dapr runtime installation path.
 // The order of precedence is:
-//  1. From --dapr-path command line flag appended with `.dapr`
-//  2. From DAPR_PATH environment variable appended with `.dapr`
-//  3. $HOME/.dapr
-func GetDaprPath(inputInstallPath string) (string, error) {
+//  1. From --runtime-path command line flag appended with `.dapr`
+//  2. From DAPR_RUNTIME_PATH environment variable appended with `.dapr`
+//  3. default $HOME/.dapr
+func GetDaprRuntimePath(inputInstallPath string) (string, error) {
 	installPath := strings.TrimSpace(inputInstallPath)
 	if installPath != "" {
 		return path_filepath.Join(installPath, DefaultDaprDirName), nil
 	}
 
-	envDaprDir := strings.TrimSpace(os.Getenv("DAPR_PATH"))
+	envDaprDir := strings.TrimSpace(os.Getenv("DAPR_RUNTIME_PATH"))
 	if envDaprDir != "" {
 		return path_filepath.Join(envDaprDir, DefaultDaprDirName), nil
 	}
@@ -66,7 +66,7 @@ func binaryFilePathWithDir(binaryDir string, binaryFilePrefix string) string {
 }
 
 func lookupBinaryFilePath(inputInstallPath string, binaryFilePrefix string) (string, error) {
-	daprPath, err := GetDaprPath(inputInstallPath)
+	daprPath, err := GetDaprRuntimePath(inputInstallPath)
 	if err != nil {
 		return "", err
 	}

--- a/pkg/standalone/common.go
+++ b/pkg/standalone/common.go
@@ -17,6 +17,7 @@ import (
 	"os"
 	path_filepath "path/filepath"
 	"runtime"
+	"strings"
 )
 
 const (
@@ -30,17 +31,18 @@ const (
 
 // GetDaprPath returns the dapr installation path.
 // The order of precedence is:
-//  1. From --dapr-path command line flag
-//  2. From DAPR_PATH environment variable
+//  1. From --dapr-path command line flag appended with `.dapr`
+//  2. From DAPR_PATH environment variable appended with `.dapr`
 //  3. $HOME/.dapr
 func GetDaprPath(inputInstallPath string) (string, error) {
-	if inputInstallPath != "" {
-		return inputInstallPath, nil
+	installPath := strings.TrimSpace(inputInstallPath)
+	if installPath != "" {
+		return path_filepath.Join(installPath, DefaultDaprDirName), nil
 	}
 
-	envDaprDir := os.Getenv("DAPR_PATH")
+	envDaprDir := strings.TrimSpace(os.Getenv("DAPR_PATH"))
 	if envDaprDir != "" {
-		return envDaprDir, nil
+		return path_filepath.Join(envDaprDir, DefaultDaprDirName), nil
 	}
 
 	homeDir, err := os.UserHomeDir()

--- a/pkg/standalone/common_test.go
+++ b/pkg/standalone/common_test.go
@@ -41,22 +41,26 @@ func TestGetDaprPath(t *testing.T) {
 	})
 
 	t.Run("with flag value", func(t *testing.T) {
-		p, err := GetDaprPath("/path/to/dapr")
+		input := path_filepath.Join("path", "to", "dapr")
+		p, err := GetDaprPath(input)
 		require.NoError(t, err)
-		assert.Equal(t, "/path/to/dapr/.dapr", p, "path should be /path/to/dapr/.dapr")
+		assert.Equal(t, path_filepath.Join(input, ".dapr"), p, "path should be /path/to/dapr/.dapr")
 	})
 
 	t.Run("with env var", func(t *testing.T) {
-		t.Setenv("DAPR_PATH", "/path/to/dapr")
+		input := path_filepath.Join("path", "to", "dapr")
+		t.Setenv("DAPR_PATH", input)
 		p, err := GetDaprPath("")
 		require.NoError(t, err)
-		assert.Equal(t, "/path/to/dapr/.dapr", p, "path should be /path/to/dapr/.dapr")
+		assert.Equal(t, path_filepath.Join(input, ".dapr"), p, "path should be /path/to/dapr/.dapr")
 	})
 
 	t.Run("with flag value and env var", func(t *testing.T) {
-		t.Setenv("DAPR_PATH", "/path/to/dapr2")
-		p, err := GetDaprPath("/path/to/dapr")
+		input := path_filepath.Join("path", "to", "dapr")
+		input2 := path_filepath.Join("path", "to", "dapr2")
+		t.Setenv("DAPR_PATH", input2)
+		p, err := GetDaprPath(input)
 		require.NoError(t, err)
-		assert.Equal(t, "/path/to/dapr/.dapr", p, "path should be /path/to/dapr/.dapr")
+		assert.Equal(t, path_filepath.Join(input, ".dapr"), p, "path should be /path/to/dapr/.dapr")
 	})
 }

--- a/pkg/standalone/common_test.go
+++ b/pkg/standalone/common_test.go
@@ -27,30 +27,30 @@ func TestGetDaprPath(t *testing.T) {
 	require.NoError(t, err, "error getting home dir")
 
 	t.Run("without flag value or env var", func(t *testing.T) {
-		p, err := GetDaprPath("")
+		p, err := GetDaprRuntimePath("")
 		require.NoError(t, err)
 		assert.Equal(t, p, path_filepath.Join(homeDir, DefaultDaprDirName), "path should be $HOME/.dapr")
-		p, err = GetDaprPath("      ")
+		p, err = GetDaprRuntimePath("      ")
 		require.NoError(t, err)
 		assert.Equal(t, path_filepath.Join(homeDir, DefaultDaprDirName), p, "path should be $HOME/.dapr")
 
-		t.Setenv("DAPR_PATH", "      ")
-		p, err = GetDaprPath("")
+		t.Setenv("DAPR_RUNTIME_PATH", "      ")
+		p, err = GetDaprRuntimePath("")
 		require.NoError(t, err)
 		assert.Equal(t, path_filepath.Join(homeDir, DefaultDaprDirName), p, "path should be $HOME/.dapr")
 	})
 
 	t.Run("with flag value", func(t *testing.T) {
 		input := path_filepath.Join("path", "to", "dapr")
-		p, err := GetDaprPath(input)
+		p, err := GetDaprRuntimePath(input)
 		require.NoError(t, err)
 		assert.Equal(t, path_filepath.Join(input, ".dapr"), p, "path should be /path/to/dapr/.dapr")
 	})
 
 	t.Run("with env var", func(t *testing.T) {
 		input := path_filepath.Join("path", "to", "dapr")
-		t.Setenv("DAPR_PATH", input)
-		p, err := GetDaprPath("")
+		t.Setenv("DAPR_RUNTIME_PATH", input)
+		p, err := GetDaprRuntimePath("")
 		require.NoError(t, err)
 		assert.Equal(t, path_filepath.Join(input, ".dapr"), p, "path should be /path/to/dapr/.dapr")
 	})
@@ -58,8 +58,8 @@ func TestGetDaprPath(t *testing.T) {
 	t.Run("with flag value and env var", func(t *testing.T) {
 		input := path_filepath.Join("path", "to", "dapr")
 		input2 := path_filepath.Join("path", "to", "dapr2")
-		t.Setenv("DAPR_PATH", input2)
-		p, err := GetDaprPath(input)
+		t.Setenv("DAPR_RUNTIME_PATH", input2)
+		p, err := GetDaprRuntimePath(input)
 		require.NoError(t, err)
 		assert.Equal(t, path_filepath.Join(input, ".dapr"), p, "path should be /path/to/dapr/.dapr")
 	})

--- a/pkg/standalone/common_test.go
+++ b/pkg/standalone/common_test.go
@@ -1,0 +1,62 @@
+/*
+Copyright 2023 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package standalone
+
+import (
+	"os"
+	path_filepath "path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetDaprPath(t *testing.T) {
+	homeDir, err := os.UserHomeDir()
+	require.NoError(t, err, "error getting home dir")
+
+	t.Run("without flag value or env var", func(t *testing.T) {
+		p, err := GetDaprPath("")
+		require.NoError(t, err)
+		assert.Equal(t, p, path_filepath.Join(homeDir, DefaultDaprDirName), "path should be $HOME/.dapr")
+		p, err = GetDaprPath("      ")
+		require.NoError(t, err)
+		assert.Equal(t, path_filepath.Join(homeDir, DefaultDaprDirName), p, "path should be $HOME/.dapr")
+
+		t.Setenv("DAPR_PATH", "      ")
+		p, err = GetDaprPath("")
+		require.NoError(t, err)
+		assert.Equal(t, path_filepath.Join(homeDir, DefaultDaprDirName), p, "path should be $HOME/.dapr")
+	})
+
+	t.Run("with flag value", func(t *testing.T) {
+		p, err := GetDaprPath("/path/to/dapr")
+		require.NoError(t, err)
+		assert.Equal(t, "/path/to/dapr/.dapr", p, "path should be /path/to/dapr/.dapr")
+	})
+
+	t.Run("with env var", func(t *testing.T) {
+		t.Setenv("DAPR_PATH", "/path/to/dapr")
+		p, err := GetDaprPath("")
+		require.NoError(t, err)
+		assert.Equal(t, "/path/to/dapr/.dapr", p, "path should be /path/to/dapr/.dapr")
+	})
+
+	t.Run("with flag value and env var", func(t *testing.T) {
+		t.Setenv("DAPR_PATH", "/path/to/dapr2")
+		p, err := GetDaprPath("/path/to/dapr")
+		require.NoError(t, err)
+		assert.Equal(t, "/path/to/dapr/.dapr", p, "path should be /path/to/dapr/.dapr")
+	})
+}

--- a/pkg/standalone/run.go
+++ b/pkg/standalone/run.go
@@ -71,7 +71,7 @@ type SharedRunConfig struct {
 	AppHealthTimeout   int               `arg:"app-health-probe-timeout" ifneq:"0" yaml:"appHealthProbeTimeout"`
 	AppHealthThreshold int               `arg:"app-health-threshold" ifneq:"0" yaml:"appHealthThreshold"`
 	EnableAPILogging   bool              `arg:"enable-api-logging" yaml:"enableApiLogging"`
-	DaprdInstallPath   string            `yaml:"daprPath"`
+	DaprdInstallPath   string            `yaml:"runtimePath"`
 	Env                map[string]string `yaml:"env"`
 }
 

--- a/pkg/standalone/runfileconfig/run_file_config_parser.go
+++ b/pkg/standalone/runfileconfig/run_file_config_parser.go
@@ -209,7 +209,7 @@ func (a *RunFileConfig) resolveResourcesFilePath(app *App) error {
 	} else if len(strings.TrimSpace(a.Common.ResourcesPath)) > 0 {
 		app.ResourcesPath = a.Common.ResourcesPath
 	} else {
-		daprDirPath, err := standalone.GetDaprPath(app.DaprdInstallPath)
+		daprDirPath, err := standalone.GetDaprRuntimePath(app.DaprdInstallPath)
 		if err != nil {
 			return fmt.Errorf("error getting dapr install path: %w", err)
 		}
@@ -230,7 +230,7 @@ func (a *RunFileConfig) resolveConfigFilePath(app *App) error {
 	} else if len(strings.TrimSpace(a.Common.ConfigFile)) > 0 {
 		app.ConfigFile = a.Common.ConfigFile
 	} else {
-		daprDirPath, err := standalone.GetDaprPath(app.DaprdInstallPath)
+		daprDirPath, err := standalone.GetDaprRuntimePath(app.DaprdInstallPath)
 		if err != nil {
 			return fmt.Errorf("error getting dapr install path: %w", err)
 		}

--- a/pkg/standalone/runfileconfig/run_file_config_parser_test.go
+++ b/pkg/standalone/runfileconfig/run_file_config_parser_test.go
@@ -266,7 +266,7 @@ func TestGetBasePathFromAbsPath(t *testing.T) {
 func getResourcesAndConfigFilePaths(t *testing.T, daprInstallPath string) []string {
 	t.Helper()
 	result := make([]string, 2)
-	daprDirPath, err := standalone.GetDaprPath(daprInstallPath)
+	daprDirPath, err := standalone.GetDaprRuntimePath(daprInstallPath)
 	assert.NoError(t, err)
 	result[0] = standalone.GetDaprComponentsPath(daprDirPath)
 	result[1] = standalone.GetDaprConfigPath(daprDirPath)

--- a/pkg/standalone/standalone.go
+++ b/pkg/standalone/standalone.go
@@ -215,7 +215,7 @@ func Init(runtimeVersion, dashboardVersion string, dockerNetwork string, slimMod
 
 	print.InfoStatusEvent(os.Stdout, "Installing runtime version %s", runtimeVersion)
 
-	installDir, err := GetDaprPath(daprInstallPath)
+	installDir, err := GetDaprRuntimePath(daprInstallPath)
 	if err != nil {
 		return err
 	}

--- a/pkg/standalone/uninstall.go
+++ b/pkg/standalone/uninstall.go
@@ -75,7 +75,7 @@ func removeDir(dirPath string) error {
 func Uninstall(uninstallAll bool, dockerNetwork string, containerRuntime string, inputInstallPath string) error {
 	var containerErrs []error
 	inputInstallPath = strings.TrimSpace(inputInstallPath)
-	installDir, err := GetDaprPath(inputInstallPath)
+	installDir, err := GetDaprRuntimePath(inputInstallPath)
 	if err != nil {
 		return err
 	}

--- a/tests/e2e/standalone/init_run_custom_path_test.go
+++ b/tests/e2e/standalone/init_run_custom_path_test.go
@@ -28,23 +28,23 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// TestStandaloneInitRunUninstallNonDefaultDaprPath covers init, version, run and uninstall with --dapr-path flag.
+// TestStandaloneInitRunUninstallNonDefaultDaprPath covers init, version, run and uninstall with --runtime-path flag.
 func TestStandaloneInitRunUninstallNonDefaultDaprPath(t *testing.T) {
 	// Ensure a clean environment
 	must(t, cmdUninstall, "failed to uninstall Dapr")
-	t.Run("run with dapr path flag", func(t *testing.T) {
+	t.Run("run with runtime path flag", func(t *testing.T) {
 		daprPath, err := os.MkdirTemp("", "dapr-e2e-run-with-flag-*")
 		assert.NoError(t, err)
 		defer os.RemoveAll(daprPath) // clean up
 
 		daprRuntimeVersion, _ := common.GetVersionsFromEnv(t, false)
-		output, err := cmdInit("--runtime-version", daprRuntimeVersion, "--dapr-path", daprPath)
+		output, err := cmdInit("--runtime-version", daprRuntimeVersion, "--runtime-path", daprPath)
 		t.Log(output)
 		require.NoError(t, err, "init failed")
 		assert.Contains(t, output, "Success! Dapr is up and running.")
 
 		// check version
-		output, err = cmdVersion("", "--dapr-path", daprPath)
+		output, err = cmdVersion("", "--runtime-path", daprPath)
 		t.Log(output)
 		require.NoError(t, err, "dapr version failed")
 		lines := strings.Split(output, "\n")
@@ -55,8 +55,8 @@ func TestStandaloneInitRunUninstallNonDefaultDaprPath(t *testing.T) {
 		assert.Contains(t, lines[1], daprRuntimeVersion)
 
 		args := []string{
-			"--dapr-path", daprPath,
-			"--app-id", "run_with_dapr_path_flag",
+			"--runtime-path", daprPath,
+			"--app-id", "run_with_dapr_runtime_path_flag",
 			"--", "bash", "-c", "echo 'test'",
 		}
 
@@ -73,7 +73,7 @@ func TestStandaloneInitRunUninstallNonDefaultDaprPath(t *testing.T) {
 		assert.NoFileExists(t, defaultDaprPath)
 
 		// Uninstall Dapr at the end of the test since it's being installed in a non-default location.
-		must(t, cmdUninstall, "failed to uninstall Dapr from custom path flag", "--dapr-path", daprPath)
+		must(t, cmdUninstall, "failed to uninstall Dapr from custom path flag", "--runtime-path", daprPath)
 		customDaprPath := filepath.Join(daprPath, ".dapr")
 		assert.NoDirExists(t, customDaprPath)
 		assert.DirExists(t, daprPath)
@@ -83,12 +83,12 @@ func TestStandaloneInitRunUninstallNonDefaultDaprPath(t *testing.T) {
 		assert.Len(t, f, 0)
 	})
 
-	t.Run("run with env var", func(t *testing.T) {
+	t.Run("run with custom runtime path env var", func(t *testing.T) {
 		daprPath, err := os.MkdirTemp("", "dapr-e2e-run-with-env-*")
 		assert.NoError(t, err)
 		defer os.RemoveAll(daprPath) // clean up
 
-		t.Setenv("DAPR_PATH", daprPath)
+		t.Setenv("DAPR_RUNTIME_PATH", daprPath)
 
 		daprRuntimeVersion, _ := common.GetVersionsFromEnv(t, false)
 
@@ -98,7 +98,7 @@ func TestStandaloneInitRunUninstallNonDefaultDaprPath(t *testing.T) {
 		assert.Contains(t, output, "Success! Dapr is up and running.")
 
 		// check version
-		output, err = cmdVersion("", "--dapr-path", daprPath)
+		output, err = cmdVersion("", "--runtime-path", daprPath)
 		t.Log(output)
 		require.NoError(t, err, "dapr version failed")
 		lines := strings.Split(output, "\n")
@@ -109,7 +109,7 @@ func TestStandaloneInitRunUninstallNonDefaultDaprPath(t *testing.T) {
 		assert.Contains(t, lines[1], daprRuntimeVersion)
 
 		args := []string{
-			"--app-id", "run_with_dapr_path_flag",
+			"--app-id", "run_with_dapr_runtime_path_flag",
 			"--", "bash", "-c", "echo 'test'",
 		}
 
@@ -136,7 +136,7 @@ func TestStandaloneInitRunUninstallNonDefaultDaprPath(t *testing.T) {
 		assert.Len(t, f, 0)
 	})
 
-	t.Run("run with both flag and env var", func(t *testing.T) {
+	t.Run("run with both runtime path flag and env var", func(t *testing.T) {
 		daprPathEnv, err := os.MkdirTemp("", "dapr-e2e-run-with-envflag-1-*")
 		assert.NoError(t, err)
 		defer os.RemoveAll(daprPathEnv) // clean up
@@ -145,17 +145,17 @@ func TestStandaloneInitRunUninstallNonDefaultDaprPath(t *testing.T) {
 		assert.NoError(t, err)
 		defer os.RemoveAll(daprPathFlag) // clean up
 
-		t.Setenv("DAPR_PATH", daprPathEnv)
+		t.Setenv("DAPR_RUNTIME_PATH", daprPathEnv)
 
 		daprRuntimeVersion, _ := common.GetVersionsFromEnv(t, false)
 
-		output, err := cmdInit("--runtime-version", daprRuntimeVersion, "--dapr-path", daprPathFlag)
+		output, err := cmdInit("--runtime-version", daprRuntimeVersion, "--runtime-path", daprPathFlag)
 		t.Log(output)
 		require.NoError(t, err, "init failed")
 		assert.Contains(t, output, "Success! Dapr is up and running.")
 
 		// check version
-		output, err = cmdVersion("", "--dapr-path", daprPathFlag)
+		output, err = cmdVersion("", "--runtime-path", daprPathFlag)
 		t.Log(output)
 		require.NoError(t, err, "dapr version failed")
 		lines := strings.Split(output, "\n")
@@ -166,8 +166,8 @@ func TestStandaloneInitRunUninstallNonDefaultDaprPath(t *testing.T) {
 		assert.Contains(t, lines[1], daprRuntimeVersion)
 
 		args := []string{
-			"--dapr-path", daprPathFlag,
-			"--app-id", "run_with_dapr_path_flag",
+			"--runtime-path", daprPathFlag,
+			"--app-id", "run_with_dapr_runtime_path_flag",
 			"--", "bash", "-c", "echo 'test'",
 		}
 
@@ -193,7 +193,7 @@ func TestStandaloneInitRunUninstallNonDefaultDaprPath(t *testing.T) {
 		assert.NoDirExists(t, envDaprBinPath)
 
 		// Uninstall Dapr at the end of the test since it's being installed in a non-default location.
-		must(t, cmdUninstall, "failed to uninstall Dapr from custom path flag", "--dapr-path", daprPathFlag)
+		must(t, cmdUninstall, "failed to uninstall Dapr from custom path flag", "--runtime-path", daprPathFlag)
 		customDaprPath := filepath.Join(daprPathFlag, ".dapr")
 		assert.NoDirExists(t, customDaprPath)
 		assert.DirExists(t, daprPathFlag)

--- a/tests/e2e/standalone/init_run_custom_path_test.go
+++ b/tests/e2e/standalone/init_run_custom_path_test.go
@@ -1,0 +1,205 @@
+//go:build e2e && !template
+// +build e2e,!template
+
+/*
+Copyright 2022 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package standalone_test
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/dapr/cli/tests/e2e/common"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestStandaloneInitRunUninstallNonDefaultDaprPath covers init, version, run and uninstall with --dapr-path flag.
+func TestStandaloneInitRunUninstallNonDefaultDaprPath(t *testing.T) {
+	// Ensure a clean environment
+	must(t, cmdUninstall, "failed to uninstall Dapr")
+	t.Run("run with dapr path flag", func(t *testing.T) {
+		daprPath, err := os.MkdirTemp("", "dapr-e2e-run-with-flag-*")
+		assert.NoError(t, err)
+		defer os.RemoveAll(daprPath) // clean up
+
+		daprRuntimeVersion, _ := common.GetVersionsFromEnv(t, false)
+		output, err := cmdInit("--runtime-version", daprRuntimeVersion, "--dapr-path", daprPath)
+		t.Log(output)
+		require.NoError(t, err, "init failed")
+		assert.Contains(t, output, "Success! Dapr is up and running.")
+
+		// check version
+		output, err = cmdVersion("", "--dapr-path", daprPath)
+		t.Log(output)
+		require.NoError(t, err, "dapr version failed")
+		lines := strings.Split(output, "\n")
+		assert.GreaterOrEqual(t, len(lines), 2, "expected at least 2 fields in components outptu")
+		assert.Contains(t, lines[0], "CLI version")
+		assert.Contains(t, lines[0], "edge")
+		assert.Contains(t, lines[1], "Runtime version")
+		assert.Contains(t, lines[1], daprRuntimeVersion)
+
+		args := []string{
+			"--dapr-path", daprPath,
+			"--app-id", "run_with_dapr_path_flag",
+			"--", "bash", "-c", "echo 'test'",
+		}
+
+		output, err = cmdRun("", args...)
+		t.Log(output)
+		require.NoError(t, err, "run failed")
+		assert.Contains(t, output, "Exited App successfully")
+		assert.Contains(t, output, "Exited Dapr successfully")
+
+		homeDir, err := os.UserHomeDir()
+		require.NoError(t, err, "failed to get user home directory")
+
+		defaultDaprPath := filepath.Join(homeDir, ".dapr")
+		assert.NoFileExists(t, defaultDaprPath)
+
+		// Uninstall Dapr at the end of the test since it's being installed in a non-default location.
+		must(t, cmdUninstall, "failed to uninstall Dapr from custom path flag", "--dapr-path", daprPath)
+		customDaprPath := filepath.Join(daprPath, ".dapr")
+		assert.NoDirExists(t, customDaprPath)
+		assert.DirExists(t, daprPath)
+		// Check the directory is empty.
+		f, err := os.ReadDir(daprPath)
+		assert.NoError(t, err)
+		assert.Len(t, f, 0)
+	})
+
+	t.Run("run with env var", func(t *testing.T) {
+		daprPath, err := os.MkdirTemp("", "dapr-e2e-run-with-env-*")
+		assert.NoError(t, err)
+		defer os.RemoveAll(daprPath) // clean up
+
+		t.Setenv("DAPR_PATH", daprPath)
+
+		daprRuntimeVersion, _ := common.GetVersionsFromEnv(t, false)
+
+		output, err := cmdInit("--runtime-version", daprRuntimeVersion)
+		t.Log(output)
+		require.NoError(t, err, "init failed")
+		assert.Contains(t, output, "Success! Dapr is up and running.")
+
+		// check version
+		output, err = cmdVersion("", "--dapr-path", daprPath)
+		t.Log(output)
+		require.NoError(t, err, "dapr version failed")
+		lines := strings.Split(output, "\n")
+		assert.GreaterOrEqual(t, len(lines), 2, "expected at least 2 fields in components outptu")
+		assert.Contains(t, lines[0], "CLI version")
+		assert.Contains(t, lines[0], "edge")
+		assert.Contains(t, lines[1], "Runtime version")
+		assert.Contains(t, lines[1], daprRuntimeVersion)
+
+		args := []string{
+			"--app-id", "run_with_dapr_path_flag",
+			"--", "bash", "-c", "echo 'test'",
+		}
+
+		output, err = cmdRun("", args...)
+		t.Log(output)
+		require.NoError(t, err, "run failed")
+		assert.Contains(t, output, "Exited App successfully")
+		assert.Contains(t, output, "Exited Dapr successfully")
+
+		homeDir, err := os.UserHomeDir()
+		require.NoError(t, err, "failed to get user home directory")
+
+		defaultDaprPath := filepath.Join(homeDir, ".dapr")
+		assert.NoFileExists(t, defaultDaprPath)
+
+		// Uninstall Dapr at the end of the test since it's being installed in a non-default location.
+		must(t, cmdUninstall, "failed to uninstall Dapr from custom env var path")
+		customDaprPath := filepath.Join(daprPath, ".dapr")
+		assert.NoDirExists(t, customDaprPath)
+		assert.DirExists(t, daprPath)
+		// Check the directory is empty.
+		f, err := os.ReadDir(daprPath)
+		assert.NoError(t, err)
+		assert.Len(t, f, 0)
+	})
+
+	t.Run("run with both flag and env var", func(t *testing.T) {
+		daprPathEnv, err := os.MkdirTemp("", "dapr-e2e-run-with-envflag-1-*")
+		assert.NoError(t, err)
+		defer os.RemoveAll(daprPathEnv) // clean up
+
+		daprPathFlag, err := os.MkdirTemp("", "dapr-e2e-run-with-envflag-2-*")
+		assert.NoError(t, err)
+		defer os.RemoveAll(daprPathFlag) // clean up
+
+		t.Setenv("DAPR_PATH", daprPathEnv)
+
+		daprRuntimeVersion, _ := common.GetVersionsFromEnv(t, false)
+
+		output, err := cmdInit("--runtime-version", daprRuntimeVersion, "--dapr-path", daprPathFlag)
+		t.Log(output)
+		require.NoError(t, err, "init failed")
+		assert.Contains(t, output, "Success! Dapr is up and running.")
+
+		// check version
+		output, err = cmdVersion("", "--dapr-path", daprPathFlag)
+		t.Log(output)
+		require.NoError(t, err, "dapr version failed")
+		lines := strings.Split(output, "\n")
+		assert.GreaterOrEqual(t, len(lines), 2, "expected at least 2 fields in components outptu")
+		assert.Contains(t, lines[0], "CLI version")
+		assert.Contains(t, lines[0], "edge")
+		assert.Contains(t, lines[1], "Runtime version")
+		assert.Contains(t, lines[1], daprRuntimeVersion)
+
+		args := []string{
+			"--dapr-path", daprPathFlag,
+			"--app-id", "run_with_dapr_path_flag",
+			"--", "bash", "-c", "echo 'test'",
+		}
+
+		flagDaprdBinPath := filepath.Join(daprPathFlag, ".dapr", "bin", "daprd")
+		if runtime.GOOS == "windows" {
+			flagDaprdBinPath += ".exe"
+		}
+		assert.FileExists(t, flagDaprdBinPath)
+
+		output, err = cmdRun("", args...)
+		t.Log(output)
+		require.NoError(t, err, "run failed")
+		assert.Contains(t, output, "Exited App successfully")
+		assert.Contains(t, output, "Exited Dapr successfully")
+
+		homeDir, err := os.UserHomeDir()
+		require.NoError(t, err, "failed to get user home directory")
+
+		defaultDaprPath := filepath.Join(homeDir, ".dapr")
+		assert.NoDirExists(t, defaultDaprPath)
+
+		envDaprBinPath := filepath.Join(daprPathEnv, ".dapr", "bin")
+		assert.NoDirExists(t, envDaprBinPath)
+
+		// Uninstall Dapr at the end of the test since it's being installed in a non-default location.
+		must(t, cmdUninstall, "failed to uninstall Dapr from custom path flag", "--dapr-path", daprPathFlag)
+		customDaprPath := filepath.Join(daprPathFlag, ".dapr")
+		assert.NoDirExists(t, customDaprPath)
+		assert.DirExists(t, daprPathFlag)
+		// Check the directory is empty.
+		f, err := os.ReadDir(daprPathFlag)
+		assert.NoError(t, err)
+		assert.Len(t, f, 0)
+	})
+}

--- a/tests/e2e/standalone/init_test.go
+++ b/tests/e2e/standalone/init_test.go
@@ -133,67 +133,6 @@ func TestStandaloneInit(t *testing.T) {
 		verifyConfigs(t, daprPath)
 	})
 
-	t.Run("init with --dapr-path flag", func(t *testing.T) {
-		// Ensure a clean environment
-		must(t, cmdUninstall, "failed to uninstall Dapr")
-
-		daprPath, err := os.MkdirTemp("", "dapr-e2e-init-with-flag-*")
-		assert.NoError(t, err)
-		defer os.RemoveAll(daprPath) // clean up
-
-		output, err := cmdInit("--runtime-version", daprRuntimeVersion, "--dapr-path", daprPath)
-		t.Log(output)
-		require.NoError(t, err, "init failed")
-		assert.Contains(t, output, "Success! Dapr is up and running.")
-
-		verifyContainers(t, daprRuntimeVersion)
-		verifyBinaries(t, daprPath, daprRuntimeVersion, daprDashboardVersion)
-		verifyConfigs(t, daprPath)
-	})
-
-	t.Run("init with DAPR_PATH env var", func(t *testing.T) {
-		// Ensure a clean environment
-		must(t, cmdUninstall, "failed to uninstall Dapr")
-
-		daprPath, err := os.MkdirTemp("", "dapr-e2e-init-with-env-var-*")
-		assert.NoError(t, err)
-		defer os.RemoveAll(daprPath) // clean up
-
-		t.Setenv("DAPR_PATH", daprPath)
-
-		output, err := cmdInit("--runtime-version", daprRuntimeVersion)
-		t.Log(output)
-		require.NoError(t, err, "init failed")
-		assert.Contains(t, output, "Success! Dapr is up and running.")
-
-		verifyContainers(t, daprRuntimeVersion)
-		verifyBinaries(t, daprPath, daprRuntimeVersion, daprDashboardVersion)
-		verifyConfigs(t, daprPath)
-	})
-
-	t.Run("init with --dapr-path flag and DAPR_PATH env var", func(t *testing.T) {
-		// Ensure a clean environment
-		must(t, cmdUninstall, "failed to uninstall Dapr")
-
-		daprPath1, err := os.MkdirTemp("", "dapr-e2e-init-with-flag-and-env-1-*")
-		assert.NoError(t, err)
-		defer os.RemoveAll(daprPath1) // clean up
-		daprPath2, err := os.MkdirTemp("", "dapr-e2e-init-with-flag-and-env-2-*")
-		assert.NoError(t, err)
-		defer os.RemoveAll(daprPath2) // clean up
-
-		t.Setenv("DAPR_PATH", daprPath1)
-
-		output, err := cmdInit("--runtime-version", daprRuntimeVersion, "--dapr-path", daprPath2)
-		t.Log(output)
-		require.NoError(t, err, "init failed")
-		assert.Contains(t, output, "Success! Dapr is up and running.")
-
-		verifyContainers(t, daprRuntimeVersion)
-		verifyBinaries(t, daprPath2, daprRuntimeVersion, daprDashboardVersion)
-		verifyConfigs(t, daprPath2)
-	})
-
 	t.Run("init without runtime-version flag", func(t *testing.T) {
 		// Ensure a clean environment
 		must(t, cmdUninstall, "failed to uninstall Dapr")

--- a/tests/e2e/standalone/run_test.go
+++ b/tests/e2e/standalone/run_test.go
@@ -18,12 +18,8 @@ package standalone_test
 
 import (
 	"fmt"
-	"os"
-	"path/filepath"
 	"runtime"
 	"testing"
-
-	"github.com/dapr/cli/tests/e2e/common"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -183,129 +179,5 @@ func TestStandaloneRun(t *testing.T) {
 		require.Contains(t, output, "Error: unknown flag: --flag\nUsage:", "expected usage to be printed")
 		require.Contains(t, output, "-a, --app-id string", "expected usage to be printed")
 		require.Contains(t, output, "The id for your application, used for service discovery", "expected usage to be printed")
-	})
-}
-
-func TestStandaloneRunNonDefaultDaprPath(t *testing.T) {
-	// Uninstall Dapr at the end of the test since it's being installed in a non-default location.
-	t.Cleanup(func() {
-		must(t, cmdUninstall, "failed to uninstall Dapr")
-	})
-
-	t.Run("run with flag", func(t *testing.T) {
-		// Ensure a clean environment
-		must(t, cmdUninstall, "failed to uninstall Dapr")
-
-		daprPath, err := os.MkdirTemp("", "dapr-e2e-run-with-flag-*")
-		assert.NoError(t, err)
-		defer os.RemoveAll(daprPath) // clean up
-
-		daprRuntimeVersion, _ := common.GetVersionsFromEnv(t, false)
-		output, err := cmdInit("--runtime-version", daprRuntimeVersion, "--dapr-path", daprPath)
-		t.Log(output)
-		require.NoError(t, err, "init failed")
-		assert.Contains(t, output, "Success! Dapr is up and running.")
-
-		args := []string{
-			"--dapr-path", daprPath,
-			"--app-id", "run_with_dapr_path_flag",
-			"--", "bash", "-c", "echo 'test'",
-		}
-
-		output, err = cmdRun("", args...)
-		t.Log(output)
-		require.NoError(t, err, "run failed")
-		assert.Contains(t, output, "Exited App successfully")
-		assert.Contains(t, output, "Exited Dapr successfully")
-
-		homeDir, err := os.UserHomeDir()
-		require.NoError(t, err, "failed to get user home directory")
-
-		defaultDaprPath := filepath.Join(homeDir, ".dapr")
-		assert.NoFileExists(t, defaultDaprPath)
-	})
-
-	t.Run("run with env var", func(t *testing.T) {
-		// Ensure a clean environment
-		must(t, cmdUninstall, "failed to uninstall Dapr")
-
-		daprPath, err := os.MkdirTemp("", "dapr-e2e-run-with-env-*")
-		assert.NoError(t, err)
-		defer os.RemoveAll(daprPath) // clean up
-
-		t.Setenv("DAPR_PATH", daprPath)
-
-		daprRuntimeVersion, _ := common.GetVersionsFromEnv(t, false)
-
-		output, err := cmdInit("--runtime-version", daprRuntimeVersion)
-		t.Log(output)
-		require.NoError(t, err, "init failed")
-		assert.Contains(t, output, "Success! Dapr is up and running.")
-
-		args := []string{
-			"--app-id", "run_with_dapr_path_flag",
-			"--", "bash", "-c", "echo 'test'",
-		}
-
-		output, err = cmdRun("", args...)
-		t.Log(output)
-		require.NoError(t, err, "run failed")
-		assert.Contains(t, output, "Exited App successfully")
-		assert.Contains(t, output, "Exited Dapr successfully")
-
-		homeDir, err := os.UserHomeDir()
-		require.NoError(t, err, "failed to get user home directory")
-
-		defaultDaprPath := filepath.Join(homeDir, ".dapr")
-		assert.NoFileExists(t, defaultDaprPath)
-	})
-
-	t.Run("run with both flag and env var", func(t *testing.T) {
-		// Ensure a clean environment
-		must(t, cmdUninstall, "failed to uninstall Dapr")
-
-		daprPathForEnv, err := os.MkdirTemp("", "dapr-e2e-run-with-envflag-1-*")
-		assert.NoError(t, err)
-		defer os.RemoveAll(daprPathForEnv) // clean up
-
-		daprPathForFlag, err := os.MkdirTemp("", "dapr-e2e-run-with-envflag-2-*")
-		assert.NoError(t, err)
-		defer os.RemoveAll(daprPathForFlag) // clean up
-
-		t.Setenv("DAPR_PATH", daprPathForEnv)
-
-		daprRuntimeVersion, _ := common.GetVersionsFromEnv(t, false)
-
-		output, err := cmdInit("--runtime-version", daprRuntimeVersion, "--dapr-path", daprPathForFlag)
-		t.Log(output)
-		require.NoError(t, err, "init failed")
-		assert.Contains(t, output, "Success! Dapr is up and running.")
-
-		args := []string{
-			"--dapr-path", daprPathForFlag,
-			"--app-id", "run_with_dapr_path_flag",
-			"--", "bash", "-c", "echo 'test'",
-		}
-
-		flagDaprdBinPath := filepath.Join(daprPathForFlag, "bin", "daprd")
-		if runtime.GOOS == "windows" {
-			flagDaprdBinPath += ".exe"
-		}
-		assert.FileExists(t, flagDaprdBinPath)
-
-		output, err = cmdRun("", args...)
-		t.Log(output)
-		require.NoError(t, err, "run failed")
-		assert.Contains(t, output, "Exited App successfully")
-		assert.Contains(t, output, "Exited Dapr successfully")
-
-		homeDir, err := os.UserHomeDir()
-		require.NoError(t, err, "failed to get user home directory")
-
-		defaultDaprPath := filepath.Join(homeDir, ".dapr")
-		assert.NoFileExists(t, defaultDaprPath)
-
-		envDaprBinPath := filepath.Join(daprPathForEnv, "bin")
-		assert.NoFileExists(t, envDaprBinPath)
 	})
 }

--- a/tests/e2e/standalone/version_test.go
+++ b/tests/e2e/standalone/version_test.go
@@ -18,13 +18,10 @@ package standalone_test
 
 import (
 	"encoding/json"
-	"os"
-	"path/filepath"
 	"strings"
 	"testing"
 
 	"github.com/dapr/cli/tests/e2e/common"
-
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -38,7 +35,10 @@ func TestStandaloneVersion(t *testing.T) {
 		lines := strings.Split(output, "\n")
 		assert.GreaterOrEqual(t, len(lines), 2, "expected at least 2 fields in components outptu")
 		assert.Contains(t, lines[0], "CLI version")
+		assert.Contains(t, lines[0], "edge")
 		assert.Contains(t, lines[1], "Runtime version")
+		runtimeVer, _ := common.GetVersionsFromEnv(t, false)
+		assert.Contains(t, lines[1], runtimeVer)
 	})
 
 	t.Run("version json", func(t *testing.T) {
@@ -48,109 +48,8 @@ func TestStandaloneVersion(t *testing.T) {
 		var result map[string]interface{}
 		err = json.Unmarshal([]byte(output), &result)
 		assert.NoError(t, err, "output was not valid JSON")
-	})
-}
-
-func TestStandaloneVersionNonDefaultDaprPath(t *testing.T) {
-	t.Cleanup(func() {
-		// remove dapr installation after all tests in this function.
-		must(t, cmdUninstall, "failed to uninstall Dapr")
-	})
-	t.Run("version with flag", func(t *testing.T) {
-		// Ensure a clean environment
-		must(t, cmdUninstall, "failed to uninstall Dapr")
-
-		daprPath, err := os.MkdirTemp("", "dapr-e2e-ver-with-flag-*")
-		assert.NoError(t, err)
-		defer os.RemoveAll(daprPath) // clean up
-
-		daprRuntimeVersion, _ := common.GetVersionsFromEnv(t, false)
-		output, err := cmdInit("--runtime-version", daprRuntimeVersion, "--dapr-path", daprPath)
-		t.Log(output)
-		require.NoError(t, err, "init failed")
-		assert.Contains(t, output, "Success! Dapr is up and running.")
-
-		output, err = cmdVersion("", "--dapr-path", daprPath)
-		t.Log(output)
-		require.NoError(t, err, "dapr version failed")
-		lines := strings.Split(output, "\n")
-		assert.GreaterOrEqual(t, len(lines), 2, "expected at least 2 fields in components outptu")
-		assert.Contains(t, lines[0], "CLI version")
-		assert.Contains(t, lines[1], "Runtime version")
-
-		homeDir, err := os.UserHomeDir()
-		require.NoError(t, err, "failed to get user home directory")
-
-		defaultDaprPath := filepath.Join(homeDir, ".dapr")
-		assert.NoFileExists(t, defaultDaprPath)
-	})
-
-	t.Run("version with env var", func(t *testing.T) {
-		// Ensure a clean environment
-		must(t, cmdUninstall, "failed to uninstall Dapr")
-
-		daprPath, err := os.MkdirTemp("", "dapr-e2e-ver-with-env-*")
-		assert.NoError(t, err)
-		defer os.RemoveAll(daprPath) // clean up
-
-		t.Setenv("DAPR_PATH", daprPath)
-
-		daprRuntimeVersion, _ := common.GetVersionsFromEnv(t, false)
-		output, err := cmdInit("--runtime-version", daprRuntimeVersion)
-		t.Log(output)
-		require.NoError(t, err, "init failed")
-		assert.Contains(t, output, "Success! Dapr is up and running.")
-
-		output, err = cmdVersion("")
-		t.Log(output)
-		require.NoError(t, err, "dapr version failed")
-		lines := strings.Split(output, "\n")
-		assert.GreaterOrEqual(t, len(lines), 2, "expected at least 2 fields in components outptu")
-		assert.Contains(t, lines[0], "CLI version")
-		assert.Contains(t, lines[1], "Runtime version")
-
-		homeDir, err := os.UserHomeDir()
-		require.NoError(t, err, "failed to get user home directory")
-
-		defaultDaprPath := filepath.Join(homeDir, ".dapr")
-		assert.NoFileExists(t, defaultDaprPath)
-	})
-
-	t.Run("version with both flag and env var", func(t *testing.T) {
-		// Ensure a clean environment
-		must(t, cmdUninstall, "failed to uninstall Dapr")
-
-		daprPath1, err := os.MkdirTemp("", "dapr-e2e-ver-with-both-flag-*")
-		assert.NoError(t, err)
-		defer os.RemoveAll(daprPath1) // clean up
-
-		daprPath2, err := os.MkdirTemp("", "dapr-e2e-ver-with-both-env-*")
-		assert.NoError(t, err)
-		defer os.RemoveAll(daprPath2) // clean up
-
-		t.Setenv("DAPR_PATH", daprPath2)
-
-		daprRuntimeVersion, _ := common.GetVersionsFromEnv(t, false)
-		output, err := cmdInit("--runtime-version", daprRuntimeVersion, "--dapr-path", daprPath1)
-		t.Log(output)
-		require.NoError(t, err, "init failed")
-		assert.Contains(t, output, "Success! Dapr is up and running.")
-
-		output, err = cmdVersion("", "--dapr-path", daprPath1)
-		t.Log(output)
-		require.NoError(t, err, "dapr version failed")
-		lines := strings.Split(output, "\n")
-		assert.GreaterOrEqual(t, len(lines), 2, "expected at least 2 fields in components outptu")
-		assert.Contains(t, lines[0], "CLI version")
-		assert.Contains(t, lines[1], "Runtime version")
-
-		homeDir, err := os.UserHomeDir()
-		require.NoError(t, err, "failed to get user home directory")
-
-		defaultDaprPath := filepath.Join(homeDir, ".dapr")
-		assert.NoFileExists(t, defaultDaprPath)
-
-		envDaprBinPath := filepath.Join(daprPath2, "bin")
-		assert.NoFileExists(t, envDaprBinPath)
+		assert.Contains(t, result["Cli version"], "edge")
+		runtimeVer, _ := common.GetVersionsFromEnv(t, false)
+		assert.Contains(t, result["Runtime version"], runtimeVer)
 	})
 }


### PR DESCRIPTION
# Description

Fix custom path installation logic.
Always install inside `.dapr` folder in the given input folder.
Added UTs for the same.

On uninstall only uninstall `.dapr` folder from the given input folder.
Custom path installation logic is `init check, version check, run command check, uninstall check` in order for 3 scenarios.
- `--runtime-path` flag is given 
- `DAPR_RUNTIME_PATH` env var is given
- Both flag and env var are given

Modified E2E. 

Fixed Version flag to work with `--runtime-path` flag and also version command to work with `--runtime-path` flag.
Modified Version E2E to check right output of version (edge for CLI and pinned version for runtime).

Added version command E2E for `--runtime-path`(as stated above).

related to https://github.com/dapr/cli/issues/1056

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: endgame

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Created/updated tests
* [x] Extended the documentation
