### PR TITLE
Send `dapr invoke`/`dapr publish` status messages to stderr to keep stdout pipeable

### DIFF
--- a/cmd/invoke.go
+++ b/cmd/invoke.go
@@ -74,7 +74,7 @@ dapr invoke --unix-domain-socket /tmp --app-id target --method sample --verb GET
 				print.FailureStatusEvent(os.Stderr, "The unix-domain-socket option is not supported on Windows")
 				os.Exit(1)
 			} else {
-				print.WarningStatusEvent(os.Stdout, "Unix domain sockets are currently a preview feature")
+				print.WarningStatusEvent(os.Stderr, "Unix domain sockets are currently a preview feature")
 			}
 		}
 
@@ -88,7 +88,7 @@ dapr invoke --unix-domain-socket /tmp --app-id target --method sample --verb GET
 		if response != "" {
 			fmt.Println(response)
 		}
-		print.SuccessStatusEvent(os.Stdout, "App invoked successfully")
+		print.SuccessStatusEvent(os.Stderr, "App invoked successfully")
 	},
 }
 

--- a/cmd/publish.go
+++ b/cmd/publish.go
@@ -73,7 +73,7 @@ dapr publish --publish-app-id myapp --pubsub target --topic sample --data '{"key
 				print.FailureStatusEvent(os.Stderr, "The unix-domain-socket option is not supported on Windows")
 				os.Exit(1)
 			} else {
-				print.WarningStatusEvent(os.Stdout, "Unix domain sockets are currently a preview feature")
+				print.WarningStatusEvent(os.Stderr, "Unix domain sockets are currently a preview feature")
 			}
 		}
 
@@ -92,7 +92,7 @@ dapr publish --publish-app-id myapp --pubsub target --topic sample --data '{"key
 			os.Exit(1)
 		}
 
-		print.SuccessStatusEvent(os.Stdout, "Event published successfully")
+		print.SuccessStatusEvent(os.Stderr, "Event published successfully")
 	},
 }
 


### PR DESCRIPTION
## Description

`dapr invoke` prints the app's response to stdout and then appends `✅  App invoked successfully` to the same stream, so piping the response into any parser fails:

```console
$ dapr invoke --app-id myapp --method getstate | jq .
{ ...valid json... }
✅  App invoked successfully      ← jq: parse error
```

This PR moves the success banners and the unix-domain-socket preview warnings in `dapr invoke` and `dapr publish` to stderr, keeping stdout clean for the response payload — consistent with the errors-to-stderr policy established in #748.

Existing e2e assertions are unaffected: the test spawner captures `CombinedOutput()` (stdout+stderr merged), so `assert.Contains(t, output, "App invoked successfully")` still passes.

## Issue reference

Fixes #1671

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Created/updated tests (existing e2e coverage exercises these paths via CombinedOutput and remains valid)
* [ ] Extended the documentation (n/a — behavior fix)
