### PR TITLE
Fix for Quote in username errors dapr init #972

### DIFF
--- a/pkg/standalone/standalone.go
+++ b/pkg/standalone/standalone.go
@@ -905,7 +905,7 @@ func moveFileToPath(filepath string, installLocation string) (string, error) {
 		p := os.Getenv("PATH")
 
 		if !strings.Contains(strings.ToLower(p), strings.ToLower(destDir)) {
-			utils.SanitizeDir(&destDir)
+			destDir = utils.SanitizeDir(destDir)
 			pathCmd := "[System.Environment]::SetEnvironmentVariable('Path',[System.Environment]::GetEnvironmentVariable('Path','user') + '" + fmt.Sprintf(";%s", destDir) + "', 'user')"
 			_, err := utils.RunCmdAndWait("powershell", pathCmd)
 			if err != nil {

--- a/pkg/standalone/standalone.go
+++ b/pkg/standalone/standalone.go
@@ -905,7 +905,7 @@ func moveFileToPath(filepath string, installLocation string) (string, error) {
 		p := os.Getenv("PATH")
 
 		if !strings.Contains(strings.ToLower(p), strings.ToLower(destDir)) {
-			utils.FixCommandWithApostrophe(&destDir)
+			utils.SanitizeDir(&destDir)
 			pathCmd := "[System.Environment]::SetEnvironmentVariable('Path',[System.Environment]::GetEnvironmentVariable('Path','user') + '" + fmt.Sprintf(";%s", destDir) + "', 'user')"
 			_, err := utils.RunCmdAndWait("powershell", pathCmd)
 			if err != nil {

--- a/pkg/standalone/standalone.go
+++ b/pkg/standalone/standalone.go
@@ -905,6 +905,7 @@ func moveFileToPath(filepath string, installLocation string) (string, error) {
 		p := os.Getenv("PATH")
 
 		if !strings.Contains(strings.ToLower(p), strings.ToLower(destDir)) {
+			utils.FixCommandWithApostrophe(&destDir)
 			pathCmd := "[System.Environment]::SetEnvironmentVariable('Path',[System.Environment]::GetEnvironmentVariable('Path','user') + '" + fmt.Sprintf(";%s", destDir) + "', 'user')"
 			_, err := utils.RunCmdAndWait("powershell", pathCmd)
 			if err != nil {

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -404,7 +404,7 @@ func FindFileInDir(dirPath, fileName string) (string, error) {
 	return filePath, nil
 }
 
-// SanitizeDir corrects any syntactical errors in the passed directory.
+// SanitizeDir sanitizes the input string to make it a valid directory.
 func SanitizeDir(destDir string) string {
 	return strings.ReplaceAll(destDir, "'", "''")
 }

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -405,6 +405,8 @@ func FindFileInDir(dirPath, fileName string) (string, error) {
 }
 
 // SanitizeDir corrects any syntactical errors in the passed directory.
-func SanitizeDir(destDir *string) {
-	*destDir = strings.Replace(*destDir, "'", "''", -1)
+func SanitizeDir(destDir string) string {
+	correctedDestDir := destDir
+	correctedDestDir = strings.Replace(correctedDestDir, "'", "''", -1)
+	return correctedDestDir
 }

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -406,7 +406,5 @@ func FindFileInDir(dirPath, fileName string) (string, error) {
 
 // SanitizeDir corrects any syntactical errors in the passed directory.
 func SanitizeDir(destDir string) string {
-	correctedDestDir := destDir
-	correctedDestDir = strings.ReplaceAll(correctedDestDir, "'", "''")
-	return correctedDestDir
+        return strings.ReplaceAll(destDir, "'", "''")
 }

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -404,7 +404,7 @@ func FindFileInDir(dirPath, fileName string) (string, error) {
 	return filePath, nil
 }
 
-// FixCommandWithApostrophe corrects the passed command which might have apostrophes in it
+// FixCommandWithApostrophe corrects the passed command which might have apostrophes in it.
 func FixCommandWithApostrophe(destDir *string) {
 	bytes := []byte(*destDir)
 	var result []byte

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -406,5 +406,5 @@ func FindFileInDir(dirPath, fileName string) (string, error) {
 
 // SanitizeDir corrects any syntactical errors in the passed directory.
 func SanitizeDir(destDir string) string {
-        return strings.ReplaceAll(destDir, "'", "''")
+	return strings.ReplaceAll(destDir, "'", "''")
 }

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -403,3 +403,18 @@ func FindFileInDir(dirPath, fileName string) (string, error) {
 	}
 	return filePath, nil
 }
+
+// FixCommandWithApostrophe corrects the passed command which might have apostrophes in it
+func FixCommandWithApostrophe(destDir *string) {
+	bytes := []byte(*destDir)
+	var result []byte
+
+	for i := 0; i < len(bytes); i++ {
+		result = append(result, bytes[i])
+		if bytes[i] == '\'' {
+			result = append(result, '\'')
+		}
+	}
+
+	*destDir = string(result)
+}

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -407,6 +407,6 @@ func FindFileInDir(dirPath, fileName string) (string, error) {
 // SanitizeDir corrects any syntactical errors in the passed directory.
 func SanitizeDir(destDir string) string {
 	correctedDestDir := destDir
-	correctedDestDir = strings.Replace(correctedDestDir, "'", "''", -1)
+	correctedDestDir = strings.ReplaceAll(correctedDestDir, "'", "''")
 	return correctedDestDir
 }

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -404,17 +404,7 @@ func FindFileInDir(dirPath, fileName string) (string, error) {
 	return filePath, nil
 }
 
-// FixCommandWithApostrophe corrects the passed command which might have apostrophes in it.
-func FixCommandWithApostrophe(destDir *string) {
-	bytes := []byte(*destDir)
-	var result []byte
-
-	for i := 0; i < len(bytes); i++ {
-		result = append(result, bytes[i])
-		if bytes[i] == '\'' {
-			result = append(result, '\'')
-		}
-	}
-
-	*destDir = string(result)
+// SanitizeDir corrects any syntactical errors in the passed directory.
+func SanitizeDir(destDir *string) {
+	*destDir = strings.Replace(*destDir, "'", "''", -1)
 }

--- a/utils/utils_test.go
+++ b/utils/utils_test.go
@@ -512,3 +512,51 @@ func cleanupTempDir(t *testing.T, fileName string) {
 	err := os.RemoveAll(fileName)
 	assert.NoError(t, err)
 }
+
+func TestSanitizeDir(t *testing.T) {
+	testcases := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "directory with single quote in three places",
+			input:    "C:\\Use'rs\\sta'rk\\Docum'ents",
+			expected: "C:\\Use''rs\\sta''rk\\Docum''ents",
+		},
+		{
+			name:     "directory with single quote in two places",
+			input:    "C:\\Use'rs\\sta'rk",
+			expected: "C:\\Use''rs\\sta''rk",
+		},
+		{
+			name:     "directory with single quote in username",
+			input:    "C:\\Users\\Debash'ish",
+			expected: "C:\\Users\\Debash''ish",
+		},
+		{
+			name:     "directory with no single quote",
+			input:    "C:\\Users\\Shubham",
+			expected: "C:\\Users\\Shubham",
+		},
+		{
+			name:     "directory with single quote in one place",
+			input:    "C:\\Use'rs\\Shubham",
+			expected: "C:\\Use''rs\\Shubham",
+		},
+		{
+			name:     "directory with single quote in many places in username",
+			input:    "C:\\Users\\Shu'bh'am",
+			expected: "C:\\Users\\Shu''bh''am",
+		},
+	}
+
+	for _, tc := range testcases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			actual := SanitizeDir(tc.input)
+			assert.Equal(t, tc.expected, actual)
+		})
+	}
+}


### PR DESCRIPTION
# Description

dapr init fails to run with certain username on Windows.
This issue was caused because of an extra apostrophe or single quote in the username since powershell considers it as special character and hence creates syntax issues. To solve this, I created a function in '/utils/utils.go' to take any command and converts into powershell compatible command by appending another quote character after every such character. This makes the command powershell compatible. Now it doesn't throw any syntax error and runs as expected.

Closes #972 

# Testing

PS C:\Users\Carlin'tVeld> cd D:
PS D:\> .\dapr.exe init
Making the jump to hyperspace...
Container images will be pulled from Docker Hub
Installing runtime version 1.11.1
Downloading binaries and setting up components...
Downloaded binaries and completed components set up.
daprd binary has been installed to C:\Users\Carlin'tVeld\.dapr\bin.
dapr_placement container is running.
dapr_redis container is running.
dapr_zipkin container is running.
Use `docker ps` to check running containers.
Success! Dapr is up and running. To get started, go here: https://aka.ms/dapr-getting-started
PS D:\>

