### PR TITLE
fix(test): correct test roles check based on runtime version

### DIFF
--- a/tests/e2e/common/common.go
+++ b/tests/e2e/common/common.go
@@ -45,6 +45,8 @@ const (
 	CustomResourceDefs Resource = iota
 	ClusterRoles
 	ClusterRoleBindings
+	// Note: Go does not like the period in 1.11 for consts
+	Dapr111Version = "v1.11.0-rc.4"
 
 	numHAPods    = 13
 	numNonHAPods = 5
@@ -428,7 +430,7 @@ func ClusterRolesTest(details VersionDetails, opts TestOptions) func(t *testing.
 		for name, found := range foundMap {
 			// Note: dapr dashboard was removed from v1.11 helm chart.
 			// Do not check for dashboard related resources for v1.11 on.
-			if name == "dapr-dashboard" && details.RuntimeVersion == "v1.11.0-rc.4" {
+			if name == "dapr-dashboard" && details.RuntimeVersion == Dapr111Version {
 				wanted = false
 			}
 			assert.Equal(t, wanted, found, "cluster role %s, found = %t, wanted = %t", name, found, wanted)

--- a/tests/e2e/common/common.go
+++ b/tests/e2e/common/common.go
@@ -426,6 +426,11 @@ func ClusterRolesTest(details VersionDetails, opts TestOptions) func(t *testing.
 		}
 
 		for name, found := range foundMap {
+			// Note: dapr dashboard was removed from v1.11 helm chart.
+			// Do not check for dashboard related resources for v1.11 on.
+			if name == "dapr-dashboard" && details.RuntimeVersion == "v1.11.0-rc.4" {
+				wanted = false
+			}
 			assert.Equal(t, wanted, found, "cluster role %s, found = %t, wanted = %t", name, found, wanted)
 		}
 	}

--- a/tests/e2e/common/common.go
+++ b/tests/e2e/common/common.go
@@ -46,7 +46,7 @@ const (
 	ClusterRoles
 	ClusterRoleBindings
 	// Note: Go does not like the period in 1.11 for consts
-	Dapr111Version = "v1.11.0-rc.4"
+	Dapr111Version = "v1.11.0"
 
 	numHAPods    = 13
 	numNonHAPods = 5


### PR DESCRIPTION
# Description

My[ other PR](https://github.com/dapr/cli/pull/1280) fails inconsistently for a check on the dashboard role for v1.11 runtime. This will prevent part of the issue. The timing related issue we can save for another PR/investigation :)

## Issue reference

https://github.com/dapr/cli/pull/1280#issuecomment-1565130574

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [X] Created/updated tests
* [ ] Extended the documentation
