### PR TITLE
Fix checks for container runtime installation

### DIFF
--- a/pkg/standalone/standalone.go
+++ b/pkg/standalone/standalone.go
@@ -162,7 +162,7 @@ func Init(runtimeVersion, dashboardVersion string, dockerNetwork string, slimMod
 	setAirGapInit(fromDir)
 	if !slimMode {
 		// If --slim installation is not requested, check if docker is installed.
-		containerRuntimeAvailable := utils.IsDockerInstalled() || utils.IsPodmanInstalled()
+		containerRuntimeAvailable := utils.IsContainerRuntimeInstalled(containerRuntime)
 		if !containerRuntimeAvailable {
 			return fmt.Errorf("could not connect to %s. %s may not be installed or running", containerRuntime, containerRuntime)
 		}

--- a/pkg/standalone/standalone_test.go
+++ b/pkg/standalone/standalone_test.go
@@ -321,12 +321,13 @@ func TestInitLogActualContainerRuntimeName(t *testing.T) {
 		{"podman", "Init should log podman as container runtime"},
 		{"docker", "Init should log docker as container runtime"},
 	}
-	containerRuntimeAvailable := utils.IsDockerInstalled() || utils.IsPodmanInstalled()
-	if containerRuntimeAvailable {
-		t.Skip("Skipping test as container runtime is available")
-	}
 	for _, test := range tests {
 		t.Run(test.testName, func(t *testing.T) {
+			containerRuntimeAvailable := utils.IsContainerRuntimeInstalled(test.containerRuntime)
+			if containerRuntimeAvailable {
+				t.Skip("Skipping test as container runtime is available")
+			}
+
 			err := Init(latestVersion, latestVersion, "", false, "", "", test.containerRuntime, "", "")
 			assert.NotNil(t, err)
 			assert.Contains(t, err.Error(), test.containerRuntime)

--- a/pkg/standalone/uninstall.go
+++ b/pkg/standalone/uninstall.go
@@ -93,7 +93,7 @@ func Uninstall(uninstallAll bool, dockerNetwork string, containerRuntime string,
 	containerRuntime = strings.TrimSpace(containerRuntime)
 	runtimeCmd := utils.GetContainerRuntimeCmd(containerRuntime)
 	containerRuntimeAvailable := false
-	containerRuntimeAvailable = utils.IsDockerInstalled() || utils.IsPodmanInstalled()
+	containerRuntimeAvailable = utils.IsContainerRuntimeInstalled(containerRuntime)
 	if containerRuntimeAvailable {
 		containerErrs = removeContainers(uninstallPlacementContainer, uninstallAll, dockerNetwork, runtimeCmd)
 	}

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -173,10 +173,22 @@ func CreateDirectory(dir string) error {
 	return os.Mkdir(dir, 0o777)
 }
 
-// IsDockerInstalled checks whether docker is installed/running.
-func IsDockerInstalled() bool {
+// IsContainerRuntimeInstalled checks whether the given container runtime is installed.
+// If the container runtime is unsupported, false is returned.
+func IsContainerRuntimeInstalled(containerRuntime string) bool {
+	if containerRuntime == string(PODMAN) {
+		return isPodmanInstalled()
+	} else if containerRuntime == string(DOCKER) {
+		return isDockerInstalled()
+	}
+	// This should never happen.
+	return false
+}
+
+// isDockerInstalled checks whether docker is installed
+func isDockerInstalled() bool {
 	//nolint:staticcheck
-	cli, err := client.NewEnvClient()
+	cli, err := client.NewClientWithOpts(client.FromEnv)
 	if err != nil {
 		return false
 	}
@@ -184,7 +196,8 @@ func IsDockerInstalled() bool {
 	return err == nil
 }
 
-func IsPodmanInstalled() bool {
+// isPodmanInstalled checks whether podman is installed.
+func isPodmanInstalled() bool {
 	cmd := exec.Command("podman", "version")
 	if err := cmd.Run(); err != nil {
 		return false

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -185,7 +185,7 @@ func IsContainerRuntimeInstalled(containerRuntime string) bool {
 	return false
 }
 
-// isDockerInstalled checks whether docker is installed
+// isDockerInstalled checks whether docker is installed.
 func isDockerInstalled() bool {
 	//nolint:staticcheck
 	cli, err := client.NewClientWithOpts(client.FromEnv)

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -187,7 +187,6 @@ func IsContainerRuntimeInstalled(containerRuntime string) bool {
 
 // isDockerInstalled checks whether docker is installed.
 func isDockerInstalled() bool {
-	//nolint:staticcheck
 	cli, err := client.NewClientWithOpts(client.FromEnv)
 	if err != nil {
 		return false


### PR DESCRIPTION
# Description

The previous logic to check if a container runtime is installed or not, used an OR logic. This resulted in issues like #1300

```go
containerRuntimeAvailable := utils.IsDockerInstalled() || utils.IsPodmanInstalled() 
```

The new fix is to check for a specific runtime based on the flag passed by the user.

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #1300

## Checklist

* [X] Code compiles correctly
* [X] Created/updated tests
* [ ] Extended the documentation
