### PR TITLE
Do not duplicate top-level command errors onto stdout; exit 1 not 255

### DIFF
--- a/cmd/dapr.go
+++ b/cmd/dapr.go
@@ -78,8 +78,10 @@ func Execute(version, apiVersion string) {
 	cobra.OnInitialize(initConfig)
 
 	if err := RootCmd.Execute(); err != nil {
-		fmt.Println(err)
-		os.Exit(-1)
+		// cobra already prints the error and usage hint to stderr, so avoid
+		// printing it a second time to stdout. Exit 1 rather than -1 (which
+		// surfaces as 255) to follow the conventional CLI failure code.
+		os.Exit(1)
 	}
 }
 


### PR DESCRIPTION
## Description

`cmd.Execute()` printed the top-level command error a second time to stdout and exited with `-1` (which surfaces as `255`):

```go
if err := RootCmd.Execute(); err != nil {
    fmt.Println(err)   // duplicate, on stdout
    os.Exit(-1)        // 255
}
```

`RootCmd` sets neither `SilenceErrors` nor `SilenceUsage`, so cobra already prints the error and usage hint to stderr. The extra `fmt.Println(err)` leaked a duplicate copy onto stdout, so `dapr <typo> | some-parser` fed the error text into the pipe.

This PR drops the duplicate print (cobra keeps handling stderr) and exits `1`.

Verified by splitting the streams:

```console
# before
$ dapr boguscmd 1>/tmp/out 2>/tmp/err ; echo $?
255
$ cat /tmp/out
unknown command "boguscmd" for "dapr"       # leaked onto stdout

# after
$ dapr boguscmd 1>/tmp/out 2>/tmp/err ; echo $?
1
$ cat /tmp/out
                                            # empty
$ cat /tmp/err
Error: unknown command "boguscmd" for "dapr"
Run 'dapr --help' for usage.
```

## Issue reference

Fixes #1677

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [ ] Created/updated tests (n/a - top-level error plumbing, no unit-test seam)
* [ ] Extended the documentation (n/a - behavior fix)
