### PR TITLE
chore: update stale bot duration to 90D

### DIFF
--- a/.github/workflows/dapr-bot-schedule.yml
+++ b/.github/workflows/dapr-bot-schedule.yml
@@ -28,7 +28,7 @@ jobs:
         repo-token: ${{ secrets.DAPR_BOT_TOKEN }}
         # Different amounts of days for issues/PRs are not currently supported but there is a PR
         # open for it: https://github.com/actions/stale/issues/214
-        days-before-stale: 30
+        days-before-stale: 90
         days-before-close: 7
         stale-issue-message: >
           This issue has been automatically marked as stale because it has not had activity in the
@@ -40,12 +40,12 @@ jobs:
           Thank you for your contributions.
         stale-pr-message: >
           This pull request has been automatically marked as stale because it has not had
-          activity in the last 30 days. It will be closed in 7 days if no further activity occurs. Please
+          activity in the last 90 days. It will be closed in 7 days if no further activity occurs. Please
           feel free to give a status update now, ping for review, or re-open when it's ready.
           Thank you for your contributions!
         close-pr-message: >
           This pull request has been automatically closed because it has not had
-          activity in the last 37 days. Please feel free to give a status update now, ping for review, or re-open when it's ready.
+          activity in the last 97 days. Please feel free to give a status update now, ping for review, or re-open when it's ready.
           Thank you for your contributions!
         stale-issue-label: 'stale'
         exempt-issue-labels: 'pinned,good first issue,help wanted,triaged/resolved'


### PR DESCRIPTION
# Description

Updates the stalebot to be a minimum of 90+7 days before closing issues/PRs

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #_[issue number]_

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [ ] Extended the documentation
