### PR TITLE
Fix dapr init test latest version retrieval

### DIFF
--- a/pkg/standalone/stop_windows.go
+++ b/pkg/standalone/stop_windows.go
@@ -20,6 +20,7 @@ import (
 	"time"
 
 	"github.com/dapr/cli/utils"
+
 	"github.com/kolesnikovae/go-winjob"
 	"golang.org/x/sys/windows"
 )

--- a/pkg/syscall/syscall_windows.go
+++ b/pkg/syscall/syscall_windows.go
@@ -26,6 +26,7 @@ import (
 	"golang.org/x/sys/windows"
 
 	"github.com/dapr/cli/pkg/print"
+
 	"github.com/kolesnikovae/go-winjob"
 	"github.com/kolesnikovae/go-winjob/jobapi"
 )

--- a/tests/e2e/standalone/init_test.go
+++ b/tests/e2e/standalone/init_test.go
@@ -27,6 +27,7 @@ import (
 	"time"
 
 	"github.com/Masterminds/semver"
+	"github.com/dapr/cli/pkg/version"
 	"github.com/dapr/cli/tests/e2e/common"
 	"github.com/dapr/cli/tests/e2e/spawn"
 	"github.com/docker/docker/api/types"
@@ -156,7 +157,11 @@ func TestStandaloneInit(t *testing.T) {
 		daprPath := filepath.Join(homeDir, ".dapr")
 		require.DirExists(t, daprPath, "Directory %s does not exist", daprPath)
 
-		latestDaprRuntimeVersion, latestDaprDashboardVersion := common.GetVersionsFromEnv(t, true)
+		latestDaprRuntimeVersion, err := version.GetDaprVersion()
+		require.NoError(t, err)
+		latestDaprDashboardVersion, err := version.GetDashboardVersion()
+		require.NoError(t, err)
+
 		verifyContainers(t, latestDaprRuntimeVersion)
 		verifyBinaries(t, daprPath, latestDaprRuntimeVersion, latestDaprDashboardVersion)
 		verifyConfigs(t, daprPath)
@@ -222,7 +227,11 @@ func TestStandaloneInit(t *testing.T) {
 		daprPath := filepath.Join(homeDir, ".dapr")
 		require.DirExists(t, daprPath, "Directory %s does not exist", daprPath)
 
-		latestDaprRuntimeVersion, latestDaprDashboardVersion := common.GetVersionsFromEnv(t, true)
+		latestDaprRuntimeVersion, err := version.GetDaprVersion()
+		require.NoError(t, err)
+		latestDaprDashboardVersion, err := version.GetDashboardVersion()
+		require.NoError(t, err)
+
 		verifyContainers(t, latestDaprRuntimeVersion+"-mariner")
 		verifyBinaries(t, daprPath, latestDaprRuntimeVersion, latestDaprDashboardVersion)
 		verifyConfigs(t, daprPath)


### PR DESCRIPTION
# Description

Some `dapr init` tests use the actual latest release from GitHub when running `dapr init` without `--runtime-version` flag. This breaks when a new version is released.
Changed the tests to compare the latest version from GitHub instead of env variable.
Lint fixes.

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #_[issue number]_

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [ ] Extended the documentation
