### PR TITLE
test(utils): fix tests that assert nothing and run them in CI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -147,7 +147,7 @@ test-deps:
 ################################################################################
 .PHONY: test
 test: test-deps
-	gotestsum --jsonfile $(TEST_OUTPUT_FILE) --format standard-quiet -- ./pkg/... $(COVERAGE_OPTS)
+	gotestsum --jsonfile $(TEST_OUTPUT_FILE) --format standard-quiet -- ./pkg/... ./utils/... $(COVERAGE_OPTS)
 
 ################################################################################
 # E2E Tests for Kubernetes												       #

--- a/utils/utils_test.go
+++ b/utils/utils_test.go
@@ -174,7 +174,9 @@ func TestGetVersionAndImageVariant(t *testing.T) {
 
 func TestValidateFilePaths(t *testing.T) {
 	dirName := createTempDir(t, "test_validate_paths")
-	defer cleanupTempDir(t, dirName)
+	t.Cleanup(func() {
+		cleanupTempDir(t, dirName)
+	})
 	validFile := createTempFile(t, dirName, "valid_test_file.yaml")
 	testcases := []struct {
 		name        string
@@ -212,6 +214,14 @@ func TestGetAbsPath(t *testing.T) {
 	assert.NoError(t, err)
 	baseDir := filepath.Dir(ex)
 
+	// An absolute path is platform specific: on Windows a rooted path such as
+	// "/absolute/path" carries no volume name, so filepath.IsAbs reports false
+	// for it and GetAbsPath joins it with baseDir instead of returning it.
+	absolutePath := "/absolute/path"
+	if runtime.GOOS == "windows" {
+		absolutePath = `C:\absolute\path`
+	}
+
 	testcases := []struct {
 		name     string
 		input    string
@@ -234,8 +244,8 @@ func TestGetAbsPath(t *testing.T) {
 		},
 		{
 			name:     "absolute path",
-			input:    "/absolute/path",
-			expected: "/absolute/path",
+			input:    absolutePath,
+			expected: absolutePath,
 		},
 	}
 
@@ -311,7 +321,9 @@ func TestResolveHomeDir(t *testing.T) {
 
 func TestReadFile(t *testing.T) {
 	fileName := createTempFile(t, "", "test_read_file")
-	defer cleanupTempDir(t, fileName)
+	t.Cleanup(func() {
+		cleanupTempDir(t, fileName)
+	})
 	testcases := []struct {
 		name        string
 		input       string


### PR DESCRIPTION
# Description

The `utils` package is not part of `make test`, which runs `./pkg/...` only, so its tests never ran in CI. Three of them fail today on a clean master.

`TestValidateFilePaths` and `TestReadFile` create a temp fixture and remove it with `defer` while their subtests call `t.Parallel()`. A parallel subtest is paused until its parent function returns, so the deferred cleanup deletes the fixture before any subtest reads it, and the "valid file path" cases assert an error that only proves the file is already gone. They fail on Linux and Windows alike. Both move to `t.Cleanup`, which runs after parallel subtests finish, matching what `TestFindFileInDir` in the same file already does.

`TestGetAbsPath` fails on Windows only: `/absolute/path` carries no volume name, so `filepath.IsAbs` reports false for it and `GetAbsPath` joins it with `baseDir`. The absolute path is now chosen per platform.

`./utils/...` is added to the `test` target so these keep working.

Before:

```console
$ go test ./utils/
--- FAIL: TestValidateFilePaths (0.00s)
    --- FAIL: TestValidateFilePaths/valid_file_path (0.00s)
--- FAIL: TestGetAbsPath (0.00s)
    --- FAIL: TestGetAbsPath/absolute_path (0.00s)
--- FAIL: TestReadFile (0.00s)
    --- FAIL: TestReadFile/valid_file_path (0.00s)
FAIL	github.com/dapr/cli/utils
```

After, on windows/amd64 and on linux/amd64 (cross-compiled test binary run under WSL):

```console
$ go test ./utils/
ok  	github.com/dapr/cli/utils

$ ./utils.test
PASS
```

No production code is touched.

## Issue reference

Please reference the issue this PR will close: #1679

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Created/updated tests
* [ ] Extended the documentation
