### PR TITLE
fix: vulnerability cve-2025-53547

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -30,7 +30,7 @@ require (
 	golang.org/x/mod v0.25.0
 	golang.org/x/sys v0.33.0
 	gopkg.in/yaml.v2 v2.4.0
-	helm.sh/helm/v3 v3.17.1
+	helm.sh/helm/v3 v3.18.4
 	k8s.io/api v0.32.1
 	k8s.io/apiextensions-apiserver v0.32.1
 	k8s.io/apimachinery v0.33.0


### PR DESCRIPTION
# Description
Fixes [CVE-2025-53547](https://avd.aquasec.com/nvd/2025/cve-2025-53547/)

_Please explain the changes you've made_
Upgraded the helm chart version from 3.17 to 3.18.4

## Issue reference
We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #_[issue number]_

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [ ] Extended the documentation
