### PR TITLE
Fix daprsystem configuration retrieval when renewing certificates

### DIFF
--- a/pkg/kubernetes/configuration.go
+++ b/pkg/kubernetes/configuration.go
@@ -43,7 +43,7 @@ func GetDaprControlPlaneCurrentConfig() (*v1alpha1.Configuration, error) {
 	if err != nil {
 		return nil, err
 	}
-	output, err := utils.RunCmdAndWait("kubectl", "get", "configurations/daprsystem", "-n", namespace, "-o", "json")
+	output, err := utils.RunCmdAndWait("kubectl", "get", "configurations.dapr.io/daprsystem", "-n", namespace, "-o", "json")
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
# Description

The issue found when similar resource were installed in k8s that use the name "configurations". In this case the knative's "configurations.serving.knative.dev/v1" was the last in the list and the command returned the error `Error from server (NotFound): configurations.serving.knative.dev "daprsystem" not found`

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #1485 

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [ ] Extended the documentation
