### PR TITLE
[1.12] Delete injector mutating webhook on downgrade from 1.12 to 1.11

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -153,14 +153,14 @@ test: test-deps
 ################################################################################
 .PHONY: test-e2e-k8s
 test-e2e-k8s: test-deps
-	gotestsum --jsonfile $(TEST_OUTPUT_FILE) --format standard-verbose -- -timeout 25m -count=1 -tags=e2e ./tests/e2e/kubernetes/...
+	gotestsum --jsonfile $(TEST_OUTPUT_FILE) --format standard-verbose -- -timeout 30m -count=1 -tags=e2e ./tests/e2e/kubernetes/...
 
 ################################################################################
 # E2E Tests for K8s Template exec											       #
 ################################################################################
 .PHONY: test-e2e-k8s-template
 test-e2e-k8s-template: test-deps
-	gotestsum --jsonfile $(TEST_OUTPUT_FILE) --format standard-verbose -- -timeout 25m -count=1 -tags=templatek8s ./tests/e2e/kubernetes/...
+	gotestsum --jsonfile $(TEST_OUTPUT_FILE) --format standard-verbose -- -timeout 30m -count=1 -tags=templatek8s ./tests/e2e/kubernetes/...
 
 ################################################################################
 # Build, E2E Tests for Kubernetes											   #

--- a/cmd/upgrade.go
+++ b/cmd/upgrade.go
@@ -14,6 +14,7 @@ limitations under the License.
 package cmd
 
 import (
+	"context"
 	"os"
 	"strings"
 
@@ -57,7 +58,7 @@ dapr upgrade -k
 			print.FailureStatusEvent(os.Stderr, err.Error())
 			os.Exit(1)
 		}
-		err = kubernetes.Upgrade(kubernetes.UpgradeConfig{
+		err = kubernetes.Upgrade(context.Background(), kubernetes.UpgradeConfig{
 			RuntimeVersion:   upgradeRuntimeVersion,
 			DashboardVersion: upgradeDashboardVersion,
 			Args:             values,

--- a/cmd/upgrade.go
+++ b/cmd/upgrade.go
@@ -14,7 +14,6 @@ limitations under the License.
 package cmd
 
 import (
-	"context"
 	"os"
 	"strings"
 
@@ -58,7 +57,7 @@ dapr upgrade -k
 			print.FailureStatusEvent(os.Stderr, err.Error())
 			os.Exit(1)
 		}
-		err = kubernetes.Upgrade(context.Background(), kubernetes.UpgradeConfig{
+		err = kubernetes.Upgrade(kubernetes.UpgradeConfig{
 			RuntimeVersion:   upgradeRuntimeVersion,
 			DashboardVersion: upgradeDashboardVersion,
 			Args:             values,

--- a/pkg/kubernetes/upgrade.go
+++ b/pkg/kubernetes/upgrade.go
@@ -192,6 +192,10 @@ func Upgrade(ctx context.Context, conf UpgradeConfig) error {
 
 	if _, err = upgradeClient.Run(chart, controlPlaneChart, vals); err != nil {
 		if mutatingWebhookConf != nil {
+			mutatingWebhookConf.ObjectMeta = metav1.ObjectMeta{
+				Name:      mutatingWebhookConf.Name,
+				Namespace: mutatingWebhookConf.Namespace,
+			}
 			_, merr := client.AdmissionregistrationV1().MutatingWebhookConfigurations().Create(ctx, mutatingWebhookConf, metav1.CreateOptions{})
 			return errors.Join(err, merr)
 		}

--- a/pkg/kubernetes/upgrade.go
+++ b/pkg/kubernetes/upgrade.go
@@ -60,7 +60,7 @@ type UpgradeConfig struct {
 	ImageVariant     string
 }
 
-func Upgrade(ctx context.Context, conf UpgradeConfig) error {
+func Upgrade(conf UpgradeConfig) error {
 	helmRepo := utils.GetEnv("DAPR_HELM_REPO_URL", daprHelmRepo)
 	status, err := GetDaprResourcesStatus()
 	if err != nil {
@@ -179,12 +179,12 @@ func Upgrade(ctx context.Context, conf UpgradeConfig) error {
 	if is12to11Downgrade(conf.RuntimeVersion, daprVersion) {
 		print.InfoStatusEvent(os.Stdout, "Downgrade from 1.12 to 1.11 detected, temporarily deleting injector mutating webhook...")
 
-		mutatingWebhookConf, err = client.AdmissionregistrationV1().MutatingWebhookConfigurations().Get(ctx, "dapr-sidecar-injector", metav1.GetOptions{})
+		mutatingWebhookConf, err = client.AdmissionregistrationV1().MutatingWebhookConfigurations().Get(context.TODO(), "dapr-sidecar-injector", metav1.GetOptions{})
 		if err != nil && !apierrors.IsNotFound(err) {
 			return err
 		}
 
-		err = client.AdmissionregistrationV1().MutatingWebhookConfigurations().Delete(ctx, "dapr-sidecar-injector", metav1.DeleteOptions{})
+		err = client.AdmissionregistrationV1().MutatingWebhookConfigurations().Delete(context.TODO(), "dapr-sidecar-injector", metav1.DeleteOptions{})
 		if err != nil && !apierrors.IsNotFound(err) {
 			return err
 		}
@@ -196,7 +196,7 @@ func Upgrade(ctx context.Context, conf UpgradeConfig) error {
 				Name:      mutatingWebhookConf.Name,
 				Namespace: mutatingWebhookConf.Namespace,
 			}
-			_, merr := client.AdmissionregistrationV1().MutatingWebhookConfigurations().Create(ctx, mutatingWebhookConf, metav1.CreateOptions{})
+			_, merr := client.AdmissionregistrationV1().MutatingWebhookConfigurations().Create(context.TODO(), mutatingWebhookConf, metav1.CreateOptions{})
 			return errors.Join(err, merr)
 		}
 		return err

--- a/tests/e2e/common/common.go
+++ b/tests/e2e/common/common.go
@@ -735,10 +735,10 @@ func SidecarInjects() func(t *testing.T) {
 		require.NoError(t, err)
 
 		t.Cleanup(func() {
-			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			cctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 			defer cancel()
 			assert.NoError(t,
-				client.AppsV1().Deployments(DaprTestNamespace).Delete(ctx, deploy.Name, metav1.DeleteOptions{}),
+				client.AppsV1().Deployments(DaprTestNamespace).Delete(cctx, deploy.Name, metav1.DeleteOptions{}),
 			)
 		})
 

--- a/tests/e2e/common/common.go
+++ b/tests/e2e/common/common.go
@@ -1237,7 +1237,7 @@ func waitPodDeletionDev(t *testing.T, done, podsDeleted chan struct{}) {
 		if len(found) == 2 {
 			podsDeleted <- struct{}{}
 		}
-		time.Sleep(15 * time.Second)
+		time.Sleep(1 * time.Second)
 	}
 }
 
@@ -1261,7 +1261,7 @@ func waitPodDeletion(t *testing.T, done, podsDeleted chan struct{}) {
 		if len(list.Items) == 0 {
 			podsDeleted <- struct{}{}
 		}
-		time.Sleep(15 * time.Second)
+		time.Sleep(1 * time.Second)
 	}
 }
 
@@ -1301,7 +1301,7 @@ func waitAllPodsRunning(t *testing.T, namespace string, haEnabled bool, done, po
 			podsRunning <- struct{}{}
 		}
 
-		time.Sleep(15 * time.Second)
+		time.Sleep(1 * time.Second)
 	}
 }
 

--- a/tests/e2e/common/common.go
+++ b/tests/e2e/common/common.go
@@ -420,7 +420,7 @@ func ClusterRoleBindingsTest(details VersionDetails, opts TestOptions) func(t *t
 			list, err := k8sClient.
 				RbacV1().
 				ClusterRoleBindings().
-				List(ctx, v1.ListOptions{
+				List(ctx, metav1.ListOptions{
 					Limit:    100,
 					Continue: listContinue,
 				})
@@ -457,7 +457,7 @@ func ClusterRolesTest(details VersionDetails, opts TestOptions) func(t *testing.
 
 		var listContinue string
 		for {
-			list, err := k8sClient.RbacV1().ClusterRoles().List(ctx, v1.ListOptions{
+			list, err := k8sClient.RbacV1().ClusterRoles().List(ctx, metav1.ListOptions{
 				Limit:    100,
 				Continue: listContinue,
 			})
@@ -500,7 +500,7 @@ func CRDTest(details VersionDetails, opts TestOptions) func(t *testing.T) {
 			list, err := apiextensionsClientSet.
 				ApiextensionsV1().
 				CustomResourceDefinitions().
-				List(ctx, v1.ListOptions{
+				List(ctx, metav1.ListOptions{
 					Limit:    100,
 					Continue: listContinue,
 				})
@@ -739,7 +739,7 @@ func SidecarInjects() func(t *testing.T) {
 		})
 
 		err = wait.PollImmediateUntilWithContext(ctx, time.Second, func(ctx context.Context) (bool, error) {
-			deploy, err := client.AppsV1().Deployments(DaprTestNamespace).Get(ctx, deploy.Name, metav1.GetOptions{})
+			deploy, err = client.AppsV1().Deployments(DaprTestNamespace).Get(ctx, deploy.Name, metav1.GetOptions{})
 			if err != nil {
 				return false, err
 			}
@@ -787,6 +787,7 @@ func SidecarInjects() func(t *testing.T) {
 
 			return false, errors.New("failed to find injected daprd container")
 		})
+		require.NoError(t, err)
 	}
 }
 

--- a/tests/e2e/upgrade/upgrade_test.go
+++ b/tests/e2e/upgrade/upgrade_test.go
@@ -115,6 +115,7 @@ func getTestsOnUpgrade(p upgradePath, installOpts, upgradeOpts common.TestOption
 		{Name: "previously applied http endpoints exist " + details.RuntimeVersion, Callable: common.HTTPEndpointsTestOnInstallUpgrade(upgradeOpts)},
 		{Name: "check mtls " + details.RuntimeVersion, Callable: common.MTLSTestOnInstallUpgrade(upgradeOpts)},
 		{Name: "status check " + details.RuntimeVersion, Callable: common.StatusTestOnInstallUpgrade(details, upgradeOpts)},
+		{Name: "injector check " + details.RuntimeVersion, Callable: common.SidecarInjects()},
 	}...)
 
 	// uninstall.


### PR DESCRIPTION
If a downgrade is occurring for 1.12 to 1.11, delete the injector mutating webhook so that 1.11 helm chart installs correct CA bundle. Re-create webhook in the event of upgrade failing.

See: https://github.com/dapr/dapr/issues/7055#issuecomment-1768573741