### PR TITLE
Adding error handling to tag version creation

### DIFF
--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -22,7 +22,7 @@ import (
 	"strings"
 
 	"github.com/hashicorp/go-version"
-	yaml "gopkg.in/yaml.v2"
+	"gopkg.in/yaml.v2"
 
 	"github.com/dapr/cli/pkg/print"
 	"github.com/dapr/cli/utils"
@@ -120,7 +120,11 @@ func GetLatestReleaseGithub(githubURL string) (string, error) {
 
 		for _, release := range githubRepoReleases {
 			if !strings.Contains(release.TagName, "-rc") {
-				cur, _ := version.NewVersion(strings.TrimPrefix(release.TagName, "v"))
+				cur, curErr := version.NewVersion(strings.TrimPrefix(release.TagName, "v"))
+				if curErr != nil {
+					print.WarningStatusEvent(os.Stdout, "Failed to parse version: '%s'", curErr)
+					continue
+				}
 				if cur.GreaterThan(latestVersion) {
 					latestVersion = cur
 				}


### PR DESCRIPTION
# Description

* Added error handling for malformed `release.Tagname`s to prevent methods being called on `nil` `cur` receiver and subsequent panic.
* Removed redundant import alias `yaml`
* Errant `release.tag_name` `vedge` causing the issue appears to have been changed or been removed.

```json
 "tag_name": "vedge",
```

## Issue reference

* #1468 

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Created/updated tests (Not applicable)
* [x] Extended the documentation (Not applicable)
