### PR TITLE
fix: allow the scheduler client to initialise for edge builds

### DIFF
--- a/cmd/run.go
+++ b/cmd/run.go
@@ -230,7 +230,7 @@ dapr run --run-file /path/to/directory -k
 					output.DaprGRPCPort)
 			}
 
-			if semver.Compare(fmt.Sprintf("v%v", daprVer.RuntimeVersion), "v1.14.0-rc.1") == -1 {
+			if (daprVer.RuntimeVersion != "edge") && (semver.Compare(fmt.Sprintf("v%v", daprVer.RuntimeVersion), "v1.14.0-rc.1") == -1) {
 				print.InfoStatusEvent(os.Stdout, "The scheduler is only compatible with dapr runtime 1.14 onwards.")
 				for i, arg := range output.DaprCMD.Args {
 					if strings.HasPrefix(arg, "--scheduler-host-address") {


### PR DESCRIPTION
# Description

Allows the scheduler to run for "edge" builds without a runtime version

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #_[issue number]_

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [ ] Extended the documentation
