### PR TITLE
Add dapr scheduler server to the status command

### DIFF
--- a/pkg/kubernetes/status.go
+++ b/pkg/kubernetes/status.go
@@ -33,6 +33,7 @@ var controlPlaneLabels = []string{
 	"dapr-placement-server",
 	"dapr-sidecar-injector",
 	"dapr-dashboard",
+	"dapr-scheduler-server",
 }
 
 type StatusClient struct {

--- a/pkg/kubernetes/status_test.go
+++ b/pkg/kubernetes/status_test.go
@@ -233,6 +233,9 @@ func TestControlPlaneServices(t *testing.T) {
 		{"dapr-sidecar-injector-74648c9dcb-5bsmn", "dapr-sidecar-injector", daprImageTag},
 		{"dapr-sidecar-injector-74648c9dcb-6bsmn", "dapr-sidecar-injector", daprImageTag},
 		{"dapr-sidecar-injector-74648c9dcb-7bsmn", "dapr-sidecar-injector", daprImageTag},
+		{"dapr-scheduler-server-0", "dapr-scheduler-server", daprImageTag},
+		{"dapr-scheduler-server-1", "dapr-scheduler-server", daprImageTag},
+		{"dapr-scheduler-server-2", "dapr-scheduler-server", daprImageTag},
 	}
 
 	expectedReplicas := map[string]int{}


### PR DESCRIPTION
# Description

Fix `dapr status -k` showing `dapr-scheduler-server` pods information

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #1433 

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Created/updated tests
* [ ] Extended the documentation
