### PR TITLE
dapr_scheduler: Adds scheduler-volume flag

### DIFF
--- a/cmd/init.go
+++ b/cmd/init.go
@@ -45,6 +45,7 @@ var (
 	fromDir           string
 	containerRuntime  string
 	imageVariant      string
+	schedulerVolume   string
 )
 
 var InitCmd = &cobra.Command{
@@ -170,7 +171,11 @@ dapr init --runtime-path <path-to-install-directory>
 				print.FailureStatusEvent(os.Stdout, "Invalid container runtime. Supported values are docker and podman.")
 				os.Exit(1)
 			}
-			err := standalone.Init(runtimeVersion, dashboardVersion, dockerNetwork, slimMode, imageRegistryURI, fromDir, containerRuntime, imageVariant, daprRuntimePath)
+			var schedVol *string
+			if cmd.Flags().Changed("scheduler-volume") {
+				schedVol = &schedulerVolume
+			}
+			err := standalone.Init(runtimeVersion, dashboardVersion, dockerNetwork, slimMode, imageRegistryURI, fromDir, containerRuntime, imageVariant, daprRuntimePath, schedVol)
 			if err != nil {
 				print.FailureStatusEvent(os.Stderr, err.Error())
 				os.Exit(1)
@@ -219,6 +224,7 @@ func init() {
 	InitCmd.Flags().String("network", "", "The Docker network on which to deploy the Dapr runtime")
 	InitCmd.Flags().StringVarP(&fromDir, "from-dir", "", "", "Use Dapr artifacts from local directory for self-hosted installation")
 	InitCmd.Flags().StringVarP(&imageVariant, "image-variant", "", "", "The image variant to use for the Dapr runtime, for example: mariner")
+	InitCmd.Flags().StringVarP(&schedulerVolume, "scheduler-volume", "", "", "Self-hosted only. Optionally specify a volume for the scheduler service data directory. By default, scheduler data is not persisted and not resilient to restarts without this flag.")
 	InitCmd.Flags().BoolP("help", "h", false, "Print this help message")
 	InitCmd.Flags().StringArrayVar(&values, "set", []string{}, "set values on the command line (can specify multiple or separate values with commas: key1=val1,key2=val2)")
 	InitCmd.Flags().String("image-registry", "", "Custom/private docker image repository URL")

--- a/pkg/standalone/common.go
+++ b/pkg/standalone/common.go
@@ -17,7 +17,6 @@ import (
 	"os"
 	path_filepath "path/filepath"
 	"runtime"
-	"strconv"
 	"strings"
 )
 
@@ -59,16 +58,6 @@ func GetDaprRuntimePath(daprRuntimePath string) (string, error) {
 
 func getDaprBinPath(daprDir string) string {
 	return path_filepath.Join(daprDir, defaultDaprBinDirName)
-}
-
-// getSchedulerDataPath returns the data path of a given instance
-// Receiving instanceID allows multiple instances of scheduler to run locally in the future.
-func getSchedulerDataPath(daprDir string, instanceID int) string {
-	return path_filepath.Join(
-		daprDir,
-		defaultSchedulerDirName,
-		defaultSchedulerDataDirName,
-		strconv.Itoa(instanceID))
 }
 
 func binaryFilePathWithDir(binaryDir string, binaryFilePrefix string) string {

--- a/pkg/standalone/standalone.go
+++ b/pkg/standalone/standalone.go
@@ -143,6 +143,7 @@ type initInfo struct {
 	imageRegistryURL string
 	containerRuntime string
 	imageVariant     string
+	schedulerVolume  *string
 }
 
 type daprImageInfo struct {
@@ -184,7 +185,7 @@ func isSchedulerIncluded(runtimeVersion string) (bool, error) {
 }
 
 // Init installs Dapr on a local machine using the supplied runtimeVersion.
-func Init(runtimeVersion, dashboardVersion string, dockerNetwork string, slimMode bool, imageRegistryURL string, fromDir string, containerRuntime string, imageVariant string, daprInstallPath string) error {
+func Init(runtimeVersion, dashboardVersion string, dockerNetwork string, slimMode bool, imageRegistryURL string, fromDir string, containerRuntime string, imageVariant string, daprInstallPath string, schedulerVolume *string) error {
 	var err error
 	var bundleDet bundleDetails
 	containerRuntime = strings.TrimSpace(containerRuntime)
@@ -262,11 +263,6 @@ func Init(runtimeVersion, dashboardVersion string, dockerNetwork string, slimMod
 		return er
 	}
 
-	err = makeDefaultSchedulerDir(installDir)
-	if err != nil {
-		return err
-	}
-
 	var wg sync.WaitGroup
 	errorChan := make(chan error)
 	initSteps := []func(*sync.WaitGroup, chan<- error, initInfo){
@@ -310,6 +306,7 @@ func Init(runtimeVersion, dashboardVersion string, dockerNetwork string, slimMod
 		imageRegistryURL: imageRegistryURL,
 		containerRuntime: containerRuntime,
 		imageVariant:     imageVariant,
+		schedulerVolume:  schedulerVolume,
 	}
 	for _, step := range initSteps {
 		// Run init on the configurations and containers.
@@ -638,15 +635,15 @@ func runSchedulerService(wg *sync.WaitGroup, errorChan chan<- error, info initIn
 		}
 	}
 
-	// instanceID is 0 because we run one instance only for now.
-	schedulerDataDir := getSchedulerDataPath(info.installDir, 0)
 	args := []string{
 		"run",
 		"--name", schedulerContainerName,
 		"--restart", "always",
 		"-d",
 		"--entrypoint", "./scheduler",
-		"--volume", fmt.Sprintf("%v:/data-default-dapr-scheduler-server-0", schedulerDataDir),
+	}
+	if info.schedulerVolume != nil {
+		args = append(args, "--volume", *info.schedulerVolume+":/data-default-dapr-scheduler-server-0")
 	}
 
 	if info.dockerNetwork != "" {
@@ -885,17 +882,6 @@ func makeDefaultComponentsDir(installDir string) error {
 
 	os.Chmod(componentsDir, 0o755)
 	return nil
-}
-
-func makeDefaultSchedulerDir(installDir string) error {
-	dataDir := getSchedulerDataPath(installDir, 0)
-
-	err := os.MkdirAll(dataDir, 0o755)
-	if err != nil {
-		return fmt.Errorf("error creating default scheduler folder: %w", err)
-	}
-
-	return os.Chmod(dataDir, 0o777)
 }
 
 func makeExecutable(filepath string) error {

--- a/pkg/standalone/standalone.go
+++ b/pkg/standalone/standalone.go
@@ -262,6 +262,11 @@ func Init(runtimeVersion, dashboardVersion string, dockerNetwork string, slimMod
 		return er
 	}
 
+	err = makeDefaultSchedulerDir(installDir)
+	if err != nil {
+		return err
+	}
+
 	var wg sync.WaitGroup
 	errorChan := make(chan error)
 	initSteps := []func(*sync.WaitGroup, chan<- error, initInfo){
@@ -880,6 +885,17 @@ func makeDefaultComponentsDir(installDir string) error {
 
 	os.Chmod(componentsDir, 0o755)
 	return nil
+}
+
+func makeDefaultSchedulerDir(installDir string) error {
+	dataDir := getSchedulerDataPath(installDir, 0)
+
+	err := os.MkdirAll(dataDir, 0o755)
+	if err != nil {
+		return fmt.Errorf("error creating default scheduler folder: %w", err)
+	}
+
+	return os.Chmod(dataDir, 0o777)
 }
 
 func makeExecutable(filepath string) error {

--- a/pkg/standalone/standalone_test.go
+++ b/pkg/standalone/standalone_test.go
@@ -328,7 +328,7 @@ func TestInitLogActualContainerRuntimeName(t *testing.T) {
 				t.Skip("Skipping test as container runtime is available")
 			}
 
-			err := Init(latestVersion, latestVersion, "", false, "", "", test.containerRuntime, "", "")
+			err := Init(latestVersion, latestVersion, "", false, "", "", test.containerRuntime, "", "", nil)
 			assert.NotNil(t, err)
 			assert.Contains(t, err.Error(), test.containerRuntime)
 		})


### PR DESCRIPTION
Expose `--scheduler-volume` to optionally specify the volume which scheduler writes to.