### PR TITLE
Fix scheduler address for dapr run with file on Windows

### DIFF
--- a/cmd/run.go
+++ b/cmd/run.go
@@ -510,6 +510,8 @@ func executeRun(runTemplateName, runFilePath string, apps []runfileconfig.App) (
 		// Set defaults if zero value provided in config yaml.
 		app.RunConfig.SetDefaultFromSchema()
 
+		app.RunConfig.SchedulerHostAddress = validateSchedulerHostAddress(daprVer.RuntimeVersion, app.RunConfig.SchedulerHostAddress)
+
 		// Validate validates the configs and modifies the ports to free ports, appId etc.
 		err := app.RunConfig.Validate()
 		if err != nil {
@@ -526,8 +528,6 @@ func executeRun(runTemplateName, runFilePath string, apps []runfileconfig.App) (
 			exitWithError = true
 			break
 		}
-
-		runConfig.SchedulerHostAddress = validateSchedulerHostAddress(daprVer.RuntimeVersion, runConfig.SchedulerHostAddress)
 
 		// Combined multiwriter for logs.
 		var appDaprdWriter io.Writer
@@ -674,7 +674,7 @@ func validateSchedulerHostAddress(version, address string) string {
 	// If no SchedulerHostAddress is supplied, set it to default value.
 	if semver.Compare(fmt.Sprintf("v%v", version), "v1.15.0-rc.0") == 1 {
 		if address == "" {
-			return "localhost:50006"
+			return "localhost"
 		}
 	}
 	return address


### PR DESCRIPTION
# Description

`dapr run -f` command was not adjusting scheduler address on Windows, same as it does when using `dapr run -- ` plain command.

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #1496

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [ ] Extended the documentation
