### PR TITLE
fix: arguments accept units

### DIFF
--- a/cmd/annotate.go
+++ b/cmd/annotate.go
@@ -16,11 +16,13 @@ package cmd
 import (
 	"bytes"
 	"fmt"
+	"github.com/dapr/dapr/pkg/runtime"
 	"io"
 	"net/http"
 	"net/url"
 	"os"
 	"path/filepath"
+	"strconv"
 
 	"k8s.io/apimachinery/pkg/api/resource"
 
@@ -396,8 +398,8 @@ func init() {
 	AnnotateCmd.Flags().StringVar(&annotateDaprImage, "dapr-image", "", "The image to use for the dapr sidecar container")
 	AnnotateCmd.Flags().BoolVar(&annotateAppSSL, "app-ssl", false, "Enable SSL for the app")
 	AnnotateCmd.Flags().MarkDeprecated("app-ssl", "This flag is deprecated and will be removed in a future release. Use \"app-protocol\" flag with https or grpcs instead")
-	AnnotateCmd.Flags().StringVar(&annotateMaxRequestBodySize, "max-body-size", "-1", "The maximum request body size to use")
-	AnnotateCmd.Flags().StringVar(&annotateReadBufferSize, "read-buffer-size", "-1", "The maximum size of HTTP header read buffer in kilobytes")
+	AnnotateCmd.Flags().StringVar(&annotateMaxRequestBodySize, "max-body-size", strconv.Itoa(runtime.DefaultMaxRequestBodySize>>20)+"Mi", "The maximum request body size to use")
+	AnnotateCmd.Flags().StringVar(&annotateReadBufferSize, "read-buffer-size", strconv.Itoa(runtime.DefaultReadBufferSize>>10)+"Ki", "The maximum size of HTTP header read buffer in kilobytes")
 	AnnotateCmd.Flags().BoolVar(&annotateHTTPStreamRequestBody, "http-stream-request-body", false, "Enable streaming request body for HTTP")
 	AnnotateCmd.Flags().IntVar(&annotateGracefulShutdownSeconds, "graceful-shutdown-seconds", -1, "The number of seconds to wait for the app to shutdown")
 	AnnotateCmd.Flags().BoolVar(&annotateEnableAPILogging, "enable-api-logging", false, "Enable API logging for the Dapr sidecar")

--- a/cmd/annotate.go
+++ b/cmd/annotate.go
@@ -17,6 +17,7 @@ import (
 	"bytes"
 	"fmt"
 	"io"
+	"k8s.io/apimachinery/pkg/api/resource"
 	"net/http"
 	"net/url"
 	"os"
@@ -60,8 +61,8 @@ var (
 	annotateReadinessProbeThreshold      int
 	annotateDaprImage                    string
 	annotateAppSSL                       bool
-	annotateMaxRequestBodySize           int
-	annotateReadBufferSize               int
+	annotateMaxRequestBodySize           string
+	annotateReadBufferSize               string
 	annotateHTTPStreamRequestBody        bool
 	annotateGracefulShutdownSeconds      int
 	annotateEnableAPILogging             bool
@@ -318,12 +319,22 @@ func getOptionsFromFlags() kubernetes.AnnotateOptions {
 	if annotateAppSSL {
 		o = append(o, kubernetes.WithAppSSL())
 	}
-	if annotateMaxRequestBodySize != -1 {
-		o = append(o, kubernetes.WithMaxRequestBodySize(annotateMaxRequestBodySize))
+	if annotateMaxRequestBodySize != "-1" {
+		if q, err := resource.ParseQuantity(annotateMaxRequestBodySize); err != nil {
+			panic(err)
+		} else {
+			o = append(o, kubernetes.WithMaxRequestBodySize(int(q.Value())))
+		}
+
 	}
-	if annotateReadBufferSize != -1 {
-		o = append(o, kubernetes.WithReadBufferSize(annotateReadBufferSize))
+	if annotateReadBufferSize != "-1" {
+		if q, err := resource.ParseQuantity(annotateReadBufferSize); err != nil {
+			panic(err)
+		} else {
+			o = append(o, kubernetes.WithReadBufferSize(int(q.Value())))
+		}
 	}
+
 	if annotateHTTPStreamRequestBody {
 		o = append(o, kubernetes.WithHTTPStreamRequestBody())
 	}
@@ -385,8 +396,8 @@ func init() {
 	AnnotateCmd.Flags().StringVar(&annotateDaprImage, "dapr-image", "", "The image to use for the dapr sidecar container")
 	AnnotateCmd.Flags().BoolVar(&annotateAppSSL, "app-ssl", false, "Enable SSL for the app")
 	AnnotateCmd.Flags().MarkDeprecated("app-ssl", "This flag is deprecated and will be removed in a future release. Use \"app-protocol\" flag with https or grpcs instead")
-	AnnotateCmd.Flags().IntVar(&annotateMaxRequestBodySize, "max-body-size", -1, "The maximum request body size to use")
-	AnnotateCmd.Flags().IntVar(&annotateReadBufferSize, "read-buffer-size", -1, "The maximum size of HTTP header read buffer in kilobytes")
+	AnnotateCmd.Flags().StringVar(&annotateMaxRequestBodySize, "max-body-size", "-1", "The maximum request body size to use")
+	AnnotateCmd.Flags().StringVar(&annotateReadBufferSize, "read-buffer-size", "-1", "The maximum size of HTTP header read buffer in kilobytes")
 	AnnotateCmd.Flags().BoolVar(&annotateHTTPStreamRequestBody, "http-stream-request-body", false, "Enable streaming request body for HTTP")
 	AnnotateCmd.Flags().IntVar(&annotateGracefulShutdownSeconds, "graceful-shutdown-seconds", -1, "The number of seconds to wait for the app to shutdown")
 	AnnotateCmd.Flags().BoolVar(&annotateEnableAPILogging, "enable-api-logging", false, "Enable API logging for the Dapr sidecar")

--- a/cmd/annotate.go
+++ b/cmd/annotate.go
@@ -16,13 +16,14 @@ package cmd
 import (
 	"bytes"
 	"fmt"
-	"github.com/dapr/dapr/pkg/runtime"
 	"io"
 	"net/http"
 	"net/url"
 	"os"
 	"path/filepath"
 	"strconv"
+
+	"github.com/dapr/dapr/pkg/runtime"
 
 	"k8s.io/apimachinery/pkg/api/resource"
 

--- a/cmd/annotate.go
+++ b/cmd/annotate.go
@@ -17,11 +17,12 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"k8s.io/apimachinery/pkg/api/resource"
 	"net/http"
 	"net/url"
 	"os"
 	"path/filepath"
+
+	"k8s.io/apimachinery/pkg/api/resource"
 
 	"github.com/spf13/cobra"
 
@@ -325,7 +326,6 @@ func getOptionsFromFlags() kubernetes.AnnotateOptions {
 		} else {
 			o = append(o, kubernetes.WithMaxRequestBodySize(int(q.Value())))
 		}
-
 	}
 	if annotateReadBufferSize != "-1" {
 		if q, err := resource.ParseQuantity(annotateReadBufferSize); err != nil {

--- a/cmd/annotate.go
+++ b/cmd/annotate.go
@@ -325,14 +325,16 @@ func getOptionsFromFlags() kubernetes.AnnotateOptions {
 	}
 	if annotateMaxRequestBodySize != "-1" {
 		if q, err := resource.ParseQuantity(annotateMaxRequestBodySize); err != nil {
-			panic(err)
+			print.FailureStatusEvent(os.Stderr, "error parsing value of max-body-size: %s, error: %s", annotateMaxRequestBodySize, err.Error())
+			os.Exit(1)
 		} else {
 			o = append(o, kubernetes.WithMaxRequestBodySize(int(q.Value())))
 		}
 	}
 	if annotateReadBufferSize != "-1" {
 		if q, err := resource.ParseQuantity(annotateReadBufferSize); err != nil {
-			panic(err)
+			print.FailureStatusEvent(os.Stderr, "error parsing value of read-buffer-size: %s, error: %s", annotateMaxRequestBodySize, err.Error())
+			os.Exit(1)
 		} else {
 			o = append(o, kubernetes.WithReadBufferSize(int(q.Value())))
 		}

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -29,6 +29,8 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 
+	daprRuntime "github.com/dapr/dapr/pkg/runtime"
+
 	"github.com/dapr/cli/pkg/kubernetes"
 	"github.com/dapr/cli/pkg/metadata"
 	"github.com/dapr/cli/pkg/print"
@@ -473,8 +475,8 @@ func init() {
 	RunCmd.Flags().MarkDeprecated("app-ssl", "This flag is deprecated and will be removed in the future releases. Use \"app-protocol\" flag with https or grpcs values instead")
 	RunCmd.Flags().IntVarP(&metricsPort, "metrics-port", "M", -1, "The port of metrics on dapr")
 	RunCmd.Flags().BoolP("help", "h", false, "Print this help message")
-	RunCmd.Flags().StringVarP(&maxRequestBodySize, "max-body-size", "", "-1", "Max size of request body in MB")
-	RunCmd.Flags().StringVarP(&readBufferSize, "read-buffer-size", "", "-1", "HTTP header read buffer in KB")
+	RunCmd.Flags().StringVarP(&maxRequestBodySize, "max-body-size", "", strconv.Itoa(daprRuntime.DefaultMaxRequestBodySize>>20)+"Mi", "Max size of request body in MB")
+	RunCmd.Flags().StringVarP(&readBufferSize, "read-buffer-size", "", strconv.Itoa(daprRuntime.DefaultReadBufferSize>>10)+"Ki", "HTTP header read buffer in KB")
 	RunCmd.Flags().StringVarP(&unixDomainSocket, "unix-domain-socket", "u", "", "Path to a unix domain socket dir. If specified, Dapr API servers will use Unix Domain Sockets")
 	RunCmd.Flags().BoolVar(&enableAppHealth, "enable-app-health-check", false, "Enable health checks for the application using the protocol defined with app-protocol")
 	RunCmd.Flags().StringVar(&appHealthPath, "app-health-check-path", "", "Path used for health checks; HTTP only")

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -55,8 +55,8 @@ var (
 	resourcesPaths       []string
 	appSSL               bool
 	metricsPort          int
-	maxRequestBodySize   int
-	readBufferSize       int
+	maxRequestBodySize   string
+	readBufferSize       string
 	unixDomainSocket     string
 	enableAppHealth      bool
 	appHealthPath        string
@@ -473,8 +473,8 @@ func init() {
 	RunCmd.Flags().MarkDeprecated("app-ssl", "This flag is deprecated and will be removed in the future releases. Use \"app-protocol\" flag with https or grpcs values instead")
 	RunCmd.Flags().IntVarP(&metricsPort, "metrics-port", "M", -1, "The port of metrics on dapr")
 	RunCmd.Flags().BoolP("help", "h", false, "Print this help message")
-	RunCmd.Flags().IntVarP(&maxRequestBodySize, "max-body-size", "", -1, "Max size of request body in MB")
-	RunCmd.Flags().IntVarP(&readBufferSize, "read-buffer-size", "", -1, "HTTP header read buffer in KB")
+	RunCmd.Flags().StringVarP(&maxRequestBodySize, "max-body-size", "", "-1", "Max size of request body in MB")
+	RunCmd.Flags().StringVarP(&readBufferSize, "read-buffer-size", "", "-1", "HTTP header read buffer in KB")
 	RunCmd.Flags().StringVarP(&unixDomainSocket, "unix-domain-socket", "u", "", "Path to a unix domain socket dir. If specified, Dapr API servers will use Unix Domain Sockets")
 	RunCmd.Flags().BoolVar(&enableAppHealth, "enable-app-health-check", false, "Enable health checks for the application using the protocol defined with app-protocol")
 	RunCmd.Flags().StringVar(&appHealthPath, "app-health-check-path", "", "Path used for health checks; HTTP only")

--- a/pkg/runexec/runexec_test.go
+++ b/pkg/runexec/runexec_test.go
@@ -15,11 +15,12 @@ package runexec
 
 import (
 	"fmt"
-	"github.com/stretchr/testify/require"
 	"os"
 	"regexp"
 	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 
 	"github.com/stretchr/testify/assert"
 

--- a/pkg/runexec/runexec_test.go
+++ b/pkg/runexec/runexec_test.go
@@ -296,6 +296,8 @@ func TestRun(t *testing.T) {
 		basicConfig.ProfilePort = 0
 		basicConfig.EnableProfiling = true
 		basicConfig.MaxConcurrency = 0
+		basicConfig.MaxRequestBodySize = ""
+		basicConfig.HTTPReadBufferSize = ""
 		basicConfig.AppProtocol = ""
 
 		basicConfig.SetDefaultFromSchema()
@@ -307,8 +309,8 @@ func TestRun(t *testing.T) {
 		assert.Equal(t, -1, basicConfig.ProfilePort)
 		assert.True(t, basicConfig.EnableProfiling)
 		assert.Equal(t, -1, basicConfig.MaxConcurrency)
-		assert.Equal(t, "-1", basicConfig.MaxRequestBodySize)
-		assert.Equal(t, "-1", basicConfig.HTTPReadBufferSize)
+		assert.Equal(t, "4Mi", basicConfig.MaxRequestBodySize)
+		assert.Equal(t, "4Ki", basicConfig.HTTPReadBufferSize)
 		assert.Equal(t, "http", basicConfig.AppProtocol)
 
 		// Test after Validate gets called.
@@ -322,8 +324,8 @@ func TestRun(t *testing.T) {
 		assert.Positive(t, basicConfig.ProfilePort)
 		assert.True(t, basicConfig.EnableProfiling)
 		assert.Equal(t, -1, basicConfig.MaxConcurrency)
-		assert.Equal(t, "-1", basicConfig.MaxRequestBodySize)
-		assert.Equal(t, "-1", basicConfig.HTTPReadBufferSize)
+		assert.Equal(t, "4Mi", basicConfig.MaxRequestBodySize)
+		assert.Equal(t, "4Ki", basicConfig.HTTPReadBufferSize)
 		assert.Equal(t, "http", basicConfig.AppProtocol)
 	})
 

--- a/pkg/standalone/run.go
+++ b/pkg/standalone/run.go
@@ -81,8 +81,8 @@ type SharedRunConfig struct {
 	ResourcesPaths []string `arg:"resources-path" yaml:"resourcesPaths"`
 	// Speicifcally omitted from annotations as appSSL is deprecated.
 	AppSSL             bool   `arg:"app-ssl" yaml:"appSSL"`
-	MaxRequestBodySize string `arg:"max-body-size" annotation:"dapr.io/max-body-size" yaml:"maxBodySize" default:"-1"`
-	HTTPReadBufferSize string `arg:"read-buffer-size" annotation:"dapr.io/read-buffer-size" yaml:"readBufferSize" default:"-1"`
+	MaxRequestBodySize string `arg:"max-body-size" annotation:"dapr.io/max-body-size" yaml:"maxBodySize" default:"4Mi"`
+	HTTPReadBufferSize string `arg:"read-buffer-size" annotation:"dapr.io/read-buffer-size" yaml:"readBufferSize" default:"4Ki"`
 	EnableAppHealth    bool   `arg:"enable-app-health-check" annotation:"dapr.io/enable-app-health-check" yaml:"enableAppHealthCheck"`
 	AppHealthPath      string `arg:"app-health-check-path" annotation:"dapr.io/app-health-check-path" yaml:"appHealthCheckPath"`
 	AppHealthInterval  int    `arg:"app-health-probe-interval" annotation:"dapr.io/app-health-probe-interval" ifneq:"0" yaml:"appHealthProbeInterval"`

--- a/pkg/standalone/run.go
+++ b/pkg/standalone/run.go
@@ -229,20 +229,27 @@ func (config *RunConfig) Validate() error {
 		config.MaxConcurrency = -1
 	}
 
-	if q, err := resource.ParseQuantity(config.MaxRequestBodySize); err != nil {
+	qBody, err := resource.ParseQuantity(config.MaxRequestBodySize)
+	if err != nil {
 		return fmt.Errorf("invalid max request body size: %w", err)
-	} else if q.Value() < 0 {
-		config.MaxRequestBodySize = "-1"
-	} else {
-		config.MaxRequestBodySize = q.String()
 	}
 
-	if q, err := resource.ParseQuantity(config.HTTPReadBufferSize); err != nil {
+	if qBody.Value() < 0 {
+		config.MaxRequestBodySize = "-1"
+	} else {
+		config.MaxRequestBodySize = qBody.String()
+	}
+
+	qBuffer, err := resource.ParseQuantity(config.HTTPReadBufferSize)
+
+	if err != nil {
 		return fmt.Errorf("invalid http read buffer size: %w", err)
-	} else if q.Value() < 0 {
+	}
+
+	if qBuffer.Value() < 0 {
 		config.HTTPReadBufferSize = "-1"
 	} else {
-		config.HTTPReadBufferSize = q.String()
+		config.HTTPReadBufferSize = qBuffer.String()
 	}
 
 	err = config.validatePlacementHostAddr()
@@ -277,20 +284,27 @@ func (config *RunConfig) ValidateK8s() error {
 		config.MaxConcurrency = -1
 	}
 
-	if q, err := resource.ParseQuantity(config.MaxRequestBodySize); err != nil {
+	qBody, err := resource.ParseQuantity(config.MaxRequestBodySize)
+	if err != nil {
 		return fmt.Errorf("invalid max request body size: %w", err)
-	} else if q.Value() <= 0 {
-		config.MaxRequestBodySize = "-1"
-	} else {
-		config.MaxRequestBodySize = q.String()
 	}
 
-	if q, err := resource.ParseQuantity(config.HTTPReadBufferSize); err != nil {
+	if qBody.Value() < 0 {
+		config.MaxRequestBodySize = "-1"
+	} else {
+		config.MaxRequestBodySize = qBody.String()
+	}
+
+	qBuffer, err := resource.ParseQuantity(config.HTTPReadBufferSize)
+
+	if err != nil {
 		return fmt.Errorf("invalid http read buffer size: %w", err)
-	} else if q.Value() <= 0 {
+	}
+
+	if qBuffer.Value() < 0 {
 		config.HTTPReadBufferSize = "-1"
 	} else {
-		config.HTTPReadBufferSize = q.String()
+		config.HTTPReadBufferSize = qBuffer.String()
 	}
 
 	return nil

--- a/pkg/standalone/run.go
+++ b/pkg/standalone/run.go
@@ -241,7 +241,6 @@ func (config *RunConfig) Validate() error {
 	}
 
 	qBuffer, err := resource.ParseQuantity(config.HTTPReadBufferSize)
-
 	if err != nil {
 		return fmt.Errorf("invalid http read buffer size: %w", err)
 	}
@@ -296,7 +295,6 @@ func (config *RunConfig) ValidateK8s() error {
 	}
 
 	qBuffer, err := resource.ParseQuantity(config.HTTPReadBufferSize)
-
 	if err != nil {
 		return fmt.Errorf("invalid http read buffer size: %w", err)
 	}

--- a/pkg/standalone/run.go
+++ b/pkg/standalone/run.go
@@ -16,7 +16,6 @@ package standalone
 import (
 	"context"
 	"fmt"
-	"k8s.io/apimachinery/pkg/api/resource"
 	"net"
 	"os"
 	"os/exec"
@@ -24,6 +23,8 @@ import (
 	"runtime"
 	"strconv"
 	"strings"
+
+	"k8s.io/apimachinery/pkg/api/resource"
 
 	"github.com/Pallinder/sillyname-go"
 	"github.com/phayes/freeport"


### PR DESCRIPTION
`max-body-size` and `read-buffer-size` now accept units as defined in the docs.

Defaults of 4Mi and 4Ki respectively are also set

Fixes #1489

# Description

_Please explain the changes you've made_

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #_[issue number]_

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [ ] Extended the documentation
