### PR TITLE
Show correct container runtime in init logging

### DIFF
--- a/pkg/standalone/standalone.go
+++ b/pkg/standalone/standalone.go
@@ -32,6 +32,8 @@ import (
 	"time"
 
 	"github.com/fatih/color"
+	"golang.org/x/text/cases"
+	"golang.org/x/text/language"
 	"gopkg.in/yaml.v2"
 
 	"github.com/dapr/cli/pkg/print"
@@ -164,7 +166,8 @@ func Init(runtimeVersion, dashboardVersion string, dockerNetwork string, slimMod
 		// If --slim installation is not requested, check if docker is installed.
 		conatinerRuntimeAvailable := utils.IsDockerInstalled() || utils.IsPodmanInstalled()
 		if !conatinerRuntimeAvailable {
-			return errors.New("could not connect to Docker. Docker may not be installed or running")
+			caser := cases.Title(language.English)
+			return fmt.Errorf("could not connect to %s. %s may not be installed or running", caser.String(containerRuntime), caser.String(containerRuntime))
 		}
 
 		// Initialize default registry only if any of --slim or --image-registry or --from-dir are not given.

--- a/pkg/standalone/standalone.go
+++ b/pkg/standalone/standalone.go
@@ -32,8 +32,6 @@ import (
 	"time"
 
 	"github.com/fatih/color"
-	"golang.org/x/text/cases"
-	"golang.org/x/text/language"
 	"gopkg.in/yaml.v2"
 
 	"github.com/dapr/cli/pkg/print"
@@ -166,8 +164,7 @@ func Init(runtimeVersion, dashboardVersion string, dockerNetwork string, slimMod
 		// If --slim installation is not requested, check if docker is installed.
 		conatinerRuntimeAvailable := utils.IsDockerInstalled() || utils.IsPodmanInstalled()
 		if !conatinerRuntimeAvailable {
-			caser := cases.Title(language.English)
-			return fmt.Errorf("could not connect to %s. %s may not be installed or running", caser.String(containerRuntime), caser.String(containerRuntime))
+			return fmt.Errorf("could not connect to %s. %s may not be installed or running", containerRuntime, containerRuntime)
 		}
 
 		// Initialize default registry only if any of --slim or --image-registry or --from-dir are not given.

--- a/pkg/standalone/standalone_test.go
+++ b/pkg/standalone/standalone_test.go
@@ -14,7 +14,6 @@ limitations under the License.
 package standalone
 
 import (
-	"fmt"
 	"os"
 	"testing"
 
@@ -317,16 +316,17 @@ func TestInitLogActualContainerRuntimeName(t *testing.T) {
 	tests := []struct {
 		containerRuntime string
 		expected         string
+		testName         string
 	}{
-		{"podman", "Podman"},
-		{"docker", "Docker"},
+		{"podman", "Podman", "Init should log Podman as container runtime"},
+		{"docker", "Docker", "Init should log Docker as container runtime"},
 	}
 	conatinerRuntimeAvailable := utils.IsDockerInstalled() || utils.IsPodmanInstalled()
 	if conatinerRuntimeAvailable {
 		t.Skip("Skipping test as container runtime is available")
 	}
 	for _, test := range tests {
-		t.Run(fmt.Sprintf("Init should log with %s as container runtime name", test.containerRuntime), func(t *testing.T) {
+		t.Run(test.testName, func(t *testing.T) {
 			err := Init(latestVersion, latestVersion, "", false, "", "", test.containerRuntime, "", "")
 			assert.NotNil(t, err)
 			assert.Contains(t, err.Error(), test.expected)

--- a/pkg/standalone/standalone_test.go
+++ b/pkg/standalone/standalone_test.go
@@ -14,9 +14,11 @@ limitations under the License.
 package standalone
 
 import (
+	"fmt"
 	"os"
 	"testing"
 
+	"github.com/dapr/cli/utils"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -308,5 +310,27 @@ func TestIsAirGapInit(t *testing.T) {
 			setAirGapInit(test.fromDir)
 			assert.Equal(t, test.expect, isAirGapInit)
 		})
+	}
+}
+
+func TestInitLogActualContainerRuntimeName(t *testing.T) {
+	tests := []struct {
+		containerRuntime string
+		expected         string
+	}{
+		{"podman", "Podman"},
+		{"docker", "Docker"},
+	}
+	conatinerRuntimeAvailable := utils.IsDockerInstalled() || utils.IsPodmanInstalled()
+	if conatinerRuntimeAvailable {
+		t.Skip("Skipping test as container runtime is available")
+	}
+	for _, test := range tests {
+		t.Run(fmt.Sprintf("Init should log with %s as container runtime name", test.containerRuntime), func(t *testing.T) {
+			err := Init(latestVersion, latestVersion, "", false, "", "", test.containerRuntime, "", "")
+			assert.NotNil(t, err)
+			assert.Contains(t, err.Error(), test.expected)
+		})
+
 	}
 }

--- a/pkg/standalone/standalone_test.go
+++ b/pkg/standalone/standalone_test.go
@@ -315,11 +315,10 @@ func TestIsAirGapInit(t *testing.T) {
 func TestInitLogActualContainerRuntimeName(t *testing.T) {
 	tests := []struct {
 		containerRuntime string
-		expected         string
 		testName         string
 	}{
-		{"podman", "Podman", "Init should log Podman as container runtime"},
-		{"docker", "Docker", "Init should log Docker as container runtime"},
+		{"podman", "Init should log podman as container runtime"},
+		{"docker", "Init should log docker as container runtime"},
 	}
 	conatinerRuntimeAvailable := utils.IsDockerInstalled() || utils.IsPodmanInstalled()
 	if conatinerRuntimeAvailable {
@@ -329,7 +328,7 @@ func TestInitLogActualContainerRuntimeName(t *testing.T) {
 		t.Run(test.testName, func(t *testing.T) {
 			err := Init(latestVersion, latestVersion, "", false, "", "", test.containerRuntime, "", "")
 			assert.NotNil(t, err)
-			assert.Contains(t, err.Error(), test.expected)
+			assert.Contains(t, err.Error(), test.containerRuntime)
 		})
 
 	}

--- a/pkg/standalone/standalone_test.go
+++ b/pkg/standalone/standalone_test.go
@@ -17,8 +17,9 @@ import (
 	"os"
 	"testing"
 
-	"github.com/dapr/cli/utils"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/dapr/cli/utils"
 )
 
 func TestStandaloneConfig(t *testing.T) {
@@ -330,6 +331,5 @@ func TestInitLogActualContainerRuntimeName(t *testing.T) {
 			assert.NotNil(t, err)
 			assert.Contains(t, err.Error(), test.containerRuntime)
 		})
-
 	}
 }


### PR DESCRIPTION
# Description

Init logging now logs using container runtime specified by the user, instead of always logging "Docker".

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #1209

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Created/updated tests
* [ ] Extended the documentation
