### PR TITLE
Add health and metrics port mapping for placement stand-alone mode

### DIFF
--- a/pkg/standalone/standalone.go
+++ b/pkg/standalone/standalone.go
@@ -78,6 +78,9 @@ const (
 	DaprZipkinContainerName = "dapr_zipkin"
 
 	errInstallTemplate = "please run `dapr uninstall` first before running `dapr init`"
+
+	healthPort = 58080
+	metricPort = 59090
 )
 
 var (
@@ -522,11 +525,9 @@ func runPlacementService(wg *sync.WaitGroup, errorChan chan<- error, info initIn
 		args = append(args,
 			"-p", fmt.Sprintf("%v:50005", osPort))
 
-		healthPort := 58080
 		args = append(args,
 			"-p", fmt.Sprintf("%v:8080", healthPort))
 
-		metricPort := 59090
 		args = append(args,
 			"-p", fmt.Sprintf("%v:9090", metricPort))
 	}

--- a/pkg/standalone/standalone.go
+++ b/pkg/standalone/standalone.go
@@ -521,6 +521,14 @@ func runPlacementService(wg *sync.WaitGroup, errorChan chan<- error, info initIn
 
 		args = append(args,
 			"-p", fmt.Sprintf("%v:50005", osPort))
+
+		healthPort := 58080
+		args = append(args,
+			"-p", fmt.Sprintf("%v:8080", healthPort))
+
+		metricPort := 59090
+		args = append(args,
+			"-p", fmt.Sprintf("%v:9090", metricPort))
 	}
 
 	args = append(args, image)

--- a/pkg/standalone/standalone.go
+++ b/pkg/standalone/standalone.go
@@ -523,13 +523,10 @@ func runPlacementService(wg *sync.WaitGroup, errorChan chan<- error, info initIn
 		}
 
 		args = append(args,
-			"-p", fmt.Sprintf("%v:50005", osPort))
-
-		args = append(args,
-			"-p", fmt.Sprintf("%v:8080", healthPort))
-
-		args = append(args,
-			"-p", fmt.Sprintf("%v:9090", metricPort))
+			"-p", fmt.Sprintf("%v:50005", osPort),
+			"-p", fmt.Sprintf("%v:8080", healthPort),
+			"-p", fmt.Sprintf("%v:9090", metricPort),
+		)
 	}
 
 	args = append(args, image)


### PR DESCRIPTION
# Description

Expose `healthz` and `metrics` ports when running self-hosted with docker.
Map `healthz` to 58080, and `metrics` to 59090, to keep 5xxxx port pattern and keep 8080 and 9090 port numbers which are easier to remember what these ports are mapped to.

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #800 

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [ ] Created/updated tests
* [ ] Extended the documentation
