### PR TITLE
feat: add --redis-stack flag to dapr init for RediSearch support

### DIFF
--- a/cmd/init.go
+++ b/cmd/init.go
@@ -47,6 +47,7 @@ var (
 	imageVariant                       string
 	schedulerVolume                    string
 	schedulerOverrideBroadcastHostPort string
+	redisStack                         bool
 )
 
 var InitCmd = &cobra.Command{
@@ -95,6 +96,9 @@ dapr init --image-variant <variant>
 # Folder .dapr will be created in folder pointed to by <path-to-install-directory>
 dapr init --runtime-path <path-to-install-directory>
 
+# Initialize Dapr in self-hosted mode with Redis Stack for RediSearch/vector store support
+dapr init --redis-stack
+
 # See more at: https://docs.dapr.io/getting-started/
 `,
 	Run: func(cmd *cobra.Command, args []string) {
@@ -108,6 +112,10 @@ dapr init --runtime-path <path-to-install-directory>
 
 			if len(strings.TrimSpace(runtime.GetDaprRuntimePath())) != 0 {
 				print.FailureStatusEvent(os.Stderr, "--runtime-path is only valid for self-hosted mode")
+				os.Exit(1)
+			}
+			if redisStack {
+				print.FailureStatusEvent(os.Stderr, "--redis-stack is only valid for self-hosted mode")
 				os.Exit(1)
 			}
 
@@ -176,7 +184,7 @@ dapr init --runtime-path <path-to-install-directory>
 				schedulerHostPort = nil
 			}
 
-			err := standalone.Init(runtimeVersion, dockerNetwork, slimMode, imageRegistryURI, fromDir, containerRuntime, imageVariant, runtime.GetDaprRuntimePath(), &schedulerVolume, schedulerHostPort)
+			err := standalone.Init(runtimeVersion, dockerNetwork, slimMode, imageRegistryURI, fromDir, containerRuntime, imageVariant, runtime.GetDaprRuntimePath(), &schedulerVolume, schedulerHostPort, redisStack)
 			if err != nil {
 				print.FailureStatusEvent(os.Stderr, err.Error())
 				os.Exit(1)
@@ -225,6 +233,7 @@ func init() {
 	InitCmd.Flags().StringVarP(&imageVariant, "image-variant", "", "", "The image variant to use for the Dapr runtime, for example: mariner")
 	InitCmd.Flags().StringVarP(&schedulerVolume, "scheduler-volume", "", "dapr_scheduler", "Self-hosted only. Specify a volume for the scheduler service data directory.")
 	InitCmd.Flags().StringVarP(&schedulerOverrideBroadcastHostPort, "scheduler-override-broadcast-host-port", "", "", "Self-hosted only. Specify the scheduler broadcast host and port, for example: 192.168.42.42:50006. If not specified, it uses localhost:50006 (6060 for Windows).")
+	InitCmd.Flags().BoolVarP(&redisStack, "redis-stack", "", false, "Self-hosted only. Use redis-stack-server image instead of standard Redis for RediSearch support")
 	InitCmd.Flags().BoolP("help", "h", false, "Print this help message")
 	InitCmd.Flags().StringArrayVar(&values, "set", []string{}, "set values on the command line (can specify multiple or separate values with commas: key1=val1,key2=val2)")
 	InitCmd.Flags().String("image-registry", "", "Custom/private docker image repository URL")

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -184,7 +184,19 @@ dapr init --redis-stack
 				schedulerHostPort = nil
 			}
 
-			err := standalone.Init(runtimeVersion, dockerNetwork, slimMode, imageRegistryURI, fromDir, containerRuntime, imageVariant, runtime.GetDaprRuntimePath(), &schedulerVolume, schedulerHostPort, redisStack)
+			err := standalone.Init(standalone.InitOptions{
+				RuntimeVersion:                     runtimeVersion,
+				DockerNetwork:                      dockerNetwork,
+				SlimMode:                           slimMode,
+				ImageRegistryURL:                   imageRegistryURI,
+				FromDir:                            fromDir,
+				ContainerRuntime:                   containerRuntime,
+				ImageVariant:                       imageVariant,
+				DaprInstallPath:                    runtime.GetDaprRuntimePath(),
+				SchedulerVolume:                    &schedulerVolume,
+				SchedulerOverrideBroadcastHostPort: schedulerHostPort,
+				RedisStack:                         redisStack,
+			})
 			if err != nil {
 				print.FailureStatusEvent(os.Stderr, err.Error())
 				os.Exit(1)

--- a/pkg/standalone/standalone.go
+++ b/pkg/standalone/standalone.go
@@ -58,20 +58,20 @@ const (
 	githubContainerRegistryName = "ghcr"
 
 	// used when DAPR_DEFAULT_IMAGE_REGISTRY is not set.
-	daprDockerImageName        = "docker.io/daprio/dapr"
-	redisDockerImageName       = "docker.io/redis:6"
-	redisStackDockerImageName  = "docker.io/redis/redis-stack-server:7.2.0-v19"
-	zipkinDockerImageName      = "docker.io/openzipkin/zipkin"
+	daprDockerImageName       = "docker.io/daprio/dapr"
+	redisDockerImageName      = "docker.io/redis:6"
+	redisStackDockerImageName = "docker.io/redis/redis-stack-server:7.2.0-v19"
+	zipkinDockerImageName     = "docker.io/openzipkin/zipkin"
 
 	// used when DAPR_DEFAULT_IMAGE_REGISTRY is set as GHCR.
 	dockerURI = "docker.io"
 	ghcrURI   = "ghcr.io"
 
 	// used when DAPR_DEFAULT_IMAGE_REGISTRY is set as GHCR or image-registry flag is set.
-	daprGhcrImageName        = "dapr/dapr"
-	redisGhcrImageName       = "dapr/3rdparty/redis:6"
-	redisStackGhcrImageName  = "dapr/3rdparty/redis-stack-server:7.2.0-v19"
-	zipkinGhcrImageName      = "dapr/3rdparty/zipkin"
+	daprGhcrImageName       = "dapr/dapr"
+	redisGhcrImageName      = "dapr/3rdparty/redis:6"
+	redisStackGhcrImageName = "dapr/3rdparty/redis-stack-server:7.2.0-v19"
+	zipkinGhcrImageName     = "dapr/3rdparty/zipkin"
 
 	// DaprPlacementContainerName is the container name of placement service.
 	DaprPlacementContainerName = "dapr_placement"
@@ -148,6 +148,21 @@ type initInfo struct {
 	redisStack                         bool
 }
 
+// InitOptions configures a standalone Dapr initialization.
+type InitOptions struct {
+	RuntimeVersion                     string
+	DockerNetwork                      string
+	SlimMode                           bool
+	ImageRegistryURL                   string
+	FromDir                            string
+	ContainerRuntime                   string
+	ImageVariant                       string
+	DaprInstallPath                    string
+	SchedulerVolume                    *string
+	SchedulerOverrideBroadcastHostPort *string
+	RedisStack                         bool
+}
+
 type daprImageInfo struct {
 	ghcrImageName      string
 	dockerHubImageName string
@@ -187,9 +202,21 @@ func isSchedulerIncluded(runtimeVersion string) (bool, error) {
 }
 
 // Init installs Dapr on a local machine using the supplied runtimeVersion.
-func Init(runtimeVersion string, dockerNetwork string, slimMode bool, imageRegistryURL string, fromDir string, containerRuntime string, imageVariant string, daprInstallPath string, schedulerVolume *string, schedulerOverrideBroadcastHostPort *string, redisStack bool) error {
+func Init(opts InitOptions) error {
 	var err error
 	var bundleDet bundleDetails
+	runtimeVersion := opts.RuntimeVersion
+	dockerNetwork := opts.DockerNetwork
+	slimMode := opts.SlimMode
+	imageRegistryURL := opts.ImageRegistryURL
+	fromDir := opts.FromDir
+	containerRuntime := opts.ContainerRuntime
+	imageVariant := opts.ImageVariant
+	daprInstallPath := opts.DaprInstallPath
+	schedulerVolume := opts.SchedulerVolume
+	schedulerOverrideBroadcastHostPort := opts.SchedulerOverrideBroadcastHostPort
+	redisStack := opts.RedisStack
+
 	containerRuntime = strings.TrimSpace(containerRuntime)
 	daprInstallPath = strings.TrimSpace(daprInstallPath)
 	// AirGap init flow is true when fromDir var is set i.e. --from-dir flag has value.

--- a/pkg/standalone/standalone.go
+++ b/pkg/standalone/standalone.go
@@ -58,18 +58,20 @@ const (
 	githubContainerRegistryName = "ghcr"
 
 	// used when DAPR_DEFAULT_IMAGE_REGISTRY is not set.
-	daprDockerImageName   = "docker.io/daprio/dapr"
-	redisDockerImageName  = "docker.io/redis:6"
-	zipkinDockerImageName = "docker.io/openzipkin/zipkin"
+	daprDockerImageName        = "docker.io/daprio/dapr"
+	redisDockerImageName       = "docker.io/redis:6"
+	redisStackDockerImageName  = "docker.io/redis/redis-stack-server:7.2.0-v19"
+	zipkinDockerImageName      = "docker.io/openzipkin/zipkin"
 
 	// used when DAPR_DEFAULT_IMAGE_REGISTRY is set as GHCR.
 	dockerURI = "docker.io"
 	ghcrURI   = "ghcr.io"
 
 	// used when DAPR_DEFAULT_IMAGE_REGISTRY is set as GHCR or image-registry flag is set.
-	daprGhcrImageName   = "dapr/dapr"
-	redisGhcrImageName  = "dapr/3rdparty/redis:6"
-	zipkinGhcrImageName = "dapr/3rdparty/zipkin"
+	daprGhcrImageName        = "dapr/dapr"
+	redisGhcrImageName       = "dapr/3rdparty/redis:6"
+	redisStackGhcrImageName  = "dapr/3rdparty/redis-stack-server:7.2.0-v19"
+	zipkinGhcrImageName      = "dapr/3rdparty/zipkin"
 
 	// DaprPlacementContainerName is the container name of placement service.
 	DaprPlacementContainerName = "dapr_placement"
@@ -143,6 +145,7 @@ type initInfo struct {
 	imageVariant                       string
 	schedulerVolume                    *string
 	schedulerOverrideBroadcastHostPort *string
+	redisStack                         bool
 }
 
 type daprImageInfo struct {
@@ -184,7 +187,7 @@ func isSchedulerIncluded(runtimeVersion string) (bool, error) {
 }
 
 // Init installs Dapr on a local machine using the supplied runtimeVersion.
-func Init(runtimeVersion string, dockerNetwork string, slimMode bool, imageRegistryURL string, fromDir string, containerRuntime string, imageVariant string, daprInstallPath string, schedulerVolume *string, schedulerOverrideBroadcastHostPort *string) error {
+func Init(runtimeVersion string, dockerNetwork string, slimMode bool, imageRegistryURL string, fromDir string, containerRuntime string, imageVariant string, daprInstallPath string, schedulerVolume *string, schedulerOverrideBroadcastHostPort *string, redisStack bool) error {
 	var err error
 	var bundleDet bundleDetails
 	containerRuntime = strings.TrimSpace(containerRuntime)
@@ -304,6 +307,7 @@ func Init(runtimeVersion string, dockerNetwork string, slimMode bool, imageRegis
 		imageVariant:                       imageVariant,
 		schedulerVolume:                    schedulerVolume,
 		schedulerOverrideBroadcastHostPort: schedulerOverrideBroadcastHostPort,
+		redisStack:                         redisStack,
 	}
 	for _, step := range initSteps {
 		// Run init on the configurations and containers.
@@ -448,12 +452,7 @@ func runRedis(wg *sync.WaitGroup, errorChan chan<- error, info initInfo) {
 		// do not create container again if it exists.
 		args = append(args, "start", redisContainerName)
 	} else {
-		imageName, err = resolveImageURI(daprImageInfo{
-			ghcrImageName:      redisGhcrImageName,
-			dockerHubImageName: redisDockerImageName,
-			imageRegistryURL:   info.imageRegistryURL,
-			imageRegistryName:  defaultImageRegistryName,
-		})
+		imageName, err = resolveImageURI(redisImageInfo(info.redisStack, info.imageRegistryURL, defaultImageRegistryName))
 		if err != nil {
 			errorChan <- err
 			return
@@ -489,6 +488,24 @@ func runRedis(wg *sync.WaitGroup, errorChan chan<- error, info initInfo) {
 		return
 	}
 	errorChan <- nil
+}
+
+func redisImageInfo(redisStack bool, imageRegistryURL string, imageRegistryName string) daprImageInfo {
+	if redisStack {
+		return daprImageInfo{
+			ghcrImageName:      redisStackGhcrImageName,
+			dockerHubImageName: redisStackDockerImageName,
+			imageRegistryURL:   imageRegistryURL,
+			imageRegistryName:  imageRegistryName,
+		}
+	}
+
+	return daprImageInfo{
+		ghcrImageName:      redisGhcrImageName,
+		dockerHubImageName: redisDockerImageName,
+		imageRegistryURL:   imageRegistryURL,
+		imageRegistryName:  imageRegistryName,
+	}
 }
 
 func runPlacementService(wg *sync.WaitGroup, errorChan chan<- error, info initInfo) {

--- a/pkg/standalone/standalone_test.go
+++ b/pkg/standalone/standalone_test.go
@@ -375,7 +375,11 @@ func TestInitLogActualContainerRuntimeName(t *testing.T) {
 				t.Skip("Skipping test as container runtime is available")
 			}
 
-			err := Init(latestVersion, "", false, "", "", test.containerRuntime, "", "", nil, ptr.Of("localhost:50006"), false)
+			err := Init(InitOptions{
+				RuntimeVersion:                     latestVersion,
+				ContainerRuntime:                   test.containerRuntime,
+				SchedulerOverrideBroadcastHostPort: ptr.Of("localhost:50006"),
+			})
 			assert.Error(t, err)
 			assert.Contains(t, err.Error(), test.containerRuntime)
 		})

--- a/pkg/standalone/standalone_test.go
+++ b/pkg/standalone/standalone_test.go
@@ -198,6 +198,55 @@ func TestResolveImageWithPrivateRegistry(t *testing.T) {
 	}
 }
 
+func TestRedisImageInfo(t *testing.T) {
+	tests := []struct {
+		name              string
+		redisStack        bool
+		imageRegistryURL  string
+		imageRegistryName string
+		expect            string
+	}{
+		{
+			name:              "standard redis with Docker Hub",
+			redisStack:        false,
+			imageRegistryName: dockerContainerRegistryName,
+			expect:            "docker.io/redis:6",
+		},
+		{
+			name:              "redis stack with Docker Hub",
+			redisStack:        true,
+			imageRegistryName: dockerContainerRegistryName,
+			expect:            "docker.io/redis/redis-stack-server:7.2.0-v19",
+		},
+		{
+			name:              "standard redis with GHCR",
+			redisStack:        false,
+			imageRegistryName: githubContainerRegistryName,
+			expect:            "ghcr.io/dapr/3rdparty/redis:6",
+		},
+		{
+			name:              "redis stack with GHCR",
+			redisStack:        true,
+			imageRegistryName: githubContainerRegistryName,
+			expect:            "ghcr.io/dapr/3rdparty/redis-stack-server:7.2.0-v19",
+		},
+		{
+			name:             "redis stack with private registry",
+			redisStack:       true,
+			imageRegistryURL: "docker.io/username",
+			expect:           "docker.io/username/dapr/3rdparty/redis-stack-server:7.2.0-v19",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got, err := resolveImageURI(redisImageInfo(test.redisStack, test.imageRegistryURL, test.imageRegistryName))
+			assert.NoError(t, err)
+			assert.Equal(t, test.expect, got)
+		})
+	}
+}
+
 func TestResolveImageErr(t *testing.T) {
 	redisImageInfo := daprImageInfo{
 		ghcrImageName:      redisGhcrImageName,
@@ -326,7 +375,7 @@ func TestInitLogActualContainerRuntimeName(t *testing.T) {
 				t.Skip("Skipping test as container runtime is available")
 			}
 
-			err := Init(latestVersion, "", false, "", "", test.containerRuntime, "", "", nil, ptr.Of("localhost:50006"))
+			err := Init(latestVersion, "", false, "", "", test.containerRuntime, "", "", nil, ptr.Of("localhost:50006"), false)
 			assert.Error(t, err)
 			assert.Contains(t, err.Error(), test.containerRuntime)
 		})

--- a/tests/e2e/standalone/init_test.go
+++ b/tests/e2e/standalone/init_test.go
@@ -113,6 +113,27 @@ func TestStandaloneInit(t *testing.T) {
 		verifyConfigs(t, daprPath)
 	})
 
+	t.Run("init with redis stack", func(t *testing.T) {
+		if isSlimMode() {
+			t.Skip("Skipping Redis Stack init test because of slim installation")
+		}
+
+		// Ensure a clean environment
+		must(t, cmdUninstall, "failed to uninstall Dapr")
+
+		args := []string{
+			"--runtime-version", daprRuntimeVersion,
+			"--redis-stack",
+		}
+		output, err := cmdInit(args...)
+		t.Log(output)
+		require.NoError(t, err, "init failed")
+		assert.Contains(t, output, "Success! Dapr is up and running.")
+
+		verifyContainers(t, daprRuntimeVersion)
+		verifyRedisContainerImage(t, "redis-stack-server:7.2.0-v19")
+	})
+
 	t.Run("init with mariner images", func(t *testing.T) {
 		// Ensure a clean environment
 		must(t, cmdUninstall, "failed to uninstall Dapr")
@@ -245,6 +266,27 @@ func TestStandaloneInit(t *testing.T) {
 		verifyBinaries(t, daprPath, latestDaprRuntimeVersion)
 		verifyConfigs(t, daprPath)
 	})
+}
+
+func verifyRedisContainerImage(t *testing.T, expectedImageSubstring string) {
+	t.Helper()
+
+	cli, err := dockerClient.NewClientWithOpts(dockerClient.FromEnv, dockerClient.WithVersion("1.48"))
+	require.NoError(t, err)
+
+	containers, err := cli.ContainerList(context.Background(), container.ListOptions{})
+	require.NoError(t, err)
+
+	for _, container := range containers {
+		for _, name := range container.Names {
+			if strings.TrimPrefix(name, "/") == "dapr_redis" {
+				assert.Contains(t, container.Image, expectedImageSubstring)
+				return
+			}
+		}
+	}
+
+	require.Fail(t, "dapr_redis container was not found")
 }
 
 // verifyContainers ensures that the correct containers are up and running.


### PR DESCRIPTION
Currently dapr init deploys a standard Redis container (redis:6) that does not include RediSearch. RediSearch is required for Dapr Agents' vector store capabilities and must be explicitly loaded or bundled in a Redis distribution that includes it.

This PR adds a `--redis-stack` flag to the `dapr init` command that switches the deployed Redis image to `redis/redis-stack-server`, which bundles Redis OSS with RediSearch and other modules pre-installed.

**Usage:**
```bash
dapr init --redis-stack
```

**Changes:**
- Added `redisStackDockerImageName` and `redisStackGhcrImageName` constants for the redis-stack image
- Added `redisStack` field to `initInfo` struct
- Modified `Init()` function signature to accept the new `redisStack` parameter
- Updated `runRedis()` to use the redis-stack image when the flag is set
- Added `--redis-stack` flag to the init command with appropriate help text and example

The change is opt-in via the flag, so existing behavior remains unchanged for users who don't need RediSearch.

Closes #1607
