### PR TITLE
Fix broken help examples and user-visible typos

### DIFF
--- a/cmd/invoke.go
+++ b/cmd/invoke.go
@@ -41,13 +41,13 @@ var InvokeCmd = &cobra.Command{
 	Short: "Invoke a method on a given Dapr application. Supported platforms: Self-hosted",
 	Example: `
 # Invoke a sample method on target app with POST Verb
-dapr invoke --app-id target --method sample --data '{"key":"value"}
+dapr invoke --app-id target --method sample --data '{"key":"value"}'
 
 # Invoke a sample method on target app with GET Verb
 dapr invoke --app-id target --method sample --verb GET
 
 # Invoke a sample method on target app with GET Verb using Unix domain socket
-dapr invoke --unix-domain-socket --app-id target --method sample --verb GET
+dapr invoke --unix-domain-socket /tmp --app-id target --method sample --verb GET
 `,
 	Run: func(cmd *cobra.Command, args []string) {
 		bytePayload := []byte{}

--- a/cmd/publish.go
+++ b/cmd/publish.go
@@ -43,7 +43,7 @@ var PublishCmd = &cobra.Command{
 dapr publish --publish-app-id myapp --pubsub target --topic sample --data '{"key":"value"}'
 
 # Publish to sample topic in target pubsub via a publishing app using Unix domain socket
-dapr publish --enable-domain-socket --publish-app-id myapp --pubsub target --topic sample --data '{"key":"value"}'
+dapr publish --unix-domain-socket /tmp --publish-app-id myapp --pubsub target --topic sample --data '{"key":"value"}'
 
 # Publish to sample topic in target pubsub via a publishing app without cloud event
 dapr publish --publish-app-id myapp --pubsub target --topic sample --data '{"key":"value"}' --metadata '{"rawPayload":"true","ttlInSeconds":"10"}'

--- a/cmd/renew_certificate.go
+++ b/cmd/renew_certificate.go
@@ -129,7 +129,7 @@ dapr mtls renew-cert -k --valid-until <no of days> --restart
 				logErrorAndExit(err)
 			}
 			print.SuccessStatusEvent(os.Stdout,
-				"Certificate rotation is successful! Your new certicate is valid through "+expiry.Format(time.RFC1123))
+				"Certificate rotation is successful! Your new certificate is valid through "+expiry.Format(time.RFC1123))
 
 			if restartDaprServices {
 				restartControlPlaneService()

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -130,7 +130,7 @@ dapr run --run-file /path/to/directory
 # Run multiple apps by providing config via stdin
 cat dapr.template.yaml | envsubst | dapr run --run-file -
 
-# Run multiple apps in Kubernetes by proficing path of a run config file
+# Run multiple apps in Kubernetes by providing a path of a run config file
 dapr run --run-file dapr.yaml -k
 
 # Run multiple apps in Kubernetes by providing a directory path containing the run config file(dapr.yaml)

--- a/cmd/uninstall.go
+++ b/cmd/uninstall.go
@@ -98,7 +98,7 @@ dapr uninstall --runtime-path <path-to-install-directory>
 
 func init() {
 	UninstallCmd.Flags().BoolVarP(&uninstallKubernetes, "kubernetes", "k", false, "Uninstall Dapr from a Kubernetes cluster")
-	UninstallCmd.Flags().BoolVarP(&uninstallDev, "dev", "", false, "Uninstall Dapr Redis and Zipking installations from Kubernetes cluster")
+	UninstallCmd.Flags().BoolVarP(&uninstallDev, "dev", "", false, "Uninstall Dapr Redis and Zipkin installations from Kubernetes cluster")
 	UninstallCmd.Flags().UintVarP(&timeout, "timeout", "", 300, "The timeout for the Kubernetes uninstall")
 	UninstallCmd.Flags().BoolVar(&uninstallAll, "all", false, "Remove .dapr directory, Redis, Placement, Scheduler (and default volume in self-hosted mode), and Zipkin containers on local machine, and CRDs on a Kubernetes cluster")
 	UninstallCmd.Flags().String("network", "", "The Docker network from which to remove the Dapr runtime")

--- a/cmd/upgrade.go
+++ b/cmd/upgrade.go
@@ -36,8 +36,8 @@ var UpgradeCmd = &cobra.Command{
 		viper.BindPFlag("image-registry", cmd.Flags().Lookup("image-registry"))
 	},
 	Example: `
-# Upgrade Dapr in Kubernetes
-dapr upgrade -k
+# Upgrade Dapr in Kubernetes to the specified version
+dapr upgrade -k --runtime-version 1.16.0
 
 # See more at: https://docs.dapr.io/getting-started/
 `,


### PR DESCRIPTION
## Description

A few of the built-in help examples don't work when copy-pasted, and there are some user-visible typos:

- `dapr publish` example used `--enable-domain-socket`, a flag that doesn't exist - the real flag is `--unix-domain-socket`, and it's a string that takes a path.
- `dapr invoke`'s unix-domain-socket example passed no value to that same string flag, so pflag silently consumes `--app-id` as the socket path if you copy-paste it.
- `dapr invoke`'s POST example was missing its closing quote.
- `dapr upgrade`'s only example (`dapr upgrade -k`) omits `--runtime-version`, which is a required flag, so the documented invocation always errors.
- Typos in user-facing strings: "Zipking" → "Zipkin" (uninstall flag help), "proficing" → "providing" (run example), "certicate" → "certificate" (renew-certificate success message).

Help text only - no behavior changes.

## Issue reference

n/a - trivial help-text corrections.

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [ ] Created/updated tests (n/a - help text only)
* [x] Extended the documentation (built-in help text corrected)
