### PR TITLE
fix(build): add httpendpoint resource

### DIFF
--- a/pkg/kubernetes/upgrade.go
+++ b/pkg/kubernetes/upgrade.go
@@ -36,6 +36,7 @@ var crds = []string{
 	"configuration",
 	"subscription",
 	"resiliency",
+	"httpendpoints",
 }
 
 var crdsFullResources = []string{
@@ -43,6 +44,7 @@ var crdsFullResources = []string{
 	"configurations.dapr.io",
 	"subscriptions.dapr.io",
 	"resiliencies.dapr.io",
+	"httpendpoints.dapr.io",
 }
 
 type UpgradeConfig struct {


### PR DESCRIPTION
# Description

Add `httpendpoints` for cli build so operator doesn't go into crash loop backoff with 1.11 RC CLI update PR here https://github.com/dapr/cli/pull/1284

## Issue reference

https://github.com/dapr/cli/pull/1280

needed for https://github.com/dapr/cli/pull/1284

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [ ] Extended the documentation
