### PR TITLE
Adding more e2e tests for mariner images

### DIFF
--- a/tests/e2e/kubernetes/kubernetes_test.go
+++ b/tests/e2e/kubernetes/kubernetes_test.go
@@ -433,3 +433,38 @@ func TestKubernetesInstallwithoutRuntimeVersionFlag(t *testing.T) {
 		t.Run(tc.Name, tc.Callable)
 	}
 }
+
+func TestK8sInstallwithoutRuntimeVersionwithMarinerImagesFlag(t *testing.T) {
+	// ensure clean env for test
+	ensureCleanEnv(t, true)
+
+	//	install with mariner images
+	currentVersionDetails.ImageVariant = "mariner"
+
+	tests := []common.TestCase{}
+	installOpts := common.TestOptions{
+		HAEnabled:             false,
+		MTLSEnabled:           true,
+		ApplyComponentChanges: true,
+		CheckResourceExists: map[common.Resource]bool{
+			common.CustomResourceDefs:  true,
+			common.ClusterRoles:        true,
+			common.ClusterRoleBindings: true,
+		},
+	}
+
+	tests = append(tests, common.GetTestsOnInstall(currentVersionDetails, installOpts)...)
+
+	// teardown everything
+	tests = append(tests, common.GetTestsOnUninstall(currentVersionDetails, common.TestOptions{
+		CheckResourceExists: map[common.Resource]bool{
+			common.CustomResourceDefs:  true,
+			common.ClusterRoles:        false,
+			common.ClusterRoleBindings: false,
+		},
+	})...)
+
+	for _, tc := range tests {
+		t.Run(tc.Name, tc.Callable)
+	}
+}

--- a/tests/e2e/standalone/init_test.go
+++ b/tests/e2e/standalone/init_test.go
@@ -158,6 +158,29 @@ func TestStandaloneInit(t *testing.T) {
 		verifyBinaries(t, daprPath, latestDaprRuntimeVersion, latestDaprDashboardVersion)
 		verifyConfigs(t, daprPath)
 	})
+
+	t.Run("init without runtime-version flag with mariner images", func(t *testing.T) {
+		// Ensure a clean environment
+		must(t, cmdUninstall, "failed to uninstall Dapr")
+		args := []string{
+			"--image-variant", "mariner",
+		}
+		output, err := cmdInit(args...)
+		t.Log(output)
+		require.NoError(t, err, "init failed")
+		assert.Contains(t, output, "Success! Dapr is up and running.")
+
+		homeDir, err := os.UserHomeDir()
+		require.NoError(t, err, "failed to get user home directory")
+
+		daprPath := filepath.Join(homeDir, ".dapr")
+		require.DirExists(t, daprPath, "Directory %s does not exist", daprPath)
+
+		latestDaprRuntimeVersion, latestDaprDashboardVersion := common.GetVersionsFromEnv(t, true)
+		verifyContainers(t, latestDaprRuntimeVersion+"-mariner")
+		verifyBinaries(t, daprPath, latestDaprRuntimeVersion, latestDaprDashboardVersion)
+		verifyConfigs(t, daprPath)
+	})
 }
 
 // verifyContainers ensures that the correct containers are up and running.


### PR DESCRIPTION
Signed-off-by: Shivam Kumar <shivamkm07@gmail.com>

# Description

This PR adds the test for init with mariner images without using --runtime-version flag. 

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #_[issue number]_

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [ ] Extended the documentation
