### PR TITLE
Add version parsing check skip malformed versions and avoid panic

### DIFF
--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -128,7 +128,7 @@ func GetLatestReleaseGithub(githubURL string) (string, error) {
 					return "", err
 				}
 				// just a safety check to make sure we don't get a nil version.
-				// all errors should be handled above
+				// all errors should be handled above.
 				if cur == nil {
 					return "", fmt.Errorf("failed to parse version %s, resulted in nil version", release.TagName)
 				}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -130,7 +130,7 @@ func GetLatestReleaseGithub(githubURL string) (string, error) {
 				// just a safety check to make sure we don't get a nil version.
 				// all errors should be handled above.
 				if cur == nil {
-					return "", fmt.Errorf("failed to parse version %s, resulted in nil version", release.TagName)
+					continue
 				}
 				if cur.GreaterThan(latestVersion) {
 					latestVersion = cur

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -120,7 +120,18 @@ func GetLatestReleaseGithub(githubURL string) (string, error) {
 
 		for _, release := range githubRepoReleases {
 			if !strings.Contains(release.TagName, "-rc") {
-				cur, _ := version.NewVersion(strings.TrimPrefix(release.TagName, "v"))
+				cur, err := version.NewVersion(strings.TrimPrefix(release.TagName, "v"))
+				if err != nil {
+					if strings.HasPrefix(err.Error(), "Malformed version") {
+						continue
+					}
+					return "", err
+				}
+				// just a safety check to make sure we don't get a nil version.
+				// all errors should be handled above
+				if cur == nil {
+					return "", fmt.Errorf("failed to parse version %s, resulted in nil version", release.TagName)
+				}
 				if cur.GreaterThan(latestVersion) {
 					latestVersion = cur
 				}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -119,22 +119,18 @@ func GetLatestReleaseGithub(githubURL string) (string, error) {
 		latestVersion := defaultVersion
 
 		for _, release := range githubRepoReleases {
-			if !strings.Contains(release.TagName, "-rc") {
-				cur, err := version.NewVersion(strings.TrimPrefix(release.TagName, "v"))
-				if err != nil {
-					if strings.HasPrefix(err.Error(), "Malformed version") {
-						continue
-					}
-					return "", err
-				}
-				// just a safety check to make sure we don't get a nil version.
-				// all errors should be handled above.
-				if cur == nil {
-					continue
-				}
-				if cur.GreaterThan(latestVersion) {
-					latestVersion = cur
-				}
+			cur, err := version.NewVersion(strings.TrimPrefix(release.TagName, "v"))
+			if err != nil || cur == nil {
+				print.WarningStatusEvent(os.Stdout, "Malformed version %s, skipping", release.TagName)
+				continue
+			}
+			// Prerelease versions and versions with metadata are skipped.
+			if cur.Prerelease() != "" || cur.Metadata() != "" {
+				continue
+			}
+
+			if cur.GreaterThan(latestVersion) {
+				latestVersion = cur
 			}
 		}
 

--- a/pkg/version/version_test.go
+++ b/pkg/version/version_test.go
@@ -162,6 +162,52 @@ func TestGetVersionsGithub(t *testing.T) {
 			"no releases",
 			"",
 		},
+		{
+			"Malformed version no releases",
+			"/malformed_version_no_releases",
+			`[
+  {
+    "url": "https://api.github.com/repos/dapr/dapr/releases/186741665",
+    "html_url": "https://github.com/dapr/dapr/releases/tag/vedge",
+    "id": 186741665,
+    "tag_name": "vedge",
+    "target_commitish": "master",
+    "name": "Dapr Runtime vedge",
+    "draft": false,
+    "prerelease": false
+  }
+]			`,
+			"no releases",
+			"",
+		},
+		{
+			"Malformed version with latest",
+			"/malformed_version_with_latest",
+			`[
+  {
+    "url": "https://api.github.com/repos/dapr/dapr/releases/186741665",
+    "html_url": "https://github.com/dapr/dapr/releases/tag/vedge",
+    "id": 186741665,
+    "tag_name": "vedge",
+    "target_commitish": "master",
+    "name": "Dapr Runtime vedge",
+    "draft": false,
+    "prerelease": false
+  },
+  {
+	"url": "https://api.github.com/repos/dapr/dapr/releases/44766923",
+	"html_url": "https://github.com/dapr/dapr/releases/tag/v1.5.1",
+	"id": 44766923,
+	"tag_name": "v1.5.1",
+	"target_commitish": "master",
+	"name": "Dapr Runtime v1.5.1",
+	"draft": false,
+	"prerelease": false
+  }
+]			`,
+			"",
+			"1.5.1",
+		},
 	}
 	m := http.NewServeMux()
 	s := http.Server{Addr: ":12345", Handler: m, ReadHeaderTimeout: time.Duration(5) * time.Second}


### PR DESCRIPTION
# Description

Fix a panic when an incorrect version is pulled from dapr releases page.
For example, this happened when a new release tag `vedge` was introduced.
```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x28 pc=0x1961f53]
goroutine 1 [running]:
github.com/hashicorp/go-version.(*Version).String(0x0)
	/home/runner/go/pkg/mod/github.com/hashicorp/go-version@v1.6.0/version.go:369 +0x33
github.com/hashicorp/go-version.(*Version).Compare(0x0, 0xc00077c000)
	/home/runner/go/pkg/mod/github.com/hashicorp/go-version@v1.6.0/version.go:116 +0x25
github.com/hashicorp/go-version.(*Version).GreaterThan(...)
	/home/runner/go/pkg/mod/github.com/hashicorp/go-version@v1.6.0/version.go:298
github.com/dapr/cli/pkg/version.GetLatestReleaseGithub.func1({0xc00106a000, 0x35bebd, 0x41e000})
	/home/runner/work/cli/cli/pkg/version/version.go:124 +0x1d4
github.com/dapr/cli/pkg/version.GetVersionFromURL({0xc0005fa2a0, 0x2f}, 0x2522[19](https://github.com/dapr/dapr/actions/runs/11962935498/job/33352369506?pr=8301#step:6:20)0)
	/home/runner/work/cli/cli/pkg/version/version.go:102 +0x2b5
github.com/dapr/cli/pkg/version.GetLatestReleaseGithub({0xc0005fa2a0?, 0x2b?})
	/home/runner/work/cli/cli/pkg/version/version.go:107 +0x1f
github.com/dapr/cli/pkg/version.GetDaprVersion()
	/home/runner/work/cli/cli/pkg/version/version.go:63 +0x6a
github.com/dapr/cli/pkg/standalone.Init({0x23e4fe8, 0x6}, {0x23e4fe8, 0x6}, {0x0, 0x0}, 0x1, {0x0, 0x0}, {0x0, ...}, ...)
	/home/runner/work/cli/cli/pkg/standalone/standalone.go:215 +0x21c
github.com/dapr/cli/cmd.glob..func11(0xc000654800?, {0x23e21a3?, 0x4?, 0x23e226b?})
	/home/runner/work/cli/cli/cmd/init.go:174 +0x2f0
github.com/spf13/cobra.(*Command).execute(0x3a89480, {0xc000477d80, 0x1, 0x1})
	/home/runner/go/pkg/mod/github.com/spf13/cobra@v1.8.0/command.go:987 +0xaa3
github.com/spf13/cobra.(*Command).ExecuteC(0x3a86f[20](https://github.com/dapr/dapr/actions/runs/11962935498/job/33352369506?pr=8301#step:6:21))
	/home/runner/go/pkg/mod/github.com/spf13/cobra@v1.8.0/command.go:1115 +0x3ff
github.com/spf13/cobra.(*Command).Execute(...)
	/home/runner/go/pkg/mod/github.com/spf13/cobra@v1.8.0/command.go:1039
github.com/dapr/cli/cmd.Execute({0x275c860?, 0x3997800?}, {0x275c85c?, 0xc0000061a0?})
	/home/runner/work/cli/cli/cmd/dapr.go:78 +0x159
main.main()
	/home/runner/work/cli/cli/main.go:27 +0x2f
```

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #_[issue number]_

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [ ] Extended the documentation
