### PR TITLE
fix: allow explicit disable of placement with empty host

### DIFF
--- a/cmd/run.go
+++ b/cmd/run.go
@@ -189,26 +189,42 @@ dapr run --run-file /path/to/directory -k
 		}
 
 		sharedRunConfig := &standalone.SharedRunConfig{
-			ConfigFile:           configFile,
-			EnableProfiling:      enableProfiling,
-			LogLevel:             logLevel,
-			MaxConcurrency:       maxConcurrency,
-			AppProtocol:          protocol,
-			PlacementHostAddr:    viper.GetString("placement-host-address"),
-			ComponentsPath:       componentsPath,
-			ResourcesPaths:       resourcesPaths,
-			AppSSL:               appSSL,
-			MaxRequestBodySize:   maxRequestBodySize,
-			HTTPReadBufferSize:   readBufferSize,
-			EnableAppHealth:      enableAppHealth,
-			AppHealthPath:        appHealthPath,
-			AppHealthInterval:    appHealthInterval,
-			AppHealthTimeout:     appHealthTimeout,
-			AppHealthThreshold:   appHealthThreshold,
-			EnableAPILogging:     enableAPILogging,
-			APIListenAddresses:   apiListenAddresses,
-			SchedulerHostAddress: schedulerHostAddress,
-			DaprdInstallPath:     daprRuntimePath,
+			ConfigFile:         configFile,
+			EnableProfiling:    enableProfiling,
+			LogLevel:           logLevel,
+			MaxConcurrency:     maxConcurrency,
+			AppProtocol:        protocol,
+			ComponentsPath:     componentsPath,
+			ResourcesPaths:     resourcesPaths,
+			AppSSL:             appSSL,
+			MaxRequestBodySize: maxRequestBodySize,
+			HTTPReadBufferSize: readBufferSize,
+			EnableAppHealth:    enableAppHealth,
+			AppHealthPath:      appHealthPath,
+			AppHealthInterval:  appHealthInterval,
+			AppHealthTimeout:   appHealthTimeout,
+			AppHealthThreshold: appHealthThreshold,
+			EnableAPILogging:   enableAPILogging,
+			APIListenAddresses: apiListenAddresses,
+			DaprdInstallPath:   daprRuntimePath,
+		}
+
+		// placement-host-address flag handling: only set pointer if flag was explicitly changed
+		if cmd.Flags().Changed("placement-host-address") {
+			val := viper.GetString("placement-host-address")
+			sharedRunConfig.PlacementHostAddr = &val // may be empty => disable
+		}
+
+		// scheduler-host-address defaulting/handling
+		if cmd.Flags().Changed("scheduler-host-address") {
+			val := schedulerHostAddress
+			sharedRunConfig.SchedulerHostAddress = &val // may be empty => disable
+		} else {
+			// Apply version-based defaulting used previously
+			addr := validateSchedulerHostAddress(daprVer.RuntimeVersion, schedulerHostAddress)
+			if addr != "" {
+				sharedRunConfig.SchedulerHostAddress = &addr
+			}
 		}
 		output, err := runExec.NewOutput(&standalone.RunConfig{
 			AppID:             appID,
@@ -529,7 +545,15 @@ func executeRun(runTemplateName, runFilePath string, apps []runfileconfig.App) (
 		// Set defaults if zero value provided in config yaml.
 		app.RunConfig.SetDefaultFromSchema()
 
-		app.RunConfig.SchedulerHostAddress = validateSchedulerHostAddress(daprVer.RuntimeVersion, app.RunConfig.SchedulerHostAddress)
+		// Adjust scheduler host address defaults for run-file apps (pointer-aware)
+		var schedIn string
+		if app.RunConfig.SchedulerHostAddress != nil {
+			schedIn = *app.RunConfig.SchedulerHostAddress
+		}
+		schedOut := validateSchedulerHostAddress(daprVer.RuntimeVersion, schedIn)
+		if schedOut != "" {
+			app.RunConfig.SchedulerHostAddress = &schedOut
+		}
 
 		// Validate validates the configs and modifies the ports to free ports, appId etc.
 		err := app.RunConfig.Validate()
@@ -1012,7 +1036,7 @@ func putAppProcessIDInMeta(runE *runExec.RunExec) {
 func putAppCommandInMeta(runConfig standalone.RunConfig, runE *runExec.RunExec) {
 	appCommand := strings.Join(runConfig.Command, " ")
 	print.StatusEvent(runE.DaprCMD.OutputWriter, print.LogInfo, "Updating metadata for app command: %s", appCommand)
-	err := metadata.Put(runE.DaprHTTPPort, "appCommand", appCommand, runE.AppID, runConfig.UnixDomainSocket)
+	err := metadata.Put(runE.DaprHTTPPort, "appCommand", appCommand, runE.AppID, unixDomainSocket)
 	if err != nil {
 		print.StatusEvent(runE.DaprCMD.OutputWriter, print.LogWarning, "Could not update sidecar metadata for appCommand: %s", err.Error())
 		return

--- a/pkg/standalone/run.go
+++ b/pkg/standalone/run.go
@@ -72,7 +72,8 @@ type SharedRunConfig struct {
 	LogLevel           string `arg:"log-level" annotation:"dapr.io.log-level" yaml:"logLevel"`
 	MaxConcurrency     int    `arg:"app-max-concurrency" annotation:"dapr.io/app-max-concurrerncy" yaml:"appMaxConcurrency" default:"-1"`
 	// Speicifcally omitted from annotations similar to config file path above.
-	PlacementHostAddr string `arg:"placement-host-address" yaml:"placementHostAddress"`
+	// Pointer string to distinguish omitted (nil) vs explicitly empty (disable) vs value provided
+	PlacementHostAddr *string `arg:"placement-host-address" yaml:"placementHostAddress"`
 	// Speicifcally omitted from annotations similar to config file path above.
 	ComponentsPath string `arg:"components-path"` // Deprecated in run template file: use ResourcesPaths instead.
 	// Speicifcally omitted from annotations similar to config file path above.
@@ -90,11 +91,12 @@ type SharedRunConfig struct {
 	AppHealthThreshold int    `arg:"app-health-threshold" annotation:"dapr.io/app-health-threshold" ifneq:"0" yaml:"appHealthThreshold"`
 	EnableAPILogging   bool   `arg:"enable-api-logging" annotation:"dapr.io/enable-api-logging" yaml:"enableApiLogging"`
 	// Specifically omitted from annotations see https://github.com/dapr/cli/issues/1324 .
-	DaprdInstallPath     string            `yaml:"runtimePath"`
-	Env                  map[string]string `yaml:"env"`
-	DaprdLogDestination  LogDestType       `yaml:"daprdLogDestination"`
-	AppLogDestination    LogDestType       `yaml:"appLogDestination"`
-	SchedulerHostAddress string            `arg:"scheduler-host-address" yaml:"schedulerHostAddress"`
+	DaprdInstallPath    string            `yaml:"runtimePath"`
+	Env                 map[string]string `yaml:"env"`
+	DaprdLogDestination LogDestType       `yaml:"daprdLogDestination"`
+	AppLogDestination   LogDestType       `yaml:"appLogDestination"`
+	// Pointer string to distinguish omitted (nil) vs explicitly empty (disable) vs value provided
+	SchedulerHostAddress *string `arg:"scheduler-host-address" yaml:"schedulerHostAddress"`
 }
 
 func (meta *DaprMeta) newAppID() string {
@@ -125,9 +127,21 @@ func (config *RunConfig) validateResourcesPaths() error {
 }
 
 func (config *RunConfig) validatePlacementHostAddr() error {
-	placementHostAddr := strings.TrimSpace(config.PlacementHostAddr)
-	// If user explicitly set empty, honor that to disable placement
+	// nil => default localhost:port; empty => disable; non-empty => ensure port
+	if config.PlacementHostAddr == nil {
+		addr := "localhost"
+		if runtime.GOOS == daprWindowsOS {
+			addr += ":6050"
+		} else {
+			addr += ":50005"
+		}
+		config.PlacementHostAddr = &addr
+		return nil
+	}
+	placementHostAddr := strings.TrimSpace(*config.PlacementHostAddr)
 	if len(placementHostAddr) == 0 {
+		empty := ""
+		config.PlacementHostAddr = &empty
 		return nil
 	}
 	if indx := strings.Index(placementHostAddr, ":"); indx == -1 {
@@ -137,16 +151,21 @@ func (config *RunConfig) validatePlacementHostAddr() error {
 			placementHostAddr += ":50005"
 		}
 	}
-	config.PlacementHostAddr = placementHostAddr
+	config.PlacementHostAddr = &placementHostAddr
 	return nil
 }
 
 func (config *RunConfig) validateSchedulerHostAddr() error {
-	schedulerHostAddr := strings.TrimSpace(config.SchedulerHostAddress)
-	if len(schedulerHostAddr) == 0 {
+	// nil => leave as-is (set later based on version), empty => disable; non-empty => ensure port
+	if config.SchedulerHostAddress == nil {
 		return nil
 	}
-
+	schedulerHostAddr := strings.TrimSpace(*config.SchedulerHostAddress)
+	if len(schedulerHostAddr) == 0 {
+		empty := ""
+		config.SchedulerHostAddress = &empty
+		return nil
+	}
 	if indx := strings.Index(schedulerHostAddr, ":"); indx == -1 {
 		if runtime.GOOS == daprWindowsOS {
 			schedulerHostAddr += ":6060"
@@ -154,9 +173,7 @@ func (config *RunConfig) validateSchedulerHostAddr() error {
 			schedulerHostAddr += ":50006"
 		}
 	}
-
-	config.SchedulerHostAddress = schedulerHostAddr
-
+	config.SchedulerHostAddress = &schedulerHostAddr
 	return nil
 }
 
@@ -403,6 +420,13 @@ func getArgsFromSchema(schema reflect.Value, args []string) []string {
 		case []string:
 			if len(vType) > 0 {
 				for _, val := range vType {
+					args = append(args, key, val)
+				}
+			}
+		case *string:
+			if vType != nil {
+				val := strings.TrimSpace(*vType)
+				if len(val) != 0 && (!hasIfneq || val != ifneq) {
 					args = append(args, key, val)
 				}
 			}

--- a/pkg/standalone/run_test.go
+++ b/pkg/standalone/run_test.go
@@ -22,6 +22,8 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func strPtr(s string) *string { return &s }
+
 func TestGetEnv(t *testing.T) {
 	config := &RunConfig{
 		SharedRunConfig:   SharedRunConfig{},
@@ -144,68 +146,72 @@ func TestGetEnv(t *testing.T) {
 
 func TestValidatePlacementHostAddr(t *testing.T) {
 	t.Run("empty disables placement", func(t *testing.T) {
-		cfg := &RunConfig{SharedRunConfig: SharedRunConfig{PlacementHostAddr: ""}}
+		cfg := &RunConfig{SharedRunConfig: SharedRunConfig{PlacementHostAddr: strPtr("")}}
 		err := cfg.validatePlacementHostAddr()
 		assert.NoError(t, err)
-		assert.Equal(t, "", cfg.PlacementHostAddr)
+		assert.NotNil(t, cfg.PlacementHostAddr)
+		assert.Equal(t, "", *cfg.PlacementHostAddr)
 	})
 
 	t.Run("whitespace disables placement", func(t *testing.T) {
-		cfg := &RunConfig{SharedRunConfig: SharedRunConfig{PlacementHostAddr: "  "}}
+		cfg := &RunConfig{SharedRunConfig: SharedRunConfig{PlacementHostAddr: strPtr("  ")}}
 		err := cfg.validatePlacementHostAddr()
 		assert.NoError(t, err)
-		assert.Equal(t, "  ", cfg.PlacementHostAddr)
+		assert.NotNil(t, cfg.PlacementHostAddr)
+		assert.Equal(t, "", *cfg.PlacementHostAddr)
 	})
 
 	t.Run("default port appended when hostname provided without port", func(t *testing.T) {
-		cfg := &RunConfig{SharedRunConfig: SharedRunConfig{PlacementHostAddr: "localhost"}}
+		cfg := &RunConfig{SharedRunConfig: SharedRunConfig{PlacementHostAddr: strPtr("localhost")}}
 		err := cfg.validatePlacementHostAddr()
 		assert.NoError(t, err)
 		if runtime.GOOS == daprWindowsOS {
-			assert.True(t, strings.HasSuffix(cfg.PlacementHostAddr, ":6050"))
+			assert.True(t, strings.HasSuffix(*cfg.PlacementHostAddr, ":6050"))
 		} else {
-			assert.True(t, strings.HasSuffix(cfg.PlacementHostAddr, ":50005"))
+			assert.True(t, strings.HasSuffix(*cfg.PlacementHostAddr, ":50005"))
 		}
 	})
 
 	t.Run("custom port preserved when provided", func(t *testing.T) {
-		cfg := &RunConfig{SharedRunConfig: SharedRunConfig{PlacementHostAddr: "1.2.3.4:12345"}}
+		cfg := &RunConfig{SharedRunConfig: SharedRunConfig{PlacementHostAddr: strPtr("1.2.3.4:12345")}}
 		err := cfg.validatePlacementHostAddr()
 		assert.NoError(t, err)
-		assert.Equal(t, "1.2.3.4:12345", cfg.PlacementHostAddr)
+		assert.Equal(t, "1.2.3.4:12345", *cfg.PlacementHostAddr)
 	})
 }
 
 func TestValidateSchedulerHostAddr(t *testing.T) {
 	t.Run("empty disables scheduler", func(t *testing.T) {
-		cfg := &RunConfig{SharedRunConfig: SharedRunConfig{SchedulerHostAddress: ""}}
+		cfg := &RunConfig{SharedRunConfig: SharedRunConfig{SchedulerHostAddress: strPtr("")}}
 		err := cfg.validateSchedulerHostAddr()
 		assert.NoError(t, err)
-		assert.Equal(t, "", cfg.SchedulerHostAddress)
+		assert.NotNil(t, cfg.SchedulerHostAddress)
+		assert.Equal(t, "", *cfg.SchedulerHostAddress)
 	})
 
 	t.Run("whitespace disables scheduler", func(t *testing.T) {
-		cfg := &RunConfig{SharedRunConfig: SharedRunConfig{SchedulerHostAddress:  "  "}}
+		cfg := &RunConfig{SharedRunConfig: SharedRunConfig{SchedulerHostAddress: strPtr("  ")}}
 		err := cfg.validateSchedulerHostAddr()
 		assert.NoError(t, err)
-		assert.Equal(t, "  ", cfg.SchedulerHostAddress)
+		assert.NotNil(t, cfg.SchedulerHostAddress)
+		assert.Equal(t, "", *cfg.SchedulerHostAddress)
 	})
 
 	t.Run("default port appended when hostname provided without port", func(t *testing.T) {
-		cfg := &RunConfig{SharedRunConfig: SharedRunConfig{SchedulerHostAddress: "localhost"}}
+		cfg := &RunConfig{SharedRunConfig: SharedRunConfig{SchedulerHostAddress: strPtr("localhost")}}
 		err := cfg.validateSchedulerHostAddr()
 		assert.NoError(t, err)
 		if runtime.GOOS == daprWindowsOS {
-			assert.True(t, strings.HasSuffix(cfg.SchedulerHostAddress, ":6060"))
+			assert.True(t, strings.HasSuffix(*cfg.SchedulerHostAddress, ":6060"))
 		} else {
-			assert.True(t, strings.HasSuffix(cfg.SchedulerHostAddress, ":50006"))
+			assert.True(t, strings.HasSuffix(*cfg.SchedulerHostAddress, ":50006"))
 		}
 	})
 
 	t.Run("custom port preserved when provided", func(t *testing.T) {
-		cfg := &RunConfig{SharedRunConfig: SharedRunConfig{SchedulerHostAddress: "1.2.3.4:45678"}}
+		cfg := &RunConfig{SharedRunConfig: SharedRunConfig{SchedulerHostAddress: strPtr("1.2.3.4:45678")}}
 		err := cfg.validateSchedulerHostAddr()
 		assert.NoError(t, err)
-		assert.Equal(t, "1.2.3.4:45678", cfg.SchedulerHostAddress)
+		assert.Equal(t, "1.2.3.4:45678", *cfg.SchedulerHostAddress)
 	})
 }


### PR DESCRIPTION
# Description

- This PR fixes a behavior where passing an explicitly empty placement host address should disable Placement, but instead the runtime still attempted to connect. It also aligns the CLI behavior and help so that users can reliably disable Placement without actors/workflows.

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: fixes: https://github.com/dapr/dapr/issues/9000

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Created/updated tests
* [ ] Extended the documentation
