### PR TITLE
feat: ignore scheduler and placement connect

### DIFF
--- a/pkg/standalone/run.go
+++ b/pkg/standalone/run.go
@@ -129,6 +129,11 @@ func (config *RunConfig) validatePlacementHostAddr() error {
 	if len(placementHostAddr) == 0 {
 		placementHostAddr = "localhost"
 	}
+
+	if strings.TrimSpace(placementHostAddr) == "" {
+		return nil
+	}
+
 	if indx := strings.Index(placementHostAddr, ":"); indx == -1 {
 		if runtime.GOOS == daprWindowsOS {
 			placementHostAddr += ":6050"
@@ -143,6 +148,10 @@ func (config *RunConfig) validatePlacementHostAddr() error {
 func (config *RunConfig) validateSchedulerHostAddr() error {
 	schedulerHostAddr := config.SchedulerHostAddress
 	if len(schedulerHostAddr) == 0 {
+		return nil
+	}
+
+	if strings.TrimSpace(schedulerHostAddr) == "" {
 		return nil
 	}
 


### PR DESCRIPTION
# Description

_Please explain the changes you've made_

## Issue reference

#1503 

https://docs.dapr.io/reference/arguments-annotations-overview/

Sometimes when developing locally, we don't need placement and scheduler.

When using cli, provide capabilities consistent with annotation.
```
dapr run --placement-host-address " " --scheduler-host-address " " -a app-id
```

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #_[issue number]_

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [ ] Extended the documentation
