### PR TITLE
Exit non-zero when `dapr stop` or `dapr uninstall` fails

### DIFF
--- a/cmd/stop.go
+++ b/cmd/stop.go
@@ -61,19 +61,22 @@ dapr stop --run-file /path/to/directory -k
 				err = executeStopWithRunFile(runFilePath)
 				if err != nil {
 					print.FailureStatusEvent(os.Stderr, "Failed to stop Dapr and app processes: %s", err)
-				} else {
-					print.SuccessStatusEvent(os.Stdout, "Dapr and app processes stopped successfully")
+					os.Exit(1)
 				}
+				print.SuccessStatusEvent(os.Stdout, "Dapr and app processes stopped successfully")
 				return
 			}
 			config, _, cErr := getRunConfigFromRunFile(runFilePath)
 			if cErr != nil {
 				print.FailureStatusEvent(os.Stderr, "Failed to parse run template file %q: %s", runFilePath, cErr.Error())
+				os.Exit(1)
 			}
 			err = kubernetes.Stop(runFilePath, config)
 			if err != nil {
 				print.FailureStatusEvent(os.Stderr, "Error stopping deployments from multi-app run template: %v", err)
+				os.Exit(1)
 			}
+			return
 		}
 		if stopAppID != "" {
 			args = append(args, stopAppID)
@@ -84,13 +87,18 @@ dapr stop --run-file /path/to/directory -k
 			os.Exit(1)
 		}
 		cliPIDToNoOfApps := standalone.GetCLIPIDCountMap(apps)
+		stopFailed := false
 		for _, appID := range args {
 			err = standalone.Stop(appID, cliPIDToNoOfApps, apps)
 			if err != nil {
 				print.FailureStatusEvent(os.Stderr, "failed to stop app id %s: %s", appID, err)
+				stopFailed = true
 			} else {
 				print.SuccessStatusEvent(os.Stdout, "app stopped successfully: %s", appID)
 			}
+		}
+		if stopFailed {
+			os.Exit(1)
 		}
 	},
 }

--- a/cmd/uninstall.go
+++ b/cmd/uninstall.go
@@ -90,9 +90,9 @@ dapr uninstall --runtime-path <path-to-install-directory>
 
 		if err != nil {
 			print.FailureStatusEvent(os.Stderr, fmt.Sprintf("Error removing Dapr: %s", err))
-		} else {
-			print.SuccessStatusEvent(os.Stdout, "Dapr has been removed successfully")
+			os.Exit(1)
 		}
+		print.SuccessStatusEvent(os.Stdout, "Dapr has been removed successfully")
 	},
 }
 

--- a/pkg/kubernetes/run.go
+++ b/pkg/kubernetes/run.go
@@ -391,13 +391,20 @@ func deployYamlToK8s(yamlToDeployPath string) error {
 	return nil
 }
 
-func deleteYamlK8s(yamlToDeletePath string) error {
+func deleteYamlK8s(yamlToDeletePath string, ignoreNotFound bool) error {
 	print.InfoStatusEvent(os.Stdout, "Deleting %q from Kubernetes", yamlToDeletePath)
 	_, err := os.Stat(yamlToDeletePath)
 	if os.IsNotExist(err) {
 		return fmt.Errorf("error given file %q does not exist", yamlToDeletePath)
 	}
-	_, err = utils.RunCmdAndWait("kubectl", "delete", "-f", yamlToDeletePath)
+	args := []string{"delete", "-f", yamlToDeletePath}
+	if ignoreNotFound {
+		// "dapr stop -f -k" races with the graceful shutdown performed by the
+		// "dapr run -f -k" process on receiving the stop signal; resources
+		// already deleted by the other process must not fail the stop.
+		args = append(args, "--ignore-not-found")
+	}
+	_, err = utils.RunCmdAndWait("kubectl", args...)
 	if err != nil {
 		return fmt.Errorf("error deleting the yaml %s from Kubernetes: %w", yamlToDeletePath, err)
 	}
@@ -412,9 +419,9 @@ func gracefullyShutdownK8sDeployment(runStates []runState, client k8s.Interface,
 	errs := make([]error, 0, len(runStates)*4)
 	for _, r := range runStates {
 		if len(r.serviceFilePath) != 0 {
-			errs = append(errs, deleteYamlK8s(r.serviceFilePath))
+			errs = append(errs, deleteYamlK8s(r.serviceFilePath, false))
 		}
-		errs = append(errs, deleteYamlK8s(r.deploymentFilePath))
+		errs = append(errs, deleteYamlK8s(r.deploymentFilePath, false))
 		labelSelector := map[string]string{
 			daprAppIDKey: r.app.AppID,
 		}

--- a/pkg/kubernetes/stop.go
+++ b/pkg/kubernetes/stop.go
@@ -42,13 +42,13 @@ func Stop(runFilePath string, config runfileconfig.RunFileConfig) error {
 		serviceFilePath := filepath.Join(deployDir, serviceFileName)
 		deploymentFilePath := filepath.Join(deployDir, deploymentFileName)
 		if app.CreateService {
-			err = deleteYamlK8s(serviceFilePath)
+			err = deleteYamlK8s(serviceFilePath, true)
 			if err != nil {
 				appError = true
 			}
 			errs = append(errs, err)
 		}
-		err = deleteYamlK8s(deploymentFilePath)
+		err = deleteYamlK8s(deploymentFilePath, true)
 		if err != nil {
 			appError = true
 		}

--- a/tests/e2e/standalone/init_negative_test.go
+++ b/tests/e2e/standalone/init_negative_test.go
@@ -54,7 +54,7 @@ func TestStandaloneInitNegatives(t *testing.T) {
 
 	t.Run("stop without install", func(t *testing.T) {
 		output, err := cmdStopWithAppID("test")
-		require.NoError(t, err, "expected no error on stop without install")
+		require.Error(t, err, "expected non-zero exit code on stop without install")
 		require.Contains(t, output, "failed to stop app id test: couldn't find app id test", "expected output to match")
 	})
 


### PR DESCRIPTION
## Description

`dapr stop` and `dapr uninstall` print failure messages but always exit 0, so shell scripts and CI pipelines cannot detect that the operation failed.

This PR makes the failure paths exit non-zero:

- `dapr stop --app-id <id>`: track per-app stop failures and exit 1 after the loop if any app failed to stop (`cmd/stop.go`).
- `dapr stop --run-file <f>` (self-hosted): exit 1 when stopping via the run file fails.
- `dapr stop --run-file <f> -k`: exit 1 on a run-template parse error instead of proceeding into `kubernetes.Stop` with a zero-value config, exit 1 when the Kubernetes stop fails, and `return` afterwards instead of falling through into the self-hosted process scan.
- `dapr uninstall`: exit 1 when the uninstall returns an error.

Repro before this change:

```console
$ dapr stop --app-id does-not-exist
❌  failed to stop app id does-not-exist: couldn't find app id does-not-exist
$ echo $?
0
```

After: exit code is 1 for the same invocation.

## Issue reference

Fixes #1667

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [ ] Created/updated tests (no exit-code test scaffolding exists in `cmd/`; happy to add one if maintainers point at a preferred pattern)
* [ ] Extended the documentation (n/a — behavior fix)
