### PR TITLE
Add support for customizing log file directory (logsDir) in Multi-App…

### DIFF
--- a/pkg/runfileconfig/run_file_config.go
+++ b/pkg/runfileconfig/run_file_config.go
@@ -51,6 +51,7 @@ type App struct {
 	standalone.RunConfig   `yaml:",inline"`
 	ContainerConfiguration `yaml:",inline"`
 	AppDirPath             string `yaml:"appDirPath"`
+	LogsDir                string `yaml:"logsDir,omitempty"`
 	AppLogFileName         string
 	DaprdLogFileName       string
 	AppLogWriteCloser      io.WriteCloser
@@ -60,10 +61,17 @@ type App struct {
 // Common represents the configuration options for the common section in the run file.
 type Common struct {
 	standalone.SharedRunConfig `yaml:",inline"`
+	LogsDir                    string `yaml:"logsDir,omitempty"`
 }
 
+// GetLogsDir returns the directory where the app and daprd log files are written.
+// It defaults to '<appDirPath>/.dapr/logs' unless a custom 'logsDir' is provided
+// in the run template file. The directory is created if it does not exist.
 func (a *App) GetLogsDir() string {
-	logsPath := filepath.Join(a.AppDirPath, standalone.DefaultDaprDirName, logsDir)
+	logsPath := a.LogsDir
+	if logsPath == "" {
+		logsPath = filepath.Join(a.AppDirPath, standalone.DefaultDaprDirName, logsDir)
+	}
 	os.MkdirAll(logsPath, 0o755)
 	return logsPath
 }

--- a/pkg/runfileconfig/run_file_config_parser.go
+++ b/pkg/runfileconfig/run_file_config_parser.go
@@ -72,6 +72,12 @@ func (a *RunFileConfig) validateRunConfig(runFilePath string) error {
 		a.Common.ResourcesPaths = append(a.Common.ResourcesPaths, a.Common.ResourcesPath)
 	}
 
+	// Resolve common's section LogsDir to an absolute path. The directory is not
+	// required to exist, it is created when the log files are written.
+	if err := a.resolvePathToAbs(baseDir, &a.Common.LogsDir); err != nil {
+		return err
+	}
+
 	for i := range len(a.Apps) {
 		if a.Apps[i].AppDirPath == "" {
 			return errors.New("required field 'appDirPath' not found in the provided app config file")
@@ -98,6 +104,16 @@ func (a *RunFileConfig) validateRunConfig(runFilePath string) error {
 		// Merge app's section ResourcesPaths and ResourcePath. ResourcesPaths will be single source of truth for resources to be loaded.
 		if len(strings.TrimSpace(a.Apps[i].ResourcesPath)) > 0 {
 			a.Apps[i].ResourcesPaths = append(a.Apps[i].ResourcesPaths, a.Apps[i].ResourcesPath)
+		}
+
+		// Resolve the app's LogsDir to an absolute path relative to AppDirPath.
+		// The directory is not required to exist, it is created when the log files are written.
+		// Precedence order -> apps[i].logsDir > common.logsDir > default (<appDirPath>/.dapr/logs).
+		if err := a.resolvePathToAbs(a.Apps[i].AppDirPath, &a.Apps[i].LogsDir); err != nil {
+			return err
+		}
+		if a.Apps[i].LogsDir == "" {
+			a.Apps[i].LogsDir = a.Common.LogsDir
 		}
 
 		// Check containerImagePullPolicy is valid.
@@ -209,6 +225,20 @@ func (a *RunFileConfig) getBasePathFromAbsPath(appDirPath string) (string, error
 		return filepath.Base(appDirPath), nil
 	}
 	return "", fmt.Errorf("error in getting the base path from the provided appDirPath %q: ", appDirPath)
+}
+
+// resolvePathToAbs resolves a relative path in the run file to an absolute path
+// without validating that it exists.
+func (a *RunFileConfig) resolvePathToAbs(baseDir string, path *string) error {
+	if *path == "" {
+		return nil
+	}
+	resolved, err := utils.ResolveHomeDir(*path)
+	if err != nil {
+		return err
+	}
+	*path = utils.GetAbsPath(baseDir, resolved)
+	return nil
 }
 
 // resolvePathToAbsAndValidate resolves the relative paths in run file to absolute path and validates the file path.

--- a/pkg/runfileconfig/run_file_config_parser_test.go
+++ b/pkg/runfileconfig/run_file_config_parser_test.go
@@ -33,6 +33,7 @@ var (
 	runFileForPrecedenceRuleDaprDir = filepath.Join(".", "testdata", "test_run_config_precedence_rule_dapr_dir.yaml")
 	runFileForLogDestination        = filepath.Join(".", "testdata", "test_run_config_log_destination.yaml")
 	runFileForMultiResourcePaths    = filepath.Join(".", "testdata", "test_run_config_multiple_resources_paths.yaml")
+	runFileForLogsDir               = filepath.Join(".", "testdata", "test_run_config_logs_dir.yaml")
 
 	runFileForContainerImagePullPolicy        = filepath.Join(".", "testdata", "test_run_config_container_image_pull_policy.yaml")
 	runFileForContainerImagePullPolicyInvalid = filepath.Join(".", "testdata", "test_run_config_container_image_pull_policy_invalid.yaml")
@@ -404,4 +405,58 @@ func getResourcesAndConfigFilePaths(t *testing.T, daprInstallPath string) []stri
 	result[0] = standalone.GetDaprComponentsPath(daprDirPath)
 	result[1] = standalone.GetDaprConfigPath(daprDirPath)
 	return result
+}
+
+func TestLogsDirPrecedenceAndResolution(t *testing.T) {
+	config := RunFileConfig{}
+	apps, err := config.GetApps(runFileForLogsDir)
+	assert.NoError(t, err)
+	assert.Len(t, apps, 3)
+
+	testDataDir, err := filepath.Abs(filepath.Join(".", "testdata"))
+	assert.NoError(t, err)
+
+	// common's relative logsDir is resolved against the run file's directory.
+	expectedCommonLogsDir := filepath.Join(testDataDir, "central-logs")
+	// app_2's relative logsDir is resolved against its appDirPath.
+	expectedApp2LogsDir := filepath.Join(testDataDir, "webapp", "custom-logs")
+
+	t.Run("app without logsDir inherits common's logsDir", func(t *testing.T) {
+		assert.Equal(t, expectedCommonLogsDir, apps[0].LogsDir)
+		assert.Equal(t, expectedCommonLogsDir, apps[0].GetLogsDir())
+	})
+
+	t.Run("app's relative logsDir overrides common and resolves against appDirPath", func(t *testing.T) {
+		assert.Equal(t, expectedApp2LogsDir, apps[1].LogsDir)
+		assert.Equal(t, expectedApp2LogsDir, apps[1].GetLogsDir())
+	})
+
+	t.Run("app's absolute logsDir is used as is", func(t *testing.T) {
+		assert.Equal(t, "/tmp/dapr-abs-logs", apps[2].LogsDir)
+		assert.Equal(t, "/tmp/dapr-abs-logs", apps[2].GetLogsDir())
+	})
+
+	t.Run("logs directory is created on use", func(t *testing.T) {
+		logsDir := apps[0].GetLogsDir()
+		stat, err := os.Stat(logsDir)
+		assert.NoError(t, err)
+		assert.True(t, stat.IsDir())
+	})
+
+	t.Cleanup(func() {
+		os.RemoveAll(expectedCommonLogsDir)
+		os.RemoveAll(expectedApp2LogsDir)
+		os.RemoveAll("/tmp/dapr-abs-logs")
+	})
+}
+
+func TestLogsDirDefault(t *testing.T) {
+	config := RunFileConfig{}
+	apps, err := config.GetApps(validRunFilePath)
+	assert.NoError(t, err)
+	for _, app := range apps {
+		assert.Empty(t, app.LogsDir)
+		expected := filepath.Join(app.AppDirPath, standalone.DefaultDaprDirName, "logs")
+		assert.Equal(t, expected, app.GetLogsDir())
+	}
 }

--- a/pkg/runfileconfig/testdata/test_run_config_logs_dir.yaml
+++ b/pkg/runfileconfig/testdata/test_run_config_logs_dir.yaml
@@ -1,0 +1,12 @@
+version: 1
+common:
+  logsDir: ./central-logs/
+apps:
+  - appDirPath: ./webapp/
+    appID: app_1
+  - appDirPath: ./webapp/
+    appID: app_2
+    logsDir: ./custom-logs/
+  - appDirPath: ./backend/
+    appID: app_3
+    logsDir: /tmp/dapr-abs-logs


### PR DESCRIPTION
# Description

When using Multi-App Run (`dapr run -f`), app and daprd log files are always written to `<appDirPath>/.dapr/logs`, with no way to change the location. This causes two problems:

1. **File watchers in dev workflows.** Dev servers that recursively watch the project tree (e.g. uvicorn `--reload`, which uses watchfiles) receive constant filesystem events from log writes inside `appDirPath`, causing churn and a performance penalty. Watcher exclusion filters don't help, because the OS-level recursive watch still delivers the events — the fix is for logs to live outside the watched tree.
2. **No centralized logging.** Logs cannot be collected into a single directory across apps.

Setting `appLogDestination`/`daprdLogDestination: console` avoids the file writes but loses persisted logs, so it is a workaround rather than a solution.

This PR adds an optional `logsDir` field to the Multi-App Run template, available under `common` and per app:

```yaml
version: 1
common:
  logsDir: ./central-logs        # optional
apps:
  - appID: myapp
    appDirPath: ./myapp
    logsDir: /tmp/myapp-logs     # optional per-app override
```

Behavior:

- Precedence: `apps[i].logsDir` > `common.logsDir` > default (`<appDirPath>/.dapr/logs`).
- Relative per-app paths resolve against `appDirPath`; relative `common` paths resolve against the run file's directory (consistent with other paths in the template). `~` is expanded.
- The directory is created on first use; it is not required to exist when the run file is parsed.
- Fully backward compatible: when `logsDir` is not set, behavior is unchanged.

Changes:

- `pkg/runfileconfig/run_file_config.go` — added `LogsDir` field on `App` and `Common`; `GetLogsDir()` honors it.
- `pkg/runfileconfig/run_file_config_parser.go` — resolves `logsDir` to absolute paths (new `resolvePathToAbs` helper that does not require the path to exist) and applies precedence.
- `pkg/runfileconfig/run_file_config_parser_test.go` — tests for precedence, relative/absolute resolution, directory creation, and unchanged default behavior.
- `pkg/runfileconfig/testdata/test_run_config_logs_dir.yaml` — test fixture.

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #1652 

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Created/updated tests
* [ ] Extended the documentation