### PR TITLE
Increase timeout for e2e upgrade tests to 60 minutes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -174,7 +174,7 @@ e2e-build-run-k8s: build test-e2e-k8s
 ################################################################################
 .PHONY: test-e2e-upgrade
 test-e2e-upgrade: test-deps
-	gotestsum --jsonfile $(TEST_OUTPUT_FILE) --format standard-verbose -- -timeout 40m -count=1 -tags=e2e ./tests/e2e/upgrade/...
+	gotestsum --jsonfile $(TEST_OUTPUT_FILE) --format standard-verbose -- -timeout 60m -count=1 -tags=e2e ./tests/e2e/upgrade/...
 
 ################################################################################
 # Build, E2E Tests for Kubernetes Upgrade									   #


### PR DESCRIPTION
# Description

Upgrade tests with the new version 1.15 are timing out running more than 40 minutes.
Try to increase to 60 minutes.

## Issue reference

New upgrade tests in PR https://github.com/dapr/cli/pull/1491

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [ ] Extended the documentation
