### PR TITLE
Fix scheduler standalone CLI address remove on certain versions, edge or dev

### DIFF
--- a/cmd/run.go
+++ b/cmd/run.go
@@ -230,8 +230,13 @@ dapr run --run-file /path/to/directory -k
 					output.DaprGRPCPort)
 			}
 
-			if (daprVer.RuntimeVersion != "edge") && (semver.Compare(fmt.Sprintf("v%v", daprVer.RuntimeVersion), "v1.14.0-rc.1") == -1) {
+			if (daprVer.RuntimeVersion != "edge") && (daprVer.RuntimeVersion != "dev") && (semver.Compare(fmt.Sprintf("v%v", daprVer.RuntimeVersion), "v1.14.0-rc.1") == -1) {
 				print.InfoStatusEvent(os.Stdout, "The scheduler is only compatible with dapr runtime 1.14 onwards.")
+				for i, arg := range output.DaprCMD.Args {
+					if strings.HasPrefix(arg, "--scheduler-host-address") {
+						output.DaprCMD.Args[i] = ""
+					}
+				}
 			}
 			print.InfoStatusEvent(os.Stdout, startInfo)
 
@@ -665,7 +670,7 @@ func executeRunWithAppsConfigFile(runFilePath string, k8sEnabled bool) {
 // populate the scheduler host address based on the dapr version.
 func validateSchedulerHostAddress(version, address string) string {
 	// If no SchedulerHostAddress is supplied, set it to default value.
-	if semver.Compare(fmt.Sprintf("v%v", version), "v1.15.0-rc.0") == 1 {
+	if version == "dev" || version == "edge" || semver.Compare(fmt.Sprintf("v%v", version), "v1.15.0-rc.0") == 1 {
 		if address == "" {
 			return "localhost:50006"
 		}

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -232,11 +232,6 @@ dapr run --run-file /path/to/directory -k
 
 			if (daprVer.RuntimeVersion != "edge") && (semver.Compare(fmt.Sprintf("v%v", daprVer.RuntimeVersion), "v1.14.0-rc.1") == -1) {
 				print.InfoStatusEvent(os.Stdout, "The scheduler is only compatible with dapr runtime 1.14 onwards.")
-				for i, arg := range output.DaprCMD.Args {
-					if strings.HasPrefix(arg, "--scheduler-host-address") {
-						output.DaprCMD.Args[i] = ""
-					}
-				}
 			}
 			print.InfoStatusEvent(os.Stdout, startInfo)
 

--- a/pkg/standalone/run.go
+++ b/pkg/standalone/run.go
@@ -141,7 +141,7 @@ func (config *RunConfig) validatePlacementHostAddr() error {
 func (config *RunConfig) validateSchedulerHostAddr() error {
 	schedulerHostAddr := config.SchedulerHostAddress
 	if len(schedulerHostAddr) == 0 {
-		schedulerHostAddr = "localhost"
+		return nil
 	}
 
 	if indx := strings.Index(schedulerHostAddr, ":"); indx == -1 {

--- a/pkg/standalone/run.go
+++ b/pkg/standalone/run.go
@@ -141,7 +141,7 @@ func (config *RunConfig) validatePlacementHostAddr() error {
 func (config *RunConfig) validateSchedulerHostAddr() error {
 	schedulerHostAddr := config.SchedulerHostAddress
 	if len(schedulerHostAddr) == 0 {
-		return nil
+		schedulerHostAddr = "localhost"
 	}
 
 	if indx := strings.Index(schedulerHostAddr, ":"); indx == -1 {


### PR DESCRIPTION
# Description


In standalone mode `scheduler-host-address` was not set by default to localhost. 
Working locally on "dev" version was removing this argument from `dapr run` command

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #_[issue number]_

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [ ] Extended the documentation
