### PR TITLE
Pin bitnami chart version for redis

### DIFF
--- a/pkg/kubernetes/kubernetes.go
+++ b/pkg/kubernetes/kubernetes.go
@@ -40,6 +40,7 @@ const (
 	daprReleaseName      = "dapr"
 	dashboardReleaseName = "dapr-dashboard"
 	latestVersion        = "latest"
+	bitnamiStableVersion = "17.14.5"
 
 	// dev mode constants.
 	thirdPartyDevNamespace   = "default"
@@ -99,9 +100,10 @@ func Init(config InitConfiguration) error {
 	if config.EnableDev {
 		redisChartVals := []string{
 			"image.tag=" + redisVersion,
+			"replica.replicaCount=0",
 		}
 
-		err = installThirdPartyWithConsole(redisReleaseName, redisChartName, latestVersion, bitnamiHelmRepo, "Dapr Redis", redisChartVals, config)
+		err = installThirdPartyWithConsole(redisReleaseName, redisChartName, bitnamiStableVersion, bitnamiHelmRepo, "Dapr Redis", redisChartVals, config)
 		if err != nil {
 			return err
 		}
@@ -124,7 +126,7 @@ func installThirdPartyWithConsole(releaseName, chartName, releaseVersion, helmRe
 	defer installSpinning(print.Failure)
 
 	// releaseVersion of chart will always be latest version.
-	err := installThirdParty(releaseName, chartName, latestVersion, helmRepo, chartValues, config)
+	err := installThirdParty(releaseName, chartName, releaseVersion, helmRepo, chartValues, config)
 	if err != nil {
 		return err
 	}
@@ -214,7 +216,7 @@ func getHelmChart(version, releaseName, helmRepo string, config *helm.Configurat
 
 	pull.Settings = &cli.EnvSettings{}
 
-	if version != latestVersion && (releaseName == daprReleaseName || releaseName == dashboardReleaseName) {
+	if version != latestVersion && (releaseName == daprReleaseName || releaseName == dashboardReleaseName || releaseName == redisChartName) {
 		pull.Version = chartVersion(version)
 	}
 


### PR DESCRIPTION
Pins the bitnami version to a stable one and removes unneeded Redis replicas for dev mode.

Fixes #1436 
and https://github.com/dapr/quickstarts/issues/1048