### PR TITLE
Fail loudly when `renew-certificate --restart` cannot restart the control plane; include scheduler

### DIFF
--- a/cmd/renew_certificate.go
+++ b/cmd/renew_certificate.go
@@ -132,9 +132,8 @@ dapr mtls renew-cert -k --valid-until <no of days> --restart
 				"Certificate rotation is successful! Your new certicate is valid through "+expiry.Format(time.RFC1123))
 
 			if restartDaprServices {
-				restartControlPlaneService()
-				if err != nil {
-					print.FailureStatusEvent(os.Stdout, err.Error())
+				if err := restartControlPlaneService(); err != nil {
+					print.FailureStatusEvent(os.Stderr, err.Error())
 					os.Exit(1)
 				}
 			}
@@ -170,15 +169,21 @@ func logErrorAndExit(err error) {
 }
 
 func restartControlPlaneService() error {
+	namespace, err := kubernetes.GetDaprNamespace()
+	if err != nil {
+		return fmt.Errorf("failed to fetch Dapr namespace: %w", err)
+	}
+
 	controlPlaneServices := []string{
 		"deploy/dapr-sentry",
 		"deploy/dapr-sidecar-injector",
 		"deploy/dapr-operator",
 		"statefulsets/dapr-placement-server",
 	}
-	namespace, err := kubernetes.GetDaprNamespace()
-	if err != nil {
-		print.FailureStatusEvent(os.Stdout, "Failed to fetch Dapr namespace")
+	// The scheduler control plane service only exists for runtime 1.14 onwards,
+	// so restart it only when it is present in the cluster.
+	if _, err := utils.RunCmdAndWait("kubectl", "get", "statefulsets/dapr-scheduler-server", "-n", namespace); err == nil {
+		controlPlaneServices = append(controlPlaneServices, "statefulsets/dapr-scheduler-server")
 	}
 
 	errs := make([]error, len(controlPlaneServices))

--- a/cmd/renew_certificate.go
+++ b/cmd/renew_certificate.go
@@ -133,7 +133,7 @@ dapr mtls renew-cert -k --valid-until <no of days> --restart
 
 			if restartDaprServices {
 				if err := restartControlPlaneService(); err != nil {
-					print.FailureStatusEvent(os.Stderr, err.Error())
+					print.FailureStatusEvent(os.Stderr, "%s", err.Error())
 					os.Exit(1)
 				}
 			}
@@ -195,12 +195,12 @@ func restartControlPlaneService() error {
 			print.InfoStatusEvent(os.Stdout, fmt.Sprintf("Restarting %s..", name))
 			_, err := utils.RunCmdAndWait("kubectl", "rollout", "restart", "-n", namespace, name)
 			if err != nil {
-				errs[i] = fmt.Errorf("error in restarting deployment %s. Error is %w", name, err)
+				errs[i] = fmt.Errorf("error in restarting %s. Error is %w", name, err)
 				return
 			}
 			_, err = utils.RunCmdAndWait("kubectl", "rollout", "status", "-n", namespace, name)
 			if err != nil {
-				errs[i] = fmt.Errorf("error in checking status for deployment %s. Error is %w", name, err)
+				errs[i] = fmt.Errorf("error in checking rollout status for %s. Error is %w", name, err)
 				return
 			}
 		}(i, name)

--- a/cmd/renew_certificate.go
+++ b/cmd/renew_certificate.go
@@ -181,8 +181,15 @@ func restartControlPlaneService() error {
 		"statefulsets/dapr-placement-server",
 	}
 	// The scheduler control plane service only exists for runtime 1.14 onwards,
-	// so restart it only when it is present in the cluster.
-	if _, err := utils.RunCmdAndWait("kubectl", "get", "statefulsets/dapr-scheduler-server", "-n", namespace); err == nil {
+	// so restart it only when it is present in the cluster. --ignore-not-found
+	// makes absence the only non-error outcome with empty output: any other
+	// probe failure (RBAC, transient API error) must fail the restart loudly
+	// rather than silently skipping the scheduler.
+	out, err := utils.RunCmdAndWait("kubectl", "get", "statefulsets/dapr-scheduler-server", "-n", namespace, "--ignore-not-found", "-o", "name")
+	if err != nil {
+		return fmt.Errorf("failed to check for dapr-scheduler-server statefulset: %w", err)
+	}
+	if strings.TrimSpace(out) != "" {
 		controlPlaneServices = append(controlPlaneServices, "statefulsets/dapr-scheduler-server")
 	}
 


### PR DESCRIPTION
## Description

`dapr mtls renew-certificate -k --restart` had three defects that combined to swallow every failure mode of the post-rotation control-plane restart:

1. The error returned by `restartControlPlaneService()` was discarded, and the `if err != nil` beneath it tested a stale variable that is provably nil at that point (a non-nil value would already have exited via `logErrorAndExit`). A failed restart still printed "Certificate rotation is successful!" and exited 0.
2. The restart list omitted `statefulsets/dapr-scheduler-server`, which is part of the control plane since runtime 1.14 — so the scheduler kept running with pre-rotation certificates (previously reported from the field in #1574, closed stale).
3. A `GetDaprNamespace()` failure was printed and then ignored, producing `kubectl rollout restart -n ""`.

Changes:

- Capture and handle the `restartControlPlaneService()` error: print to stderr and exit 1.
- Return early on namespace lookup failure instead of continuing with an empty namespace.
- Add `statefulsets/dapr-scheduler-server` to the restart list — probed with `kubectl get` first so clusters on runtime < 1.14 (no scheduler) are unaffected.

## Issue reference

Fixes #1669
Related: #1574 (field report of the missing scheduler restart, closed by the stale bot), #807 (mTLS rotation reliability epic)

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [ ] Created/updated tests (restart path shells out to kubectl; no existing harness for it — happy to add coverage if maintainers point at a preferred pattern)
* [ ] Extended the documentation (n/a — behavior fix)
