### PR TITLE
auto open issue on ci failure during release

### DIFF
--- a/.github/workflows/dapr_cli.yaml
+++ b/.github/workflows/dapr_cli.yaml
@@ -211,7 +211,7 @@ jobs:
       actions: read
     uses: dapr/.github/.github/workflows/open-issue-on-failure.yml@main
     with:
-      title: "Release publish failed: ${{ github.workflow }} (${{ github.ref_name }})"
+      title: "Release publish failed: ${{ github.workflow }} (${{ inputs.tag || github.ref_name }})"
       labels: "release,ci/publish-failure"
       mention: "@dapr/maintainers-cli @dapr/approvers-cli"
     secrets:

--- a/.github/workflows/dapr_cli.yaml
+++ b/.github/workflows/dapr_cli.yaml
@@ -209,7 +209,7 @@ jobs:
     permissions:
       issues: write
       actions: read
-    uses: dapr/.github/.github/workflows/open-issue-on-failure.yml@master
+    uses: dapr/.github/.github/workflows/open-issue-on-failure.yml@main
     with:
       title: "Release publish failed: ${{ github.workflow }} (${{ github.ref_name }})"
       labels: "release,ci/publish-failure"

--- a/.github/workflows/dapr_cli.yaml
+++ b/.github/workflows/dapr_cli.yaml
@@ -200,3 +200,19 @@ jobs:
             $PackageIdentifier="Dapr.CLI"
           }
           .\wingetcreate.exe update "$PackageIdentifier" --submit --urls "$url|x64" --version "${{ env.REL_VERSION }}" --token "${{ secrets.DAPR_BOT_TOKEN }}"
+
+  # Opens (or comments on) a tracking issue when a tagged release fails
+  # anywhere in the build/publish chain.
+  notify-on-failure:
+    needs: [build, publish, publish-winget]
+    if: failure() && (startsWith(github.ref, 'refs/tags/v') || inputs.tag != '')
+    permissions:
+      issues: write
+      actions: read
+    uses: dapr/.github/.github/workflows/open-issue-on-failure.yml@master
+    with:
+      title: "Release publish failed: ${{ github.workflow }} (${{ github.ref_name }})"
+      labels: "release,ci/publish-failure"
+      mention: "@dapr/maintainers-cli @dapr/approvers-cli"
+    secrets:
+      dapr_bot_token: ${{ secrets.DAPR_BOT_TOKEN }}


### PR DESCRIPTION
Reusable workflow_call that opens (or comments on) a tracking issue in the caller repo when a release/publish job fails, with links to the failed jobs and a maintainer @-mention.

[Needs this PR merged first.](https://github.com/dapr/.github/pull/14)