### PR TITLE
Fix scheduler broadcast address for windows

### DIFF
--- a/pkg/standalone/standalone.go
+++ b/pkg/standalone/standalone.go
@@ -659,12 +659,12 @@ func runSchedulerService(wg *sync.WaitGroup, errorChan chan<- error, info initIn
 		}
 	}
 
+	osPort := 50006
 	if info.dockerNetwork != "" {
 		args = append(args,
 			"--network", info.dockerNetwork,
 			"--network-alias", DaprSchedulerContainerName)
 	} else {
-		osPort := 50006
 		if runtime.GOOS == daprWindowsOS {
 			osPort = 6060
 		}
@@ -684,7 +684,7 @@ func runSchedulerService(wg *sync.WaitGroup, errorChan chan<- error, info initIn
 	}
 
 	if schedulerOverrideHostPort(info) {
-		args = append(args, "--override-broadcast-host-port=localhost:50006")
+		args = append(args, fmt.Sprintf("--override-broadcast-host-port=localhost:%v", osPort))
 	}
 
 	_, err = utils.RunCmdAndWait(runtimeCmd, args...)


### PR DESCRIPTION
# Description

Fix the scheduler standalone broadcast address on Windows.
Docker forwarded ports are different for the scheduler and placement

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #_[issue number]_

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [ ] Extended the documentation
