### PR TITLE
release: add upgrade/downgrade tests and bump kind/k8s

### DIFF
--- a/.github/workflows/kind_e2e.yaml
+++ b/.github/workflows/kind_e2e.yaml
@@ -58,9 +58,9 @@ jobs:
       fail-fast: false # Keep running if one leg fails.
       matrix:
         k8s-version:
-        - v1.23.12
-        - v1.24.6
-        - v1.25.2
+        - v1.30.8
+        - v1.31.4
+        - v1.32.0
         mode:
         - ha
         - non-ha
@@ -68,15 +68,15 @@ jobs:
         # This is attempting to make it a bit clearer what's being tested.
         # See: https://github.com/kubernetes-sigs/kind/releases/tag/v0.16.0
         include:
-        - k8s-version: v1.23.12
-          kind-version: v0.16.0
-          kind-image-sha: sha256:9402cf1330bbd3a0d097d2033fa489b2abe40d479cc5ef47d0b6a6960613148a
-        - k8s-version: v1.24.6
-          kind-version: v0.16.0
-          kind-image-sha: sha256:97e8d00bc37a7598a0b32d1fabd155a96355c49fa0d4d4790aab0f161bf31be1
-        - k8s-version: v1.25.2
-          kind-version: v0.16.0
-          kind-image-sha: sha256:9be91e9e9cdf116809841fc77ebdb8845443c4c72fe5218f3ae9eb57fdb4bace
+        - k8s-version: v1.30.8
+          kind-version: v0.26.0
+          kind-image-sha: sha256:17cd608b3971338d9180b00776cb766c50d0a0b6b904ab4ff52fd3fc5c6369bf
+        - k8s-version: v1.31.4
+          kind-version: v0.26.0
+          kind-image-sha: sha256:2cb39f7295fe7eafee0842b1052a599a4fb0f8bcf3f83d96c7f4864c357c6c30
+        - k8s-version: v1.32.0
+          kind-version: v0.26.0
+          kind-image-sha: sha256:c48c62eac5da28cdadcf560d1d8616cfa6783b58f0d94cf63ad1bf49600cb027
     steps:
     - name: Check out code onto GOPATH
       uses: actions/checkout@v4

--- a/.github/workflows/upgrade_e2e.yaml
+++ b/.github/workflows/upgrade_e2e.yaml
@@ -53,9 +53,9 @@ jobs:
       fail-fast: false # Keep running if one leg fails.
       matrix:
         k8s-version:
-        - v1.23.12
-        - v1.24.6
-        - v1.25.2
+        - v1.30.8
+        - v1.31.4
+        - v1.32.0
         mode:
         - ha
         - non-ha
@@ -63,15 +63,15 @@ jobs:
         # This is attempting to make it a bit clearer what's being tested.
         # See: https://github.com/kubernetes-sigs/kind/releases/tag/v0.16.0
         include:
-        - k8s-version: v1.23.12
-          kind-version: v0.16.0
-          kind-image-sha: sha256:9402cf1330bbd3a0d097d2033fa489b2abe40d479cc5ef47d0b6a6960613148a
-        - k8s-version: v1.24.6
-          kind-version: v0.16.0
-          kind-image-sha: sha256:97e8d00bc37a7598a0b32d1fabd155a96355c49fa0d4d4790aab0f161bf31be1
-        - k8s-version: v1.25.2
-          kind-version: v0.16.0
-          kind-image-sha: sha256:9be91e9e9cdf116809841fc77ebdb8845443c4c72fe5218f3ae9eb57fdb4bace
+        - k8s-version: v1.30.8
+          kind-version: v0.26.0
+          kind-image-sha: sha256:17cd608b3971338d9180b00776cb766c50d0a0b6b904ab4ff52fd3fc5c6369bf
+        - k8s-version: v1.31.4
+          kind-version: v0.26.0
+          kind-image-sha: sha256:2cb39f7295fe7eafee0842b1052a599a4fb0f8bcf3f83d96c7f4864c357c6c30
+        - k8s-version: v1.32.0
+          kind-version: v0.26.0
+          kind-image-sha: sha256:c48c62eac5da28cdadcf560d1d8616cfa6783b58f0d94cf63ad1bf49600cb027
     steps:
     - name: Check out code onto GOPATH
       uses: actions/checkout@v4

--- a/tests/e2e/upgrade/upgrade_test.go
+++ b/tests/e2e/upgrade/upgrade_test.go
@@ -55,24 +55,8 @@ var supportedUpgradePaths = []upgradePath{
 			CustomResourceDefs:  []string{"components.dapr.io", "configurations.dapr.io", "subscriptions.dapr.io", "resiliencies.dapr.io", "httpendpoints.dapr.io"},
 		},
 		next: common.VersionDetails{
-			RuntimeVersion:      "1.13.0-rc.2",
-			DashboardVersion:    "0.14.0",
-			ClusterRoles:        []string{"dapr-dashboard", "dapr-injector", "dapr-operator-admin", "dapr-placement", "dapr-sentry"},
-			ClusterRoleBindings: []string{"dapr-operator-admin", "dapr-dashboard", "dapr-injector", "dapr-placement", "dapr-sentry"},
-			CustomResourceDefs:  []string{"components.dapr.io", "configurations.dapr.io", "subscriptions.dapr.io", "resiliencies.dapr.io", "httpendpoints.dapr.io"},
-		},
-	},
-	{
-		previous: common.VersionDetails{
 			RuntimeVersion:      "1.13.0",
 			DashboardVersion:    "0.14.0",
-			ClusterRoles:        []string{"dapr-dashboard", "dapr-injector", "dapr-operator-admin", "dapr-placement", "dapr-sentry"},
-			ClusterRoleBindings: []string{"dapr-operator-admin", "dapr-dashboard", "dapr-injector", "dapr-placement", "dapr-sentry"},
-			CustomResourceDefs:  []string{"components.dapr.io", "configurations.dapr.io", "subscriptions.dapr.io", "resiliencies.dapr.io", "httpendpoints.dapr.io"},
-		},
-		next: common.VersionDetails{
-			RuntimeVersion:      "1.14.0",
-			DashboardVersion:    "0.15.0",
 			ClusterRoles:        []string{"dapr-dashboard", "dapr-injector", "dapr-operator-admin", "dapr-placement", "dapr-sentry"},
 			ClusterRoleBindings: []string{"dapr-operator-admin", "dapr-dashboard", "dapr-injector", "dapr-placement", "dapr-sentry"},
 			CustomResourceDefs:  []string{"components.dapr.io", "configurations.dapr.io", "subscriptions.dapr.io", "resiliencies.dapr.io", "httpendpoints.dapr.io"},
@@ -113,23 +97,7 @@ var supportedUpgradePaths = []upgradePath{
 	},
 	{
 		previous: common.VersionDetails{
-			RuntimeVersion:      "1.14.0",
-			DashboardVersion:    "0.15.0",
-			ClusterRoles:        []string{"dapr-dashboard", "dapr-injector", "dapr-operator-admin", "dapr-placement", "dapr-sentry"},
-			ClusterRoleBindings: []string{"dapr-operator-admin", "dapr-dashboard", "dapr-injector", "dapr-placement", "dapr-sentry"},
-			CustomResourceDefs:  []string{"components.dapr.io", "configurations.dapr.io", "subscriptions.dapr.io", "resiliencies.dapr.io", "httpendpoints.dapr.io"},
-		},
-		next: common.VersionDetails{
 			RuntimeVersion:      "1.13.0",
-			DashboardVersion:    "0.14.0",
-			ClusterRoles:        []string{"dapr-dashboard", "dapr-injector", "dapr-operator-admin", "dapr-placement", "dapr-sentry"},
-			ClusterRoleBindings: []string{"dapr-operator-admin", "dapr-dashboard", "dapr-injector", "dapr-placement", "dapr-sentry"},
-			CustomResourceDefs:  []string{"components.dapr.io", "configurations.dapr.io", "subscriptions.dapr.io", "resiliencies.dapr.io", "httpendpoints.dapr.io"},
-		},
-	},
-	{
-		previous: common.VersionDetails{
-			RuntimeVersion:      "1.13.0-rc.2",
 			DashboardVersion:    "0.14.0",
 			ClusterRoles:        []string{"dapr-dashboard", "dapr-injector", "dapr-operator-admin", "dapr-placement", "dapr-sentry"},
 			ClusterRoleBindings: []string{"dapr-operator-admin", "dapr-dashboard", "dapr-injector", "dapr-placement", "dapr-sentry"},

--- a/tests/e2e/upgrade/upgrade_test.go
+++ b/tests/e2e/upgrade/upgrade_test.go
@@ -72,7 +72,7 @@ var supportedUpgradePaths = []upgradePath{
 		},
 		next: common.VersionDetails{
 			RuntimeVersion:      "1.14.0",
-			DashboardVersion:    "0.14.0",
+			DashboardVersion:    "0.15.0",
 			ClusterRoles:        []string{"dapr-dashboard", "dapr-injector", "dapr-operator-admin", "dapr-placement", "dapr-sentry"},
 			ClusterRoleBindings: []string{"dapr-operator-admin", "dapr-dashboard", "dapr-injector", "dapr-placement", "dapr-sentry"},
 			CustomResourceDefs:  []string{"components.dapr.io", "configurations.dapr.io", "subscriptions.dapr.io", "resiliencies.dapr.io", "httpendpoints.dapr.io"},
@@ -81,14 +81,14 @@ var supportedUpgradePaths = []upgradePath{
 	{
 		previous: common.VersionDetails{
 			RuntimeVersion:      "1.14.0",
-			DashboardVersion:    "0.14.0",
+			DashboardVersion:    "0.15.0",
 			ClusterRoles:        []string{"dapr-dashboard", "dapr-injector", "dapr-operator-admin", "dapr-placement", "dapr-sentry"},
 			ClusterRoleBindings: []string{"dapr-operator-admin", "dapr-dashboard", "dapr-injector", "dapr-placement", "dapr-sentry"},
 			CustomResourceDefs:  []string{"components.dapr.io", "configurations.dapr.io", "subscriptions.dapr.io", "resiliencies.dapr.io", "httpendpoints.dapr.io"},
 		},
 		next: common.VersionDetails{
 			RuntimeVersion:      "1.15.0-rc.2",
-			DashboardVersion:    "0.14.0",
+			DashboardVersion:    "0.15.0",
 			ClusterRoles:        []string{"dapr-dashboard", "dapr-injector", "dapr-operator-admin", "dapr-placement", "dapr-sentry"},
 			ClusterRoleBindings: []string{"dapr-operator-admin", "dapr-dashboard", "dapr-injector", "dapr-placement", "dapr-sentry"},
 			CustomResourceDefs:  []string{"components.dapr.io", "configurations.dapr.io", "subscriptions.dapr.io", "resiliencies.dapr.io", "httpendpoints.dapr.io"},
@@ -98,14 +98,14 @@ var supportedUpgradePaths = []upgradePath{
 	{
 		previous: common.VersionDetails{
 			RuntimeVersion:      "1.15.0-rc.2",
-			DashboardVersion:    "0.14.0",
+			DashboardVersion:    "0.15.0",
 			ClusterRoles:        []string{"dapr-dashboard", "dapr-injector", "dapr-operator-admin", "dapr-placement", "dapr-sentry"},
 			ClusterRoleBindings: []string{"dapr-operator-admin", "dapr-dashboard", "dapr-injector", "dapr-placement", "dapr-sentry"},
 			CustomResourceDefs:  []string{"components.dapr.io", "configurations.dapr.io", "subscriptions.dapr.io", "resiliencies.dapr.io", "httpendpoints.dapr.io"},
 		},
 		next: common.VersionDetails{
 			RuntimeVersion:      "1.14.0",
-			DashboardVersion:    "0.14.0",
+			DashboardVersion:    "0.15.0",
 			ClusterRoles:        []string{"dapr-dashboard", "dapr-injector", "dapr-operator-admin", "dapr-placement", "dapr-sentry"},
 			ClusterRoleBindings: []string{"dapr-operator-admin", "dapr-dashboard", "dapr-injector", "dapr-placement", "dapr-sentry"},
 			CustomResourceDefs:  []string{"components.dapr.io", "configurations.dapr.io", "subscriptions.dapr.io", "resiliencies.dapr.io", "httpendpoints.dapr.io"},
@@ -114,7 +114,7 @@ var supportedUpgradePaths = []upgradePath{
 	{
 		previous: common.VersionDetails{
 			RuntimeVersion:      "1.14.0",
-			DashboardVersion:    "0.14.0",
+			DashboardVersion:    "0.15.0",
 			ClusterRoles:        []string{"dapr-dashboard", "dapr-injector", "dapr-operator-admin", "dapr-placement", "dapr-sentry"},
 			ClusterRoleBindings: []string{"dapr-operator-admin", "dapr-dashboard", "dapr-injector", "dapr-placement", "dapr-sentry"},
 			CustomResourceDefs:  []string{"components.dapr.io", "configurations.dapr.io", "subscriptions.dapr.io", "resiliencies.dapr.io", "httpendpoints.dapr.io"},

--- a/tests/e2e/upgrade/upgrade_test.go
+++ b/tests/e2e/upgrade/upgrade_test.go
@@ -31,41 +31,6 @@ type upgradePath struct {
 
 var supportedUpgradePaths = []upgradePath{
 	{
-		// test upgrade on mariner images.
-		previous: common.VersionDetails{
-			RuntimeVersion:      "1.8.0",
-			DashboardVersion:    "0.10.0",
-			ImageVariant:        "mariner",
-			ClusterRoles:        []string{"dapr-operator-admin", "dashboard-reader"},
-			ClusterRoleBindings: []string{"dapr-operator", "dapr-role-tokenreview-binding", "dashboard-reader-global"},
-			CustomResourceDefs:  []string{"components.dapr.io", "configurations.dapr.io", "subscriptions.dapr.io", "resiliencies.dapr.io"},
-		},
-		next: common.VersionDetails{
-			RuntimeVersion:      "1.8.7",
-			DashboardVersion:    "0.10.0",
-			ImageVariant:        "mariner",
-			ClusterRoles:        []string{"dapr-operator-admin", "dashboard-reader"},
-			ClusterRoleBindings: []string{"dapr-operator", "dapr-role-tokenreview-binding", "dashboard-reader-global"},
-			CustomResourceDefs:  []string{"components.dapr.io", "configurations.dapr.io", "subscriptions.dapr.io", "resiliencies.dapr.io"},
-		},
-	},
-	{
-		previous: common.VersionDetails{
-			RuntimeVersion:      "1.9.5",
-			DashboardVersion:    "0.11.0",
-			ClusterRoles:        []string{"dapr-operator-admin", "dashboard-reader"},
-			ClusterRoleBindings: []string{"dapr-operator", "dapr-role-tokenreview-binding", "dashboard-reader-global"},
-			CustomResourceDefs:  []string{"components.dapr.io", "configurations.dapr.io", "subscriptions.dapr.io", "resiliencies.dapr.io"},
-		},
-		next: common.VersionDetails{
-			RuntimeVersion:      "1.10.7",
-			DashboardVersion:    "0.12.0",
-			ClusterRoles:        []string{"dapr-dashboard", "dapr-injector", "dapr-operator-admin", "dapr-placement", "dapr-sentry"},
-			ClusterRoleBindings: []string{"dapr-operator-admin", "dapr-dashboard", "dapr-injector", "dapr-placement", "dapr-sentry"},
-			CustomResourceDefs:  []string{"components.dapr.io", "configurations.dapr.io", "subscriptions.dapr.io", "resiliencies.dapr.io"},
-		},
-	},
-	{
 		previous: common.VersionDetails{
 			RuntimeVersion:      "1.11.0",
 			DashboardVersion:    "0.14.0",
@@ -97,7 +62,71 @@ var supportedUpgradePaths = []upgradePath{
 			CustomResourceDefs:  []string{"components.dapr.io", "configurations.dapr.io", "subscriptions.dapr.io", "resiliencies.dapr.io", "httpendpoints.dapr.io"},
 		},
 	},
+	{
+		previous: common.VersionDetails{
+			RuntimeVersion:      "1.13.0",
+			DashboardVersion:    "0.14.0",
+			ClusterRoles:        []string{"dapr-dashboard", "dapr-injector", "dapr-operator-admin", "dapr-placement", "dapr-sentry"},
+			ClusterRoleBindings: []string{"dapr-operator-admin", "dapr-dashboard", "dapr-injector", "dapr-placement", "dapr-sentry"},
+			CustomResourceDefs:  []string{"components.dapr.io", "configurations.dapr.io", "subscriptions.dapr.io", "resiliencies.dapr.io", "httpendpoints.dapr.io"},
+		},
+		next: common.VersionDetails{
+			RuntimeVersion:      "1.14.0",
+			DashboardVersion:    "0.14.0",
+			ClusterRoles:        []string{"dapr-dashboard", "dapr-injector", "dapr-operator-admin", "dapr-placement", "dapr-sentry"},
+			ClusterRoleBindings: []string{"dapr-operator-admin", "dapr-dashboard", "dapr-injector", "dapr-placement", "dapr-sentry"},
+			CustomResourceDefs:  []string{"components.dapr.io", "configurations.dapr.io", "subscriptions.dapr.io", "resiliencies.dapr.io", "httpendpoints.dapr.io"},
+		},
+	},
+	{
+		previous: common.VersionDetails{
+			RuntimeVersion:      "1.14.0",
+			DashboardVersion:    "0.14.0",
+			ClusterRoles:        []string{"dapr-dashboard", "dapr-injector", "dapr-operator-admin", "dapr-placement", "dapr-sentry"},
+			ClusterRoleBindings: []string{"dapr-operator-admin", "dapr-dashboard", "dapr-injector", "dapr-placement", "dapr-sentry"},
+			CustomResourceDefs:  []string{"components.dapr.io", "configurations.dapr.io", "subscriptions.dapr.io", "resiliencies.dapr.io", "httpendpoints.dapr.io"},
+		},
+		next: common.VersionDetails{
+			RuntimeVersion:      "1.15.0-rc.2",
+			DashboardVersion:    "0.14.0",
+			ClusterRoles:        []string{"dapr-dashboard", "dapr-injector", "dapr-operator-admin", "dapr-placement", "dapr-sentry"},
+			ClusterRoleBindings: []string{"dapr-operator-admin", "dapr-dashboard", "dapr-injector", "dapr-placement", "dapr-sentry"},
+			CustomResourceDefs:  []string{"components.dapr.io", "configurations.dapr.io", "subscriptions.dapr.io", "resiliencies.dapr.io", "httpendpoints.dapr.io"},
+		},
+	},
 	// test downgrade.
+	{
+		previous: common.VersionDetails{
+			RuntimeVersion:      "1.15.0-rc.2",
+			DashboardVersion:    "0.14.0",
+			ClusterRoles:        []string{"dapr-dashboard", "dapr-injector", "dapr-operator-admin", "dapr-placement", "dapr-sentry"},
+			ClusterRoleBindings: []string{"dapr-operator-admin", "dapr-dashboard", "dapr-injector", "dapr-placement", "dapr-sentry"},
+			CustomResourceDefs:  []string{"components.dapr.io", "configurations.dapr.io", "subscriptions.dapr.io", "resiliencies.dapr.io", "httpendpoints.dapr.io"},
+		},
+		next: common.VersionDetails{
+			RuntimeVersion:      "1.14.0",
+			DashboardVersion:    "0.14.0",
+			ClusterRoles:        []string{"dapr-dashboard", "dapr-injector", "dapr-operator-admin", "dapr-placement", "dapr-sentry"},
+			ClusterRoleBindings: []string{"dapr-operator-admin", "dapr-dashboard", "dapr-injector", "dapr-placement", "dapr-sentry"},
+			CustomResourceDefs:  []string{"components.dapr.io", "configurations.dapr.io", "subscriptions.dapr.io", "resiliencies.dapr.io", "httpendpoints.dapr.io"},
+		},
+	},
+	{
+		previous: common.VersionDetails{
+			RuntimeVersion:      "1.14.0",
+			DashboardVersion:    "0.14.0",
+			ClusterRoles:        []string{"dapr-dashboard", "dapr-injector", "dapr-operator-admin", "dapr-placement", "dapr-sentry"},
+			ClusterRoleBindings: []string{"dapr-operator-admin", "dapr-dashboard", "dapr-injector", "dapr-placement", "dapr-sentry"},
+			CustomResourceDefs:  []string{"components.dapr.io", "configurations.dapr.io", "subscriptions.dapr.io", "resiliencies.dapr.io", "httpendpoints.dapr.io"},
+		},
+		next: common.VersionDetails{
+			RuntimeVersion:      "1.13.0",
+			DashboardVersion:    "0.14.0",
+			ClusterRoles:        []string{"dapr-dashboard", "dapr-injector", "dapr-operator-admin", "dapr-placement", "dapr-sentry"},
+			ClusterRoleBindings: []string{"dapr-operator-admin", "dapr-dashboard", "dapr-injector", "dapr-placement", "dapr-sentry"},
+			CustomResourceDefs:  []string{"components.dapr.io", "configurations.dapr.io", "subscriptions.dapr.io", "resiliencies.dapr.io", "httpendpoints.dapr.io"},
+		},
+	},
 	{
 		previous: common.VersionDetails{
 			RuntimeVersion:      "1.13.0-rc.2",


### PR DESCRIPTION
# Description

Adds upgrade/downgrade tests for 1.15
Also removes tests for 1.8/1.9/1.10 which are documented as unsupported.

Bumps kind to 0.26.0 and k8s versions to 1.30/1.31/1.32

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #_[issue number]_

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [ ] Extended the documentation
