### PR TITLE
Use non-deprecated flags in List operation

### DIFF
--- a/pkg/standalone/list.go
+++ b/pkg/standalone/list.go
@@ -105,9 +105,9 @@ func List() ([]ListOutput, error) {
 				enableMetrics = true
 			}
 
-			maxRequestBodySize := getIntArg(argumentsMap, "--dapr-http-max-request-size", runtime.DefaultMaxRequestBodySize)
+			maxRequestBodySize := getIntArg(argumentsMap, "http-max-request-size", runtime.DefaultMaxRequestBodySize)
 
-			httpReadBufferSize := getIntArg(argumentsMap, "--dapr-http-read-buffer-size", runtime.DefaultReadBufferSize)
+			httpReadBufferSize := getIntArg(argumentsMap, "http-read-buffer-size", runtime.DefaultReadBufferSize)
 
 			appID := argumentsMap["--app-id"]
 			appCmd := ""


### PR DESCRIPTION
The CLI currently uses a deprecated flag in `daprd` for max request size and read buffer body. This PR sets the correct flags. The CLI can continue to exist with the user facing `--dapr` prefix.
