### PR TITLE
Add detection for incompatible flags with --run-file

### DIFF
--- a/cmd/run.go
+++ b/cmd/run.go
@@ -146,7 +146,7 @@ dapr run --run-file /path/to/directory -k
 			incompatibleFlags := detectIncompatibleFlags(cmd)
 			if len(incompatibleFlags) > 0 {
 				// Print warning message about incompatible flags
-				warningMsg := generateWarningMessage(incompatibleFlags)
+				warningMsg := "The following flags are ignored when using --run-file and should be configured in the run file instead: " + strings.Join(incompatibleFlags, ", ")
 				print.WarningStatusEvent(os.Stdout, warningMsg)
 			}
 
@@ -1101,12 +1101,4 @@ func detectIncompatibleFlags(cmd *cobra.Command) []string {
 	}
 
 	return incompatibleFlags
-}
-
-// generateWarningMessage creates an appropriate warning message based on the
-// number and types of incompatible flags
-func generateWarningMessage(incompatibleFlags []string) string {
-	return fmt.Sprintf(
-		"The following flags are ignored when using --run-file and should be configured in the run file instead: %s",
-		strings.Join(incompatibleFlags, ", "))
 }

--- a/cmd/run_test.go
+++ b/cmd/run_test.go
@@ -48,21 +48,3 @@ func TestDetectIncompatibleFlags(t *testing.T) {
 		assert.NotContains(t, incompatibleFlags, "kubernetes")
 	})
 }
-
-func TestGenerateWarningMessage(t *testing.T) {
-	t.Run("warning message", func(t *testing.T) {
-		warning := generateWarningMessage([]string{"app-id", "app-port"})
-		assert.Contains(t, warning, "app-id, app-port")
-		assert.Contains(t, warning, "ignored when using --run-file")
-	})
-
-	t.Run("warning message with multiple flags", func(t *testing.T) {
-		warning := generateWarningMessage([]string{
-			"app-id", "app-port", "app-protocol", "app-max-concurrency",
-			"dapr-http-port", "dapr-grpc-port", "resources-path",
-		})
-		assert.Contains(t, warning, "app-id")
-		assert.Contains(t, warning, "dapr-http-port")
-		assert.Contains(t, warning, "ignored when using --run-file")
-	})
-}

--- a/cmd/run_test.go
+++ b/cmd/run_test.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"testing"
 
+	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -15,5 +16,53 @@ func TestValidateSchedulerHostAddress(t *testing.T) {
 	t.Run("test scheduler host address - v1.15.0-rc.0", func(t *testing.T) {
 		address := validateSchedulerHostAddress("1.15.0", "")
 		assert.Equal(t, "localhost:50006", address)
+	})
+}
+
+func TestDetectIncompatibleFlags(t *testing.T) {
+	// Setup a temporary run file path to trigger the incompatible flag check
+	originalRunFilePath := runFilePath
+	runFilePath = "some/path"
+	defer func() {
+		// Restore the original runFilePath
+		runFilePath = originalRunFilePath
+	}()
+
+	t.Run("detect incompatible flags", func(t *testing.T) {
+		// Create a test command with flags
+		cmd := &cobra.Command{Use: "test"}
+		cmd.Flags().String("app-id", "", "")
+		cmd.Flags().String("dapr-http-port", "", "")
+		cmd.Flags().String("kubernetes", "", "") // Compatible flag
+
+		// Mark flags as changed
+		cmd.Flags().Set("app-id", "myapp")
+		cmd.Flags().Set("dapr-http-port", "3500")
+		cmd.Flags().Set("kubernetes", "true")
+
+		// Test detection
+		incompatibleFlags := detectIncompatibleFlags(cmd)
+		assert.Len(t, incompatibleFlags, 2)
+		assert.Contains(t, incompatibleFlags, "app-id")
+		assert.Contains(t, incompatibleFlags, "dapr-http-port")
+		assert.NotContains(t, incompatibleFlags, "kubernetes")
+	})
+}
+
+func TestGenerateWarningMessage(t *testing.T) {
+	t.Run("warning message", func(t *testing.T) {
+		warning := generateWarningMessage([]string{"app-id", "app-port"})
+		assert.Contains(t, warning, "app-id, app-port")
+		assert.Contains(t, warning, "ignored when using --run-file")
+	})
+
+	t.Run("warning message with multiple flags", func(t *testing.T) {
+		warning := generateWarningMessage([]string{
+			"app-id", "app-port", "app-protocol", "app-max-concurrency",
+			"dapr-http-port", "dapr-grpc-port", "resources-path",
+		})
+		assert.Contains(t, warning, "app-id")
+		assert.Contains(t, warning, "dapr-http-port")
+		assert.Contains(t, warning, "ignored when using --run-file")
 	})
 }

--- a/cmd/run_test.go
+++ b/cmd/run_test.go
@@ -33,12 +33,16 @@ func TestDetectIncompatibleFlags(t *testing.T) {
 		cmd := &cobra.Command{Use: "test"}
 		cmd.Flags().String("app-id", "", "")
 		cmd.Flags().String("dapr-http-port", "", "")
-		cmd.Flags().String("kubernetes", "", "") // Compatible flag
+		cmd.Flags().String("kubernetes", "", "")   // Compatible flag
+		cmd.Flags().String("runtime-path", "", "") // Compatible flag
+		cmd.Flags().String("log-as-json", "", "")  // Compatible flag
 
 		// Mark flags as changed
 		cmd.Flags().Set("app-id", "myapp")
 		cmd.Flags().Set("dapr-http-port", "3500")
 		cmd.Flags().Set("kubernetes", "true")
+		cmd.Flags().Set("runtime-path", "/path/to/runtime")
+		cmd.Flags().Set("log-as-json", "true")
 
 		// Test detection
 		incompatibleFlags := detectIncompatibleFlags(cmd)
@@ -46,5 +50,29 @@ func TestDetectIncompatibleFlags(t *testing.T) {
 		assert.Contains(t, incompatibleFlags, "app-id")
 		assert.Contains(t, incompatibleFlags, "dapr-http-port")
 		assert.NotContains(t, incompatibleFlags, "kubernetes")
+		assert.NotContains(t, incompatibleFlags, "runtime-path")
+		assert.NotContains(t, incompatibleFlags, "log-as-json")
+	})
+
+	t.Run("no incompatible flags when run file not specified", func(t *testing.T) {
+		// Create a test command with flags
+		cmd := &cobra.Command{Use: "test"}
+		cmd.Flags().String("app-id", "", "")
+		cmd.Flags().String("dapr-http-port", "", "")
+
+		// Mark flags as changed
+		cmd.Flags().Set("app-id", "myapp")
+		cmd.Flags().Set("dapr-http-port", "3500")
+
+		// Temporarily clear runFilePath
+		originalRunFilePath := runFilePath
+		runFilePath = ""
+		defer func() {
+			runFilePath = originalRunFilePath
+		}()
+
+		// Test detection
+		incompatibleFlags := detectIncompatibleFlags(cmd)
+		assert.Nil(t, incompatibleFlags)
 	})
 }

--- a/go.mod
+++ b/go.mod
@@ -24,6 +24,7 @@ require (
 	github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c
 	github.com/shirou/gopsutil v3.21.11+incompatible
 	github.com/spf13/cobra v1.8.1
+	github.com/spf13/pflag v1.0.5
 	github.com/spf13/viper v1.13.0
 	github.com/stretchr/testify v1.10.0
 	golang.org/x/mod v0.22.0
@@ -186,7 +187,6 @@ require (
 	github.com/spf13/afero v1.8.2 // indirect
 	github.com/spf13/cast v1.7.0 // indirect
 	github.com/spf13/jwalterweatherman v1.1.0 // indirect
-	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/spiffe/go-spiffe/v2 v2.1.7 // indirect
 	github.com/stoewer/go-strcase v1.3.0 // indirect
 	github.com/subosito/gotenv v1.4.1 // indirect


### PR DESCRIPTION
# Description

This PR adds detection for incompatible flags when using the `--run-file` flag in the `dapr run` command. When a user tries to use command line flags that are incompatible with the run file configuration, a warning message is now displayed to inform the user that these flags will be ignored and should instead be configured in the run file.

## Issue reference

Please reference the issue this PR will close: #1508 

## Changes implemented

- Added a list of flag names that are incompatible with the `--run-file` option
- Implemented a detection function (`detectIncompatibleFlags`) that identifies when incompatible flags are being used
- Created a message generator (`generateWarningMessage`) to create a clear warning for users
- Added logic in the run command to check for incompatible flags and display warnings
- Added unit tests for both the detection function and message generator

## Behavior change

**Before**: When using both `--run-file` and other command-line flags that should be configured in the run file, the command-line flags were silently ignored, potentially causing confusion for users.

**After**: When using both `--run-file` and incompatible command-line flags, a warning message is displayed to inform the user that these flags are ignored and should be configured in the run file.

## Example warning

```
WARNING: The following flags are ignored when using --run-file and should be configured in the run file instead: app-id, app-port, dapr-http-port
```

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Created/updated tests
* [ ] Extended the documentation 