### PR TITLE
Route error and warning status messages to stderr so `-o json` output stays parseable

### DIFF
--- a/cmd/init.go
+++ b/cmd/init.go
@@ -175,7 +175,7 @@ dapr init --redis-stack
 			}
 
 			if !utils.IsValidContainerRuntime(containerRuntime) {
-				print.FailureStatusEvent(os.Stdout, "Invalid container runtime. Supported values are docker and podman.")
+				print.FailureStatusEvent(os.Stderr, "Invalid container runtime. Supported values are docker and podman.")
 				os.Exit(1)
 			}
 

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -34,13 +34,13 @@ func outputList(list interface{}, length int) {
 	if outputFormat == "json" || outputFormat == "yaml" {
 		err := utils.PrintDetail(os.Stdout, outputFormat, list)
 		if err != nil {
-			print.FailureStatusEvent(os.Stdout, err.Error())
+			print.FailureStatusEvent(os.Stderr, err.Error())
 			os.Exit(1)
 		}
 	} else {
 		table, err := gocsv.MarshalString(list)
 		if err != nil {
-			print.FailureStatusEvent(os.Stdout, err.Error())
+			print.FailureStatusEvent(os.Stderr, err.Error())
 			os.Exit(1)
 		}
 
@@ -72,13 +72,13 @@ dapr list -k --all-namespaces
 `,
 	PreRun: func(cmd *cobra.Command, args []string) {
 		if outputFormat != "" && outputFormat != "json" && outputFormat != "yaml" && outputFormat != "table" {
-			print.FailureStatusEvent(os.Stdout, "An invalid output format was specified.")
+			print.FailureStatusEvent(os.Stderr, "An invalid output format was specified.")
 			os.Exit(1)
 		}
 	},
 	Run: func(cmd *cobra.Command, args []string) {
 		if kubernetesMode {
-			print.WarningStatusEvent(os.Stdout, "In future releases, this command will only query the \"default\" namespace by default. Please use the --namespace flag for a specific namespace, or the --all-namespaces (-A) flag for all namespaces.")
+			print.WarningStatusEvent(os.Stderr, "In future releases, this command will only query the \"default\" namespace by default. Please use the --namespace flag for a specific namespace, or the --all-namespaces (-A) flag for all namespaces.")
 			if allNamespaces {
 				resourceNamespace = meta_v1.NamespaceAll
 			} else if resourceNamespace == "" {

--- a/cmd/uninstall.go
+++ b/cmd/uninstall.go
@@ -80,7 +80,7 @@ dapr uninstall --runtime-path <path-to-install-directory>
 			err = kubernetes.Uninstall(uninstallNamespace, uninstallAll, uninstallDev, timeout)
 		} else {
 			if !utils.IsValidContainerRuntime(uninstallContainerRuntime) {
-				print.FailureStatusEvent(os.Stdout, "Invalid container runtime. Supported values are docker and podman.")
+				print.FailureStatusEvent(os.Stderr, "Invalid container runtime. Supported values are docker and podman.")
 				os.Exit(1)
 			}
 			print.InfoStatusEvent(os.Stdout, "Removing Dapr from your machine...")

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -36,7 +36,7 @@ dapr version --output json
 `,
 	Run: func(cmd *cobra.Command, args []string) {
 		if output != "" && output != "json" {
-			print.FailureStatusEvent(os.Stdout, "An invalid output format was specified.")
+			print.FailureStatusEvent(os.Stderr, "An invalid output format was specified.")
 			os.Exit(1)
 		}
 		switch output {

--- a/cmd/workflow/raiseevent.go
+++ b/cmd/workflow/raiseevent.go
@@ -58,7 +58,7 @@ var RaiseEventCmd = &cobra.Command{
 		}
 
 		if err = workflow.RaiseEvent(ctx, opts); err != nil {
-			print.FailureStatusEvent(os.Stdout, err.Error())
+			print.FailureStatusEvent(os.Stderr, err.Error())
 			os.Exit(1)
 		}
 

--- a/cmd/workflow/rerun.go
+++ b/cmd/workflow/rerun.go
@@ -58,7 +58,7 @@ var ReRunCmd = &cobra.Command{
 
 		id, err := workflow.ReRun(ctx, opts)
 		if err != nil {
-			print.FailureStatusEvent(os.Stdout, err.Error())
+			print.FailureStatusEvent(os.Stderr, err.Error())
 			os.Exit(1)
 		}
 

--- a/cmd/workflow/resume.go
+++ b/cmd/workflow/resume.go
@@ -47,7 +47,7 @@ var ResumeCmd = &cobra.Command{
 		}
 
 		if err = workflow.Resume(ctx, opts); err != nil {
-			print.FailureStatusEvent(os.Stdout, err.Error())
+			print.FailureStatusEvent(os.Stderr, err.Error())
 			os.Exit(1)
 		}
 

--- a/cmd/workflow/run.go
+++ b/cmd/workflow/run.go
@@ -60,7 +60,7 @@ var RunCmd = &cobra.Command{
 
 		id, err := workflow.Run(ctx, opts)
 		if err != nil {
-			print.FailureStatusEvent(os.Stdout, err.Error())
+			print.FailureStatusEvent(os.Stderr, err.Error())
 			os.Exit(1)
 		}
 

--- a/cmd/workflow/suspend.go
+++ b/cmd/workflow/suspend.go
@@ -47,7 +47,7 @@ var SuspendCmd = &cobra.Command{
 		}
 
 		if err = workflow.Suspend(ctx, opts); err != nil {
-			print.FailureStatusEvent(os.Stdout, err.Error())
+			print.FailureStatusEvent(os.Stderr, err.Error())
 			os.Exit(1)
 		}
 

--- a/cmd/workflow/terminate.go
+++ b/cmd/workflow/terminate.go
@@ -52,7 +52,7 @@ var TerminateCmd = &cobra.Command{
 		}
 
 		if err = workflow.Terminate(ctx, opts); err != nil {
-			print.FailureStatusEvent(os.Stdout, err.Error())
+			print.FailureStatusEvent(os.Stderr, err.Error())
 			os.Exit(1)
 		}
 


### PR DESCRIPTION
## Description

`dapr list -k -o json` prints the namespace deprecation warning to stdout ahead of the JSON, so the output can't be parsed - the exact problem reported in #1015:

```console
$ dapr list -k -o json | jq .
⚠  In future releases, this command will only query the "default" namespace by default. ...
[ ... ]      ← jq: parse error
```

Beyond that one warning, twelve `FailureStatusEvent` call sites across `list`, `version`, `init`, `uninstall` and the six `workflow` subcommands print errors to stdout, which both corrupts `-o json`/`-o yaml` output and hides errors from `2>` redirection. Errors-to-stderr has been project policy since #748; these sites crept back in over time.

This PR routes all of them to stderr. The two remaining stdout sites in `cmd/renew_certificate.go` are intentionally left out - #1670 already moves them, and touching them here would just conflict.

No message text changes, so existing e2e assertions (which capture combined output) are unaffected; the invalid-output-format test asserts on the exit code, which is unchanged.

## Issue reference

Fixes #1015

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Created/updated tests (existing e2e coverage exercises these paths via combined output and remains valid)
* [ ] Extended the documentation (n/a — behavior fix)
