### PR TITLE
E2e fix

### DIFF
--- a/.github/workflows/kind_e2e.yaml
+++ b/.github/workflows/kind_e2e.yaml
@@ -53,8 +53,8 @@ jobs:
       GOVER: 1.19.3
       DAPR_RUNTIME_PINNED_VERSION: 1.10.0-rc.4
       DAPR_DASHBOARD_PINNED_VERSION: 0.11.0
-      DAPR_RUNTIME_LATEST_VERSION:
-      DAPR_DASHBOARD_LATEST_VERSION:
+      DAPR_RUNTIME_LATEST_STABLE_VERSION:
+      DAPR_DASHBOARD_LATEST_STABLE_VERSION:
       DAPR_TGZ: dapr-1.10.0-rc.4.tgz
     strategy:
       fail-fast: false # Keep running if one leg fails.
@@ -131,37 +131,39 @@ jobs:
     - name: Free up some diskspace
       run: |
         docker image prune -a -f
-    - name: Determine latest stable Dapr Runtime version
+    - name: Determine latest Dapr Runtime version including Pre-releases
+      if: github.base_ref == 'master'
       run: |
-        export RUNTIME_VERSION=$(curl -s -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" https://api.github.com/repos/dapr/dapr/releases/latest | grep tag_name | awk -F':' '{print $2}' | tr -d '", ' | sed '/-/! s/$/_/' | sort -V | sed 's/_$//' | tr -d 'v' | tail -1)
+        export RUNTIME_VERSION=$(curl -s -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" https://api.github.com/repos/dapr/dapr/releases | grep tag_name | awk -F':' '{print $2}' | tr -d '", ' | sed '/-/! s/$/_/' | sort -V | sed 's/_$//' | tr -d 'v' | tail -1)
         if [[ -z "$RUNTIME_VERSION" ]]; then
-          echo "Could not fetch the latest Dapr Runtime version. Using default version $DAPR_RUNTIME_PINNED_VERSION"
-          echo "DAPR_RUNTIME_LATEST_VERSION=$DAPR_RUNTIME_PINNED_VERSION" >> $GITHUB_ENV
+          echo "Could not fetch the latest Dapr Runtime version. Using pinned version $DAPR_RUNTIME_PINNED_VERSION"
         else
           echo "Found $RUNTIME_VERSION"
-          echo "DAPR_RUNTIME_LATEST_VERSION=$RUNTIME_VERSION" >> $GITHUB_ENV
-          base_ref=${{ github.base_ref }}
-          echo "Branch $base_ref"
-          if [[ $base_ref = 'master' ]]; then
-            echo "DAPR_RUNTIME_PINNED_VERSION=$RUNTIME_VERSION" >> $GITHUB_ENV
-          fi
+          echo "DAPR_RUNTIME_PINNED_VERSION=$RUNTIME_VERSION" >> $GITHUB_ENV
         fi
+      shell: bash
+    - name: Determine latest Dapr Dashboard version including Pre-releases
+      if: github.base_ref == 'master'
+      run: |
+        export DASHBOARD_VERSION=$(curl -s -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" https://api.github.com/repos/dapr/dashboard/releases | grep tag_name | awk -F':' '{print $2}' | tr -d '", ' | sed '/-/! s/$/_/' | sort -V | sed 's/_$//' | tr -d 'v' | tail -1)
+        if [[ -z "$DASHBOARD_VERSION" ]]; then
+          echo "Could not fetch the latest Dapr Dashboard version. Using pinned version $DAPR_DASHBOARD_PINNED_VERSION"
+        else
+          echo "Found $DASHBOARD_VERSION"
+          echo "DAPR_DASHBOARD_PINNED_VERSION=$DASHBOARD_VERSION" >> $GITHUB_ENV
+        fi
+      shell: bash
+    - name: Determine latest stable Dapr Runtime version
+      run: |
+        export LATEST_STABLE_RUNTIME_VERSION=$(curl -s -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" https://api.github.com/repos/dapr/dapr/releases/latest | grep tag_name | awk -F':' '{print $2}' | tr -d '", ' | sed '/-/! s/$/_/' | sort -V | sed 's/_$//' | tr -d 'v' | tail -1)
+        echo "Found $LATEST_STABLE_RUNTIME_VERSION"
+        echo "DAPR_RUNTIME_LATEST_STABLE_VERSION=$LATEST_STABLE_RUNTIME_VERSION" >> $GITHUB_ENV
       shell: bash
     - name: Determine latest stable Dapr Dashboard version
       run: |
-        export DASHBOARD_VERSION=$(curl -s -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" https://api.github.com/repos/dapr/dashboard/releases/latest | grep tag_name | awk -F':' '{print $2}' | tr -d '", ' | sed '/-/! s/$/_/' | sort -V | sed 's/_$//' | tr -d 'v' | tail -1)
-        if [[ -z "$DASHBOARD_VERSION" ]]; then
-          echo "Could not fetch the latest Dapr Dashboard version. Using default version $DAPR_DASHBOARD_PINNED_VERSION"
-          echo "DAPR_DASHBOARD_LATEST_VERSION=$DAPR_DASHBOARD_PINNED_VERSION" >> $GITHUB_ENV
-        else
-          echo "Found $DASHBOARD_VERSION"
-          echo "DAPR_DASHBOARD_LATEST_VERSION=$DASHBOARD_VERSION" >> $GITHUB_ENV
-          base_ref=${{ github.base_ref }}
-          echo "Branch $base_ref"
-          if [[ $base_ref = 'master' ]]; then
-            echo "DAPR_DASHBOARD_PINNED_VERSION=$DASHBOARD_VERSION" >> $GITHUB_ENV
-          fi
-        fi
+        export LATEST_STABLE_DASHBOARD_VERSION=$(curl -s -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" https://api.github.com/repos/dapr/dashboard/releases/latest | grep tag_name | awk -F':' '{print $2}' | tr -d '", ' | sed '/-/! s/$/_/' | sort -V | sed 's/_$//' | tr -d 'v' | tail -1)
+        echo "Found $LATEST_STABLE_DASHBOARD_VERSION"
+        echo "DAPR_DASHBOARD_LATEST_STABLE_VERSION=$LATEST_STABLE_DASHBOARD_VERSION" >> $GITHUB_ENV
       shell: bash
     - name: Run tests with GHCR
       # runs every 6hrs

--- a/.github/workflows/self_hosted_e2e.yaml
+++ b/.github/workflows/self_hosted_e2e.yaml
@@ -146,4 +146,6 @@ jobs:
         uses: actions/upload-artifact@master
         with:
           name: ${{ matrix.target_os }}_${{ matrix.target_arch }}_e2e_standalone.json
-          path: ${{ env.TEST_OUTPUT_FILE }}
+          path: |
+            ${{ env.TEST_OUTPUT_FILE }}
+            $GITHUB_WORKSPACE/tests/apps/**/*.log

--- a/.github/workflows/self_hosted_e2e.yaml
+++ b/.github/workflows/self_hosted_e2e.yaml
@@ -42,8 +42,8 @@ jobs:
       ARCHIVE_OUTDIR: dist/archives
       DAPR_RUNTIME_PINNED_VERSION: "1.10.0-rc.4"
       DAPR_DASHBOARD_PINNED_VERSION: 0.11.0
-      DAPR_RUNTIME_LATEST_VERSION:
-      DAPR_DASHBOARD_LATEST_VERSION:
+      DAPR_RUNTIME_LATEST_STABLE_VERSION:
+      DAPR_DASHBOARD_LATEST_STABLE_VERSION:
     strategy:
       matrix:
         os: [macos-latest, ubuntu-latest, windows-latest]
@@ -78,37 +78,39 @@ jobs:
           podman machine init
           podman machine start
           echo "CONTAINER_RUNTIME=podman" >> $GITHUB_ENV
-      - name: Determine latest stable Dapr Runtime version
+      - name: Determine latest Dapr Runtime version including Pre-releases
+        if: github.base_ref == 'master'
         run: |
-          export RUNTIME_VERSION=$(curl -s -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" https://api.github.com/repos/dapr/dapr/releases/latest | grep tag_name | awk -F':' '{print $2}' | tr -d '", ' | sed '/-/! s/$/_/' | sort -V | sed 's/_$//' | tr -d 'v' | tail -1)
+          export RUNTIME_VERSION=$(curl -s -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" https://api.github.com/repos/dapr/dapr/releases | grep tag_name | awk -F':' '{print $2}' | tr -d '", ' | sed '/-/! s/$/_/' | sort -V | sed 's/_$//' | tr -d 'v' | tail -1)
           if [[ -z "$RUNTIME_VERSION" ]]; then
-            echo "Could not fetch the latest Dapr Runtime version. Using default version $DAPR_RUNTIME_PINNED_VERSION"
-            echo "DAPR_RUNTIME_LATEST_VERSION=$DAPR_RUNTIME_PINNED_VERSION" >> $GITHUB_ENV
+            echo "Could not fetch the latest Dapr Runtime version. Using pinned version $DAPR_RUNTIME_PINNED_VERSION"
           else
             echo "Found $RUNTIME_VERSION"
-            echo "DAPR_RUNTIME_LATEST_VERSION=$RUNTIME_VERSION" >> $GITHUB_ENV
-            base_ref=${{ github.base_ref }}
-            echo "Branch $base_ref"
-            if [[ $base_ref = 'master' ]]; then
-              echo "DAPR_RUNTIME_PINNED_VERSION=$RUNTIME_VERSION" >> $GITHUB_ENV
-            fi
+            echo "DAPR_RUNTIME_PINNED_VERSION=$RUNTIME_VERSION" >> $GITHUB_ENV
           fi
+        shell: bash
+      - name: Determine latest Dapr Dashboard version including Pre-releases
+        if: github.base_ref == 'master'
+        run: |
+          export DASHBOARD_VERSION=$(curl -s -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" https://api.github.com/repos/dapr/dashboard/releases | grep tag_name | awk -F':' '{print $2}' | tr -d '", ' | sed '/-/! s/$/_/' | sort -V | sed 's/_$//' | tr -d 'v' | tail -1)
+          if [[ -z "$DASHBOARD_VERSION" ]]; then
+            echo "Could not fetch the latest Dapr Dashboard version. Using pinned version $DAPR_DASHBOARD_PINNED_VERSION"
+          else
+            echo "Found $DASHBOARD_VERSION"
+            echo "DAPR_DASHBOARD_PINNED_VERSION=$DASHBOARD_VERSION" >> $GITHUB_ENV
+          fi
+        shell: bash
+      - name: Determine latest stable Dapr Runtime version
+        run: |
+          export LATEST_STABLE_RUNTIME_VERSION=$(curl -s -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" https://api.github.com/repos/dapr/dapr/releases/latest | grep tag_name | awk -F':' '{print $2}' | tr -d '", ' | sed '/-/! s/$/_/' | sort -V | sed 's/_$//' | tr -d 'v' | tail -1)
+          echo "Found $LATEST_STABLE_RUNTIME_VERSION"
+          echo "DAPR_RUNTIME_LATEST_STABLE_VERSION=$LATEST_STABLE_RUNTIME_VERSION" >> $GITHUB_ENV
         shell: bash
       - name: Determine latest stable Dapr Dashboard version
         run: |
-          export DASHBOARD_VERSION=$(curl -s -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" https://api.github.com/repos/dapr/dashboard/releases/latest | grep tag_name | awk -F':' '{print $2}' | tr -d '", ' | sed '/-/! s/$/_/' | sort -V | sed 's/_$//' | tr -d 'v' | tail -1)
-          if [[ -z "$DASHBOARD_VERSION" ]]; then
-            echo "Could not fetch the latest Dapr Dashboard version. Using default version $DAPR_DASHBOARD_PINNED_VERSION"
-            echo "DAPR_DASHBOARD_LATEST_VERSION=$DAPR_DASHBOARD_PINNED_VERSION" >> $GITHUB_ENV
-          else
-            echo "Found $DASHBOARD_VERSION"
-            echo "DAPR_DASHBOARD_LATEST_VERSION=$DASHBOARD_VERSION" >> $GITHUB_ENV
-            base_ref=${{ github.base_ref }}
-            echo "Branch $base_ref"
-            if [[ $base_ref = 'master' ]]; then
-              echo "DAPR_DASHBOARD_PINNED_VERSION=$DASHBOARD_VERSION" >> $GITHUB_ENV
-            fi
-          fi
+          export LATEST_STABLE_DASHBOARD_VERSION=$(curl -s -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" https://api.github.com/repos/dapr/dashboard/releases/latest | grep tag_name | awk -F':' '{print $2}' | tr -d '", ' | sed '/-/! s/$/_/' | sort -V | sed 's/_$//' | tr -d 'v' | tail -1)
+          echo "Found $LATEST_STABLE_DASHBOARD_VERSION"
+          echo "DAPR_DASHBOARD_LATEST_STABLE_VERSION=$LATEST_STABLE_DASHBOARD_VERSION" >> $GITHUB_ENV
         shell: bash
       - name: Set the test timeout - MacOS
         if: matrix.os == 'macos-latest'

--- a/.github/workflows/self_hosted_e2e.yaml
+++ b/.github/workflows/self_hosted_e2e.yaml
@@ -146,6 +146,4 @@ jobs:
         uses: actions/upload-artifact@master
         with:
           name: ${{ matrix.target_os }}_${{ matrix.target_arch }}_e2e_standalone.json
-          path: |
-            ${{ env.TEST_OUTPUT_FILE }}
-            $GITHUB_WORKSPACE/tests/apps/**/*.log
+          path: ${{ env.TEST_OUTPUT_FILE }}

--- a/tests/e2e/common/common.go
+++ b/tests/e2e/common/common.go
@@ -329,7 +329,10 @@ func StatusTestOnInstallUpgrade(details VersionDetails, opts TestOptions) func(t
 					require.Equal(t, "True", cols[2], "healthly field must be true")
 					require.Equal(t, "Running", cols[3], "pods must be Running")
 					require.Equal(t, toVerify[1], cols[4], "replicas must be equal")
-					require.Equal(t, toVerify[0], cols[5], "versions must match")
+					// TODO: Skip the dashboard version check for now until the helm chart is updated.
+					if cols[0] != "dapr-dashboard" {
+						require.Equal(t, toVerify[0], cols[5], "versions must match")
+					}
 					delete(notFound, cols[0])
 				}
 			}
@@ -708,7 +711,8 @@ func installTest(details VersionDetails, opts TestOptions) func(t *testing.T) {
 			"--log-as-json",
 		}
 		if !details.UseDaprLatestVersion {
-			args = append(args, "--runtime-version", details.RuntimeVersion, "--dashboard-version", details.DashboardVersion)
+			// TODO: Pass dashboard-version also when charts are released.
+			args = append(args, "--runtime-version", details.RuntimeVersion)
 		}
 		if opts.HAEnabled {
 			args = append(args, "--enable-ha")
@@ -864,9 +868,9 @@ func validatePodsOnInstallUpgrade(t *testing.T, details VersionDetails) {
 	require.NoError(t, err)
 
 	notFound := map[string]string{
-		"sentry":    details.RuntimeVersion,
-		"sidecar":   details.RuntimeVersion,
-		"dashboard": details.DashboardVersion,
+		"sentry":  details.RuntimeVersion,
+		"sidecar": details.RuntimeVersion,
+		// "dashboard": details.DashboardVersion, TODO: enable when helm charts are updated.
 		"placement": details.RuntimeVersion,
 		"operator":  details.RuntimeVersion,
 	}
@@ -879,9 +883,9 @@ func validatePodsOnInstallUpgrade(t *testing.T, details VersionDetails) {
 	}
 
 	prefixes := map[string]string{
-		"sentry":    "dapr-sentry-",
-		"sidecar":   "dapr-sidecar-injector-",
-		"dashboard": "dapr-dashboard-",
+		"sentry":  "dapr-sentry-",
+		"sidecar": "dapr-sidecar-injector-",
+		// "dashboard": "dapr-dashboard-", TODO: enable when helm charts are updated.
 		"placement": "dapr-placement-server-",
 		"operator":  "dapr-operator-",
 	}

--- a/tests/e2e/common/common.go
+++ b/tests/e2e/common/common.go
@@ -708,7 +708,7 @@ func installTest(details VersionDetails, opts TestOptions) func(t *testing.T) {
 			"--log-as-json",
 		}
 		if !details.UseDaprLatestVersion {
-			args = append(args, "--runtime-version", details.RuntimeVersion)
+			args = append(args, "--runtime-version", details.RuntimeVersion, "--dashboard-version", details.DashboardVersion)
 		}
 		if opts.HAEnabled {
 			args = append(args, "--enable-ha")

--- a/tests/e2e/common/common.go
+++ b/tests/e2e/common/common.go
@@ -80,8 +80,8 @@ func GetVersionsFromEnv(t *testing.T, latest bool) (string, string) {
 	runtimeEnvVar := "DAPR_RUNTIME_PINNED_VERSION"
 	dashboardEnvVar := "DAPR_DASHBOARD_PINNED_VERSION"
 	if latest {
-		runtimeEnvVar = "DAPR_RUNTIME_LATEST_VERSION"
-		dashboardEnvVar = "DAPR_DASHBOARD_LATEST_VERSION"
+		runtimeEnvVar = "DAPR_RUNTIME_LATEST_STABLE_VERSION"
+		dashboardEnvVar = "DAPR_DASHBOARD_LATEST_STABLE_VERSION"
 	}
 	if runtimeVersion, ok := os.LookupEnv(runtimeEnvVar); ok {
 		daprRuntimeVersion = runtimeVersion

--- a/tests/e2e/standalone/init_run_custom_path_test.go
+++ b/tests/e2e/standalone/init_run_custom_path_test.go
@@ -37,8 +37,13 @@ func TestStandaloneInitRunUninstallNonDefaultDaprPath(t *testing.T) {
 		assert.NoError(t, err)
 		defer os.RemoveAll(daprPath) // clean up
 
-		daprRuntimeVersion, _ := common.GetVersionsFromEnv(t, false)
-		output, err := cmdInit("--runtime-version", daprRuntimeVersion, "--runtime-path", daprPath)
+		daprRuntimeVersion, daprDashboardVersion := common.GetVersionsFromEnv(t, false)
+		args := []string{
+			"--runtime-version", daprRuntimeVersion,
+			"--dashboard-version", daprDashboardVersion,
+			"--runtime-path", daprPath,
+		}
+		output, err := cmdInit(args...)
 		t.Log(output)
 		require.NoError(t, err, "init failed")
 		assert.Contains(t, output, "Success! Dapr is up and running.")
@@ -54,7 +59,7 @@ func TestStandaloneInitRunUninstallNonDefaultDaprPath(t *testing.T) {
 		assert.Contains(t, lines[1], "Runtime version")
 		assert.Contains(t, lines[1], daprRuntimeVersion)
 
-		args := []string{
+		args = []string{
 			"--runtime-path", daprPath,
 			"--app-id", "run_with_dapr_runtime_path_flag",
 			"--", "bash", "-c", "echo 'test'",
@@ -90,9 +95,12 @@ func TestStandaloneInitRunUninstallNonDefaultDaprPath(t *testing.T) {
 
 		t.Setenv("DAPR_RUNTIME_PATH", daprPath)
 
-		daprRuntimeVersion, _ := common.GetVersionsFromEnv(t, false)
-
-		output, err := cmdInit("--runtime-version", daprRuntimeVersion)
+		daprRuntimeVersion, daprDashboardVersion := common.GetVersionsFromEnv(t, false)
+		args := []string{
+			"--runtime-version", daprRuntimeVersion,
+			"--dashboard-version", daprDashboardVersion,
+		}
+		output, err := cmdInit(args...)
 		t.Log(output)
 		require.NoError(t, err, "init failed")
 		assert.Contains(t, output, "Success! Dapr is up and running.")
@@ -108,7 +116,7 @@ func TestStandaloneInitRunUninstallNonDefaultDaprPath(t *testing.T) {
 		assert.Contains(t, lines[1], "Runtime version")
 		assert.Contains(t, lines[1], daprRuntimeVersion)
 
-		args := []string{
+		args = []string{
 			"--app-id", "run_with_dapr_runtime_path_flag",
 			"--", "bash", "-c", "echo 'test'",
 		}
@@ -147,9 +155,13 @@ func TestStandaloneInitRunUninstallNonDefaultDaprPath(t *testing.T) {
 
 		t.Setenv("DAPR_RUNTIME_PATH", daprPathEnv)
 
-		daprRuntimeVersion, _ := common.GetVersionsFromEnv(t, false)
-
-		output, err := cmdInit("--runtime-version", daprRuntimeVersion, "--runtime-path", daprPathFlag)
+		daprRuntimeVersion, daprDashboardVersion := common.GetVersionsFromEnv(t, false)
+		args := []string{
+			"--runtime-version", daprRuntimeVersion,
+			"--dashboard-version", daprDashboardVersion,
+			"--runtime-path", daprPathFlag,
+		}
+		output, err := cmdInit(args...)
 		t.Log(output)
 		require.NoError(t, err, "init failed")
 		assert.Contains(t, output, "Success! Dapr is up and running.")
@@ -165,7 +177,7 @@ func TestStandaloneInitRunUninstallNonDefaultDaprPath(t *testing.T) {
 		assert.Contains(t, lines[1], "Runtime version")
 		assert.Contains(t, lines[1], daprRuntimeVersion)
 
-		args := []string{
+		args = []string{
 			"--runtime-path", daprPathFlag,
 			"--app-id", "run_with_dapr_runtime_path_flag",
 			"--", "bash", "-c", "echo 'test'",

--- a/tests/e2e/standalone/init_test.go
+++ b/tests/e2e/standalone/init_test.go
@@ -50,6 +50,7 @@ func TestStandaloneInit(t *testing.T) {
 		must(t, cmdUninstall, "failed to uninstall Dapr")
 		args := []string{
 			"--runtime-version", daprRuntimeVersion,
+			"--dashboard-version", daprDashboardVersion,
 			"--image-registry", "smplregistry.io/owner",
 		}
 		output, err := cmdInit(args...)
@@ -66,6 +67,7 @@ func TestStandaloneInit(t *testing.T) {
 		must(t, cmdUninstall, "failed to uninstall Dapr")
 		args := []string{
 			"--runtime-version", daprRuntimeVersion,
+			"--dashboard-version", daprDashboardVersion,
 			"--image-registry", "localhost:5000",
 			"--from-dir", "./local-dir",
 		}
@@ -79,6 +81,7 @@ func TestStandaloneInit(t *testing.T) {
 		must(t, cmdUninstall, "failed to uninstall Dapr")
 		args := []string{
 			"--runtime-version", daprRuntimeVersion,
+			"--dashboard-version", daprDashboardVersion,
 			"--container-runtime", "invalid",
 		}
 		output, err := cmdInit(args...)
@@ -92,6 +95,7 @@ func TestStandaloneInit(t *testing.T) {
 
 		args := []string{
 			"--runtime-version", daprRuntimeVersion,
+			"--dashboard-version", daprDashboardVersion,
 		}
 		output, err := cmdInit(args...)
 		t.Log(output)
@@ -115,6 +119,7 @@ func TestStandaloneInit(t *testing.T) {
 
 		args := []string{
 			"--runtime-version", daprRuntimeVersion,
+			"--dashboard-version", daprDashboardVersion,
 			"--image-variant", "mariner",
 		}
 		output, err := cmdInit(args...)

--- a/tests/e2e/standalone/utils.go
+++ b/tests/e2e/standalone/utils.go
@@ -125,7 +125,7 @@ func executeAgainstRunningDapr(t *testing.T, f func(), daprArgs ...string) {
 // ensureDaprInstallation ensures that Dapr is installed.
 // If Dapr is not installed, a new installation is attempted.
 func ensureDaprInstallation(t *testing.T) {
-	daprRuntimeVersion, _ := common.GetVersionsFromEnv(t, false)
+	daprRuntimeVersion, daprDashboardVersion := common.GetVersionsFromEnv(t, false)
 	homeDir, err := os.UserHomeDir()
 	require.NoError(t, err, "failed to get user home directory")
 
@@ -134,6 +134,7 @@ func ensureDaprInstallation(t *testing.T) {
 	if os.IsNotExist(err) {
 		args := []string{
 			"--runtime-version", daprRuntimeVersion,
+			"--dashboard-version", daprDashboardVersion,
 		}
 		output, err := cmdInit(args...)
 		require.NoError(t, err, "failed to install dapr:%v", output)


### PR DESCRIPTION
Signed-off-by: Pravin Pushkar [ppushkar@microsoft.com](mailto:ppushkar@microsoft.com)

# Description

- separate pinned versions for dapr and dashboard from stable version being used for `dapr init` w/o `runtime-version`
- pass dashboard version also to `dapr init` when running tests on pinned versions
- disable dashboard version check for k8s (helm charts are not updated)
