### PR TITLE
Fix unexpected behaviour in dapr list

### DIFF
--- a/pkg/standalone/list.go
+++ b/pkg/standalone/list.go
@@ -21,10 +21,11 @@ import (
 	ps "github.com/mitchellh/go-ps"
 	process "github.com/shirou/gopsutil/process"
 
+	"github.com/dapr/dapr/pkg/runtime"
+
 	"github.com/dapr/cli/pkg/age"
 	"github.com/dapr/cli/pkg/metadata"
 	"github.com/dapr/cli/utils"
-	"github.com/dapr/dapr/pkg/runtime"
 )
 
 // ListOutput represents the application ID, application port and creation time.
@@ -77,9 +78,16 @@ func List() ([]ListOutput, error) {
 				continue
 			}
 
+			// Parse command line arguments. `daprd --flag1 value1 --enable-flag2 --flag3 value3`
 			argumentsMap := make(map[string]string)
-			for i := 1; i < len(cmdLineItems)-1; i += 2 {
-				argumentsMap[cmdLineItems[i]] = cmdLineItems[i+1]
+			for i := 1; i < len(cmdLineItems)-1; {
+				if !strings.HasPrefix(cmdLineItems[i+1], "--") {
+					argumentsMap[cmdLineItems[i]] = cmdLineItems[i+1]
+					i += 2
+				} else {
+					argumentsMap[cmdLineItems[i]] = ""
+					i++
+				}
 			}
 
 			httpPort := getIntArg(argumentsMap, "--dapr-http-port", runtime.DefaultDaprHTTPPort)

--- a/pkg/standalone/list.go
+++ b/pkg/standalone/list.go
@@ -78,7 +78,7 @@ func List() ([]ListOutput, error) {
 				continue
 			}
 
-			// Parse command line arguments. `daprd --flag1 value1 --enable-flag2 --flag3 value3`
+			// Parse command line arguments, example format for cmdLine `daprd --flag1 value1 --enable-flag2 --flag3 value3`.
 			argumentsMap := make(map[string]string)
 			for i := 1; i < len(cmdLineItems)-1; {
 				if !strings.HasPrefix(cmdLineItems[i+1], "--") {

--- a/tests/e2e/standalone/list_test.go
+++ b/tests/e2e/standalone/list_test.go
@@ -99,7 +99,7 @@ func TestStandaloneList(t *testing.T) {
 	})
 
 	t.Run("daprd instance started by run in list", func(t *testing.T) {
-		runoutput, err := cmdRun("", "--app-id", "dapr_e2e_list", "--dapr-http-port", "3555", "--dapr-grpc-port", "4555", "--app-port", "0", "--enable-app-health-check", "--", "bash", "-c", "sleep 5; exit 1")
+		runoutput, err := cmdRun("", "--app-id", "dapr_e2e_list", "--dapr-http-port", "3555", "--dapr-grpc-port", "4555", "--app-port", "0", "--enable-app-health-check", "--", "bash", "-c", "sleep 5; exit 0")
 		t.Log(runoutput)
 		require.NoError(t, err, "run failed")
 

--- a/tests/e2e/standalone/list_test.go
+++ b/tests/e2e/standalone/list_test.go
@@ -25,6 +25,7 @@ import (
 	"runtime"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -95,6 +96,20 @@ func TestStandaloneList(t *testing.T) {
 		}
 
 		cmd.Process.Kill()
+	})
+
+	t.Run("daprd instance started by run in list", func(t *testing.T) {
+		runoutput, err := cmdRun("", "--app-id", "dapr_e2e_list", "--dapr-http-port", "3555", "--dapr-grpc-port", "4555", "--app-port", "0", "--enable-app-health-check", "--", "bash", "-c", "sleep 5; exit 1")
+		t.Log(runoutput)
+		require.NoError(t, err, "run failed")
+
+		output, err := cmdList("")
+		t.Log(output)
+		require.NoError(t, err, "dapr list failed with dapr run instance")
+		listOutputCheck(t, output, true)
+		// daprd starts and sleep for 5s, this ensures daprd started by `dapr run ...` is stopped
+		time.Sleep(5 * time.Second)
+		assert.Contains(t, output, "Exited Dapr successfully")
 	})
 
 	t.Run("dashboard instance should not be listed", func(t *testing.T) {

--- a/tests/e2e/standalone/list_test.go
+++ b/tests/e2e/standalone/list_test.go
@@ -99,17 +99,24 @@ func TestStandaloneList(t *testing.T) {
 	})
 
 	t.Run("daprd instance started by run in list", func(t *testing.T) {
-		runoutput, err := cmdRun("", "--app-id", "dapr_e2e_list", "--dapr-http-port", "3555", "--dapr-grpc-port", "4555", "--app-port", "0", "--enable-app-health-check", "--", "bash", "-c", "sleep 5; exit 0")
-		t.Log(runoutput)
-		require.NoError(t, err, "run failed")
+		go func() {
+			// starts dapr run in a goroutine
+			runoutput, err := cmdRun("", "--app-id", "dapr_e2e_list", "--dapr-http-port", "3555", "--dapr-grpc-port", "4555", "--app-port", "0", "--enable-app-health-check", "--", "bash", "-c", "sleep 15; exit 0")
+			t.Log(runoutput)
+			require.NoError(t, err, "run failed")
+			// daprd starts and sleep for 50s, this ensures daprd started by `dapr run ...` is stopped
+			time.Sleep(15 * time.Second)
+			assert.Contains(t, runoutput, "Exited Dapr successfully")
+		}()
 
+		// wait for daprd to start
+		time.Sleep(time.Second)
 		output, err := cmdList("")
 		t.Log(output)
 		require.NoError(t, err, "dapr list failed with dapr run instance")
 		listOutputCheck(t, output, true)
-		// daprd starts and sleep for 5s, this ensures daprd started by `dapr run ...` is stopped
-		time.Sleep(5 * time.Second)
-		assert.Contains(t, output, "Exited Dapr successfully")
+		// sleep to wait dapr run exit, in case have effect on other tests
+		time.Sleep(15 * time.Second)
 	})
 
 	t.Run("dashboard instance should not be listed", func(t *testing.T) {


### PR DESCRIPTION
# Description

In previous version dapr run puts the `--enable-app-health-check` at the end of the args list, while 1.10 put it in the middle. Below is an example of the command dapr starts daprd.
```
# previous
/root/.dapr/bin/daprd --app-id Watcherswift-Carp --app-port 3000 --dapr-http-port 41309 --dapr-grpc-port 39479 --config /root/.dapr/config.yaml --app-protocol http --profile-port -1 --log-level info --app-max-concurrency -1 --placement-host-address localhost:50005 --components-path /root/.dapr/components --metrics-port 33949 --dapr-http-max-request-size -1 --dapr-http-read-buffer-size -1 --dapr-internal-grpc-port 44463 --enable-app-health-check

#now
/root/.dapr/bin/daprd --config /root/.dapr/config.yaml --app-protocol http --log-level info --app-max-concurrency -1 --placement-host-address localhost:50005 --components-path /root/.dapr/components --dapr-http-max-request-size -1 --dapr-http-read-buffer-size -1 --enable-app-health-check --app-id herogreat-buffalo --app-port 3000 --dapr-http-port 35985 --dapr-grpc-port 43717 --profile-port -1 --metrics-port 46873 --dapr-internal-grpc-port 43069
```

I changed the args parse to fit these flag without params.

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #1241

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Created/updated tests
* [ ] Extended the documentation
