### PR TITLE
#1023: Add default port for http grpc

### DIFF
--- a/pkg/runexec/runexec_test.go
+++ b/pkg/runexec/runexec_test.go
@@ -301,8 +301,8 @@ func TestRun(t *testing.T) {
 		basicConfig.SetDefaultFromSchema()
 
 		assert.Equal(t, -1, basicConfig.AppPort)
-		assert.True(t, basicConfig.HTTPPort == -1)
-		assert.True(t, basicConfig.GRPCPort == -1)
+		assert.True(t, basicConfig.HTTPPort == 3500)
+		assert.True(t, basicConfig.GRPCPort == 50001)
 		assert.True(t, basicConfig.MetricsPort == -1)
 		assert.True(t, basicConfig.ProfilePort == -1)
 		assert.True(t, basicConfig.EnableProfiling)

--- a/pkg/standalone/run.go
+++ b/pkg/standalone/run.go
@@ -50,8 +50,8 @@ type RunConfig struct {
 	AppID             string   `env:"APP_ID" arg:"app-id" yaml:"appID"`
 	AppChannelAddress string   `env:"APP_CHANNEL_ADDRESS" arg:"app-channel-address" ifneq:"127.0.0.1" yaml:"appChannelAddress"`
 	AppPort           int      `env:"APP_PORT" arg:"app-port" yaml:"appPort" default:"-1"`
-	HTTPPort          int      `env:"DAPR_HTTP_PORT" arg:"dapr-http-port" yaml:"daprHTTPPort" default:"-1"`
-	GRPCPort          int      `env:"DAPR_GRPC_PORT" arg:"dapr-grpc-port" yaml:"daprGRPCPort" default:"-1"`
+	HTTPPort          int      `env:"DAPR_HTTP_PORT" arg:"dapr-http-port" yaml:"daprHTTPPort" default:"3500"`
+	GRPCPort          int      `env:"DAPR_GRPC_PORT" arg:"dapr-grpc-port" yaml:"daprGRPCPort" default:"50001"`
 	ProfilePort       int      `arg:"profile-port" yaml:"profilePort" default:"-1"`
 	Command           []string `yaml:"command"`
 	MetricsPort       int      `env:"DAPR_METRICS_PORT" arg:"metrics-port" yaml:"metricsPort" default:"-1"`


### PR DESCRIPTION
# Description

Add default ports for HTTP and gRPC for dapr run.

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #1023 

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Created/updated tests
* [ ] Extended the documentation
