### PR TITLE
Change scheduler container data dir from `/var/run/...` to `/var/lib/...`

### DIFF
--- a/pkg/standalone/standalone.go
+++ b/pkg/standalone/standalone.go
@@ -643,7 +643,7 @@ func runSchedulerService(wg *sync.WaitGroup, errorChan chan<- error, info initIn
 		"--entrypoint", "./scheduler",
 	}
 	if info.schedulerVolume != nil {
-		args = append(args, "--volume", *info.schedulerVolume+":/var/run/dapr/scheduler")
+		args = append(args, "--volume", *info.schedulerVolume+":/var/lib/dapr/scheduler")
 	}
 
 	if info.dockerNetwork != "" {
@@ -664,7 +664,7 @@ func runSchedulerService(wg *sync.WaitGroup, errorChan chan<- error, info initIn
 		)
 	}
 
-	args = append(args, image, "--etcd-data-dir=/var/run/dapr/scheduler")
+	args = append(args, image, "--etcd-data-dir=/var/lib/dapr/scheduler")
 
 	_, err = utils.RunCmdAndWait(runtimeCmd, args...)
 	if err != nil {


### PR DESCRIPTION
Changes scheduler data dir in selfhosted mode to be under `/var/lib/dapr/scheduler` as this is strictly more correct under FSH.

https://refspecs.linuxfoundation.org/FHS_3.0/fhs-3.0.html#varlibVariableStateInformation