### PR TITLE
fix: stop masking workflow list errors as pre-v1.17

### DIFF
--- a/pkg/workflow/dclient/dclient.go
+++ b/pkg/workflow/dclient/dclient.go
@@ -18,6 +18,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"os"
 	"slices"
 	"sort"
 	"strconv"
@@ -31,6 +32,7 @@ import (
 	"google.golang.org/protobuf/proto"
 
 	"github.com/dapr/cli/pkg/kubernetes"
+	"github.com/dapr/cli/pkg/print"
 	"github.com/dapr/cli/pkg/standalone"
 	"github.com/dapr/cli/pkg/workflow/db"
 	"github.com/dapr/dapr/pkg/apis/components/v1alpha1"
@@ -203,19 +205,19 @@ func kube(ctx context.Context, opts Options) (*Client, error) {
 }
 
 func (c *Client) InstanceIDs(ctx context.Context) ([]string, error) {
-	resp, err := c.WF.ListInstanceIDs(ctx)
-	if err != nil {
-		code, ok := status.FromError(err)
-		if !ok || (code.Code() != codes.Unimplemented && code.Code() != codes.Unknown) {
-			return nil, err
+	resp, rpcErr := c.WF.ListInstanceIDs(ctx)
+	if rpcErr != nil {
+		if ctx.Err() != nil {
+			return nil, rpcErr
 		}
 
-		// Dapr is pre v1.17, so fall back to reading from the state store
-		// directly.
-		var metaKeys []string
-		metaKeys, err = c.metaKeysFromDB(ctx)
+		// The listing API may not be served by this runtime (pre v1.17), so
+		// fall back to reading from the state store directly.
+		print.WarningStatusEvent(os.Stderr, "Failed to list workflows via the Dapr runtime, falling back to reading the state store directly: %v", rpcErr)
+
+		metaKeys, err := c.metaKeysFromDB(ctx)
 		if err != nil {
-			return nil, err
+			return nil, errors.Join(rpcErr, err)
 		}
 
 		instanceIDs := make([]string, 0, len(metaKeys))
@@ -228,15 +230,15 @@ func (c *Client) InstanceIDs(ctx context.Context) ([]string, error) {
 			instanceIDs = append(instanceIDs, split[2])
 		}
 
-		return instanceIDs, err
+		return instanceIDs, nil
 	}
 
 	ids := resp.InstanceIds
 
 	for resp.ContinuationToken != nil {
-		resp, err = c.WF.ListInstanceIDs(ctx, workflow.WithListInstanceIDsContinuationToken(*resp.ContinuationToken))
-		if err != nil {
-			return nil, err
+		resp, rpcErr = c.WF.ListInstanceIDs(ctx, workflow.WithListInstanceIDsContinuationToken(*resp.ContinuationToken))
+		if rpcErr != nil {
+			return nil, rpcErr
 		}
 
 		ids = append(ids, resp.InstanceIds...)

--- a/pkg/workflow/dclient/dclient_test.go
+++ b/pkg/workflow/dclient/dclient_test.go
@@ -1,0 +1,104 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package dclient
+
+import (
+	"context"
+	"errors"
+	"net"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+
+	"github.com/dapr/durabletask-go/api/protos"
+	"github.com/dapr/durabletask-go/workflow"
+)
+
+type fakeSidecar struct {
+	protos.UnimplementedTaskHubSidecarServiceServer
+	listErr  error
+	listResp *protos.ListInstanceIDsResponse
+}
+
+func (f *fakeSidecar) ListInstanceIDs(ctx context.Context, req *protos.ListInstanceIDsRequest) (*protos.ListInstanceIDsResponse, error) {
+	if f.listErr != nil {
+		return nil, f.listErr
+	}
+	return f.listResp, nil
+}
+
+func newTestClient(t *testing.T, sidecar *fakeSidecar) *Client {
+	t.Helper()
+
+	lis, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+
+	srv := grpc.NewServer()
+	protos.RegisterTaskHubSidecarServiceServer(srv, sidecar)
+	go srv.Serve(lis)
+	t.Cleanup(srv.Stop)
+	t.Cleanup(func() { lis.Close() })
+
+	conn, err := grpc.NewClient(lis.Addr().String(), grpc.WithTransportCredentials(insecure.NewCredentials()))
+	require.NoError(t, err)
+	t.Cleanup(func() { conn.Close() })
+
+	return &Client{
+		WF:             workflow.NewClient(conn),
+		kubernetesMode: true,
+		appID:          "myapp",
+		ns:             "default",
+	}
+}
+
+func TestInstanceIDsSurfacesRuntimeError(t *testing.T) {
+	// When the listing RPC fails and the state-store fallback cannot run, the
+	// user must see the RPC error, not only the fallback's complaint.
+	c := newTestClient(t, &fakeSidecar{
+		listErr: errors.New("invalid key format: myapp||dapr.internal.default.myapp.workflow||weird||id||metadata"),
+	})
+
+	_, err := c.InstanceIDs(t.Context())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid key format")
+	assert.Contains(t, err.Error(), "connection string is required")
+}
+
+func TestInstanceIDsSuccess(t *testing.T) {
+	c := newTestClient(t, &fakeSidecar{
+		listResp: &protos.ListInstanceIDsResponse{InstanceIds: []string{"wf-1", "wf-2"}},
+	})
+
+	ids, err := c.InstanceIDs(t.Context())
+	require.NoError(t, err)
+	assert.Equal(t, []string{"wf-1", "wf-2"}, ids)
+}
+
+func TestInstanceIDsCancelledContext(t *testing.T) {
+	// A cancelled context must surface immediately, without attempting the
+	// state-store fallback.
+	c := newTestClient(t, &fakeSidecar{
+		listResp: &protos.ListInstanceIDsResponse{},
+	})
+
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+
+	_, err := c.InstanceIDs(ctx)
+	require.Error(t, err)
+	assert.NotContains(t, err.Error(), "connection string is required")
+}


### PR DESCRIPTION
# Description

`dapr workflow list` treated any `codes.Unknown` error from the sidecar as "runtime is pre v1.17" and fell back to the direct state-store path, printing:

```
Error: connection string is required for all database drivers for Dapr pre v1.17
```

`Unknown` is gRPC's catch-all for server-side errors, so every runtime failure was misreported as a version problem and the real error was discarded.

Classifying the error reliably is fragile — a pre-1.17 daprd returns a version-dependent proxy error rather than `Unimplemented`. Instead, on any listing failure the CLI now prints the RPC error as a warning, attempts the state-store fallback, and reports both errors if the fallback also fails.

## Issue reference

Fixes #1681

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Created/updated tests
* [x] Extended the documentation / Not needed
