### PR TITLE
`dapr mcpservers`: skip cert-expiry check in self-hosted mode, validate `--output`

### DIFF
--- a/cmd/mcpservers.go
+++ b/cmd/mcpservers.go
@@ -35,6 +35,12 @@ var (
 var MCPServersCmd = &cobra.Command{
 	Use:   "mcpservers",
 	Short: "List all Dapr MCPServer resources. Supported platforms: Kubernetes and self-hosted",
+	PreRun: func(cmd *cobra.Command, args []string) {
+		if mcpServersOutputFormat != "list" && mcpServersOutputFormat != "json" && mcpServersOutputFormat != "yaml" {
+			print.FailureStatusEvent(os.Stderr, "An invalid output format was specified. Valid values are: json, yaml, or list")
+			os.Exit(1)
+		}
+	},
 	Run: func(cmd *cobra.Command, args []string) {
 		if kubernetesMode {
 			if allNamespaces || resourceNamespace == "" {
@@ -59,7 +65,9 @@ var MCPServersCmd = &cobra.Command{
 		}
 	},
 	PostRun: func(cmd *cobra.Command, args []string) {
-		kubernetes.CheckForCertExpiry()
+		if kubernetesMode {
+			kubernetes.CheckForCertExpiry()
+		}
 	},
 	Example: `
 # List all Dapr MCPServer resources in self-hosted mode (reads from ~/.dapr/components/ by default)


### PR DESCRIPTION
## Description

Two fixes for the new `dapr mcpservers` command:

- **Self-hosted runs no longer touch the cluster.** PostRun called `kubernetes.CheckForCertExpiry()` unconditionally, so a purely local resources-directory listing reached for kubeconfig/cluster access. It's now guarded behind `kubernetesMode`, matching what `dapr list` does.
- **`--output` is validated.** `dapr mcpservers -o table` used to be silently accepted and behave like the default; it now fails in PreRun with the valid values (json, yaml, list), matching `dapr list`'s behavior.

The `-n` shorthand clash described in the issue (name here vs namespace in `init`/`uninstall`/`workflow`/`scheduler`) is deliberately not touched - changing a shorthand is breaking, so that part needs a maintainer call first.

## Issue reference

Fixes #1675

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [ ] Created/updated tests (no e2e harness exercises mcpservers yet; happy to add coverage if wanted)
* [ ] Extended the documentation (n/a - behavior fix)
